### PR TITLE
ci: updating release actions to use ubuntu-latest by default

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ on:
 name: Publish Docs
 jobs:
   build-publish:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-please:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     outputs:
       package-sdk-server-released: ${{ steps.release.outputs['pkgs/sdk/server--release_created'] }}
@@ -26,7 +26,7 @@ jobs:
           target-branch: ${{ github.ref_name }}
 
   release-sdk-server:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: release-please
     permissions:
       id-token: write
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   release-telemetry:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: release-please
     permissions:
       id-token: write
@@ -83,36 +83,14 @@ jobs:
           aws_role: ${{ vars.AWS_ROLE_ARN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # this job calls to the release-sdk-client workflow because the client SDK has to be built on macos
   release-sdk-client:
-    runs-on: macos-latest
     needs: release-please
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
     if: ${{ needs.release-please.outputs.package-sdk-client-released == 'true'}}
-    outputs:
-      hashes: ${{ steps.full-release.outputs.hashes }}
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Env from project's Env file
-        shell: bash
-        run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+    uses: ./.github/workflows/release-sdk-client.yml
+    with:
+      dry_run: false
 
-      - uses: ./.github/actions/full-release
-        id: full-release
-        with:
-          workspace_path: ${{ env.WORKSPACE_PATH }}
-          project_file: ${{ env.PROJECT_FILE }}
-          build_output_path: ${{ env.BUILD_OUTPUT_PATH }}
-          test_project_file: ${{ env.TEST_PROJECT_FILE }}
-          dll_name: ${{ env.BUILD_OUTPUT_DLL_NAME }}
-          dry_run: false
-          aws_role: ${{ vars.AWS_ROLE_ARN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  # TODO: refactor provenance
   release-sdk-server-provenance:
     needs: ['release-please', 'release-sdk-server']
     permissions:
@@ -125,7 +103,6 @@ jobs:
       upload-assets: true
       upload-tag-name: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
       provenance-name: ${{ format('LaunchDarkly.ServerSdk-{0}_provenance.intoto.jsonl', needs.release-please.outputs.package-sdk-server-tag_name) }}
-
 
   release-telemetry-provenance:
     needs: ['release-please', 'release-telemetry']
@@ -140,4 +117,15 @@ jobs:
       upload-tag-name: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
       provenance-name: ${{ format('LaunchDarkly.ServerSdk.Telemetry-{0}_provenance.intoto.jsonl', needs.release-please.outputs.package-sdk-server-telemetry-tag_name) }}
 
-  # TODO: add client provenance
+  release-sdk-client-provenance:
+    needs: ['release-please', 'release-sdk-client']
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    with:
+      base64-subjects: "${{ needs.release-sdk-client.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
+      provenance-name: ${{ format('LaunchDarkly.ClientSdk-{0}_provenance.intoto.jsonl', needs.release-please.outputs.package-sdk-client-tag_name) }}

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -1,0 +1,164 @@
+# This workflow exists because the client sdk build process requires macos.
+name: Manual Publish SDK Client Package
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Is this a dry run. If so no package will be published.'
+        type: boolean
+        required: true
+  workflow_call:
+    inputs:
+      dry_run:
+        description: 'Is this a dry run. If so no package will be published.'
+        type: boolean
+        required: true
+    outputs:
+      hashes:
+        description: sha256sum hashes of built artifacts
+        value: ${{ jobs.publish.outputs.hashes }}
+
+jobs:
+# Building is done on mac runner due to xcode build dependencies
+  build:
+    runs-on: macos-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # If you only need the current version keep this
+
+      - name: Setup Env from project's Env file
+        shell: bash
+        run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
+        name: Get secrets
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          s3_path_pairs: 'launchdarkly-releaser/dotnet/LaunchDarkly.snk = LaunchDarkly.snk'
+
+      - name: CI check
+        uses: ./.github/actions/ci
+        with:
+          project_file: ${{ env.PROJECT_FILE }}
+          test_project_file: ${{ env.TEST_PROJECT_FILE }}
+
+      - name: Release build
+        uses: ./.github/actions/build-release
+        with:
+          project_file: ${{ env.PROJECT_FILE }}
+
+      - name: Build Documentation
+        uses: ./.github/actions/build-docs
+        with:
+          workspace_path: ${{ env.WORKSPACE_PATH }}
+
+      - name: Retain build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dir-bin-release
+          path: ${{ env.BUILD_OUTPUT_PATH }}
+          retention-days: 1
+
+      - name: Retain docs artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dir-docs
+          path: ${{ env.WORKSPACE_PATH }}/docs
+          retention-days: 1
+
+# Signing DLLs is done on Ubuntu due to Digicert tooling compatibility
+  sign-dlls:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # If you only need the current version keep this
+
+      - name: Setup Env from project's Env file
+        shell: bash
+        run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+
+      - name: Restore release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: dir-bin-release
+          path: ${{ env.BUILD_OUTPUT_PATH }}
+
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
+        name: Get secrets
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/digicert/host = DIGICERT_HOST,/production/common/releasing/digicert/api_key = DIGICERT_API_KEY,/production/common/releasing/digicert/client_cert_file_b64 = DIGICERT_CLIENT_CERT_FILE_B64,/production/common/releasing/digicert/client_cert_password = DIGICERT_CLIENT_CERT_PASSWORD,/production/common/releasing/digicert/code_signing_cert_sha1_hash = DIGICERT_CODE_SIGNING_CERT_SHA1_HASH'
+
+      - name: Sign DLLs
+        uses: ./.github/actions/sign-dlls
+
+      - name: Retain signed artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dir-bin-release-signed
+          path: ${{ env.BUILD_OUTPUT_PATH }}
+          retention-days: 1
+
+# Packing is done on Mac due to ios workload requirements.
+  publish:
+    runs-on: macos-latest
+    needs: sign-dlls
+    permissions:
+      id-token: write
+      contents: write
+    outputs:
+      hashes: ${{ steps.publish.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # If you only need the current version keep this
+
+      - name: Setup Env from project's Env file
+        shell: bash
+        run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+
+      - name: Restore release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: dir-bin-release-signed
+          path: ${{ env.BUILD_OUTPUT_PATH }}
+
+      - name: Restore docs artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: dir-docs
+          path: ${{ env.WORKSPACE_PATH }}/docs
+
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.1
+        name: Get secrets
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/nuget/api_key = NUGET_API_KEY'
+
+      - name: Publish Nupkg
+        id: publish
+        uses: ./.github/actions/publish-package
+        with:
+          project_file: ${{ env.PROJECT_FILE }}
+          dry_run: ${{ inputs.dry_run }}
+
+      - name: Build Documentation
+        uses: ./.github/actions/build-docs
+        with:
+          workspace_path: ${{ env.WORKSPACE_PATH }}
+
+      - name: Publish Documentation
+        if: ${{ inputs.dry_run == 'false' }}
+        uses: ./.github/actions/publish-docs
+        with:
+          workspace_path: ${{ env.WORKSPACE_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: choice
         options:
-          - pkgs/sdk/client
+          # pkgs/sdk/client is omitted here since this workflow is for ubuntu and the client sdk build process requires macos.  Use release-sdk-client for client sdk.
           - pkgs/sdk/server
           - pkgs/telemetry
       dry_run:
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
**Describe the solution you've provided**

Updated the release please workflow to use ubuntu-latest runner.  Added special case workflow for the client SDK that is brought in from the dotnet-client repo with some modifications.  The modifications were to make it work in the dotnet-core workflow/actions structure and to support provenance.
