### PR TITLE
feat: report prerequisite relations in AllFlagState

### DIFF
--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -37,7 +37,8 @@ namespace TestService
             "tags",
             "inline-context",
             "anonymous-redaction",
-            "evaluation-hooks"
+            "evaluation-hooks",
+            "client-prereq-events"
         };
 
         public readonly Handler Handler;

--- a/pkgs/sdk/server/src/FeatureFlagsState.cs
+++ b/pkgs/sdk/server/src/FeatureFlagsState.cs
@@ -168,7 +168,7 @@ namespace LaunchDarkly.Sdk.Server
         /// </summary>
         /// <param name="flagKey">the flag key</param>
         /// <param name="result">the evaluation result</param>
-        /// <returns></returns>
+        /// <returns>the same builder</returns>
         public FeatureFlagsStateBuilder AddFlag(string flagKey, EvaluationDetail<LdValue> result)
         {
             return AddFlag(flagKey, result, new List<string>());
@@ -181,7 +181,7 @@ namespace LaunchDarkly.Sdk.Server
         /// <param name="flagKey">the flag key</param>
         /// <param name="result">the evaluation result</param>
         /// <param name="prerequisites">the direct prerequisites evaluated for this flag</param>
-        /// <returns></returns>
+        /// <returns>the same builder</returns>
         public FeatureFlagsStateBuilder AddFlag(string flagKey, EvaluationDetail<LdValue> result, List<string> prerequisites)
         {
             return AddFlag(flagKey,
@@ -228,6 +228,7 @@ namespace LaunchDarkly.Sdk.Server
         internal EvaluationReason? Reason { get; set; }
 
         internal List<string> Prerequisites { get; set; }
+
 
         public bool Equals(FlagState o)
         {
@@ -319,6 +320,7 @@ namespace LaunchDarkly.Sdk.Server
         {
             var valid = true;
             var flags = new Dictionary<string, FlagState>();
+
             for (var topLevelObj = RequireObject(ref reader); topLevelObj.Next(ref reader);)
             {
                 var key = topLevelObj.Name;

--- a/pkgs/sdk/server/src/FeatureFlagsState.cs
+++ b/pkgs/sdk/server/src/FeatureFlagsState.cs
@@ -332,9 +332,14 @@ namespace LaunchDarkly.Sdk.Server
                         for (var flagsObj = RequireObject(ref reader); flagsObj.Next(ref reader);)
                         {
                             var subKey = flagsObj.Name;
+
                             var flag = flags.ContainsKey(subKey)
                                 ? flags[subKey]
-                                : new FlagState() { Prerequisites = new List<string>() };
+                                : new FlagState
+                                {
+                                    // Most flags have no prerequisites, don't allocate unless we need to.
+                                    Prerequisites = new List<string>(0)
+                                };
 
                             for (var metaObj = RequireObject(ref reader); metaObj.Next(ref reader);)
                             {
@@ -359,7 +364,6 @@ namespace LaunchDarkly.Sdk.Server
                                                 EvaluationReasonConverter.ReadJsonValue(ref reader);
                                         break;
                                     case "prerequisites":
-                                        flag.Prerequisites = new List<string>();
                                         for (var prereqs = RequireArray(ref reader); prereqs.Next(ref reader);)
                                         {
                                             flag.Prerequisites.Add(reader.GetString());
@@ -372,7 +376,11 @@ namespace LaunchDarkly.Sdk.Server
                         break;
 
                     default:
-                        var flagForValue = flags.ContainsKey(key) ? flags[key] : new FlagState(){Prerequisites = new List<string>()};
+                        var flagForValue = flags.ContainsKey(key) ? flags[key] : new FlagState
+                        {
+                            // Most flags have no prerequisites, don't allocate unless we need to.
+                            Prerequisites = new List<string>(0)
+                        };
                         flagForValue.Value = LdValueConverter.ReadJsonValue(ref reader);
                         flags[key] = flagForValue;
                         break;

--- a/pkgs/sdk/server/src/Internal/Evaluation/EvaluatorTypes.cs
+++ b/pkgs/sdk/server/src/Internal/Evaluation/EvaluatorTypes.cs
@@ -21,6 +21,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
         internal struct PrerequisiteEvalRecord
         {
             internal readonly FeatureFlag PrerequisiteFlag;
+            // This is mis-named, this should be flagKey or parentOfPrerequisite
             internal readonly string PrerequisiteOfFlagKey;
             internal readonly EvaluationDetail<LdValue> Result;
 

--- a/pkgs/sdk/server/src/Internal/Evaluation/EvaluatorTypes.cs
+++ b/pkgs/sdk/server/src/Internal/Evaluation/EvaluatorTypes.cs
@@ -21,15 +21,14 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
         internal struct PrerequisiteEvalRecord
         {
             internal readonly FeatureFlag PrerequisiteFlag;
-            // This is mis-named, this should be flagKey or parentOfPrerequisite
-            internal readonly string PrerequisiteOfFlagKey;
+            internal readonly string FlagKey;
             internal readonly EvaluationDetail<LdValue> Result;
 
-            internal PrerequisiteEvalRecord(FeatureFlag prerequisiteFlag, string prerequisiteOfFlagKey,
+            internal PrerequisiteEvalRecord(FeatureFlag prerequisiteFlag, string flagKey,
                 EvaluationDetail<LdValue> result)
             {
                 PrerequisiteFlag = prerequisiteFlag;
-                PrerequisiteOfFlagKey = prerequisiteOfFlagKey;
+                FlagKey = flagKey;
                 Result = result;
             }
         }

--- a/pkgs/sdk/server/src/LdClient.cs
+++ b/pkgs/sdk/server/src/LdClient.cs
@@ -399,7 +399,7 @@ namespace LaunchDarkly.Sdk.Server
                     bool inExperiment = EventFactory.IsExperiment(flag, result.Result.Reason);
 
                     var directPrerequisites = result.PrerequisiteEvals.Where(
-                        e => e.PrerequisiteOfFlagKey == flag.Key)
+                        e => e.FlagKey == flag.Key)
                         .Select(p => p.PrerequisiteFlag.Key).ToList();
 
                     builder.AddFlag(
@@ -482,7 +482,7 @@ namespace LaunchDarkly.Sdk.Server
                     foreach (var prereqEvent in evalResult.PrerequisiteEvals)
                     {
                         _eventProcessor.RecordEvaluationEvent(eventFactory.NewPrerequisiteEvaluationEvent(
-                            prereqEvent.PrerequisiteFlag, context, prereqEvent.Result, prereqEvent.PrerequisiteOfFlagKey));
+                            prereqEvent.PrerequisiteFlag, context, prereqEvent.Result, prereqEvent.FlagKey));
                     }
                 }
                 var evalDetail = evalResult.Result;

--- a/pkgs/sdk/server/test/Internal/Evaluation/EvaluatorPrerequisitesTest.cs
+++ b/pkgs/sdk/server/test/Internal/Evaluation/EvaluatorPrerequisitesTest.cs
@@ -64,7 +64,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
                     Assert.Equal(f1.Key, e.PrerequisiteFlag.Key);
                     Assert.Equal(LdValue.Of("go"), e.Result.Value);
                     Assert.Equal(f1.Version, e.PrerequisiteFlag.Version);
-                    Assert.Equal(f0.Key, e.PrerequisiteOfFlagKey);
+                    Assert.Equal(f0.Key, e.FlagKey);
                 });
         }
 
@@ -99,7 +99,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
                     Assert.Equal(f1.Key, e.PrerequisiteFlag.Key);
                     Assert.Equal(LdValue.Of("nogo"), e.Result.Value);
                     Assert.Equal(f1.Version, e.PrerequisiteFlag.Version);
-                    Assert.Equal(f0.Key, e.PrerequisiteOfFlagKey);
+                    Assert.Equal(f0.Key, e.FlagKey);
                 });
         }
 
@@ -133,7 +133,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
                     Assert.Equal(f1.Key, e.PrerequisiteFlag.Key);
                     Assert.Equal(LdValue.Of("go"), e.Result.Value);
                     Assert.Equal(f1.Version, e.PrerequisiteFlag.Version);
-                    Assert.Equal(f0.Key, e.PrerequisiteOfFlagKey);
+                    Assert.Equal(f0.Key, e.FlagKey);
                 });
         }
 
@@ -176,14 +176,14 @@ namespace LaunchDarkly.Sdk.Server.Internal.Evaluation
                     Assert.Equal(f2.Key, e.PrerequisiteFlag.Key);
                     Assert.Equal(LdValue.Of("go"), e.Result.Value);
                     Assert.Equal(f2.Version, e.PrerequisiteFlag.Version);
-                    Assert.Equal(f1.Key, e.PrerequisiteOfFlagKey);
+                    Assert.Equal(f1.Key, e.FlagKey);
                 },
                 e =>
                 {
                     Assert.Equal(f1.Key, e.PrerequisiteFlag.Key);
                     Assert.Equal(LdValue.Of("go"), e.Result.Value);
                     Assert.Equal(f1.Version, e.PrerequisiteFlag.Version);
-                    Assert.Equal(f0.Key, e.PrerequisiteOfFlagKey);
+                    Assert.Equal(f0.Key, e.FlagKey);
                 });
         }
 

--- a/pkgs/sdk/server/test/Internal/Model/FeatureFlagBuilder.cs
+++ b/pkgs/sdk/server/test/Internal/Model/FeatureFlagBuilder.cs
@@ -202,6 +202,11 @@ namespace LaunchDarkly.Sdk.Server.Internal.Model
             return On(false).OffVariation(0).Variations(value);
         }
 
+        internal FeatureFlagBuilder OnWithValue(LdValue value)
+        {
+            return On(true).OffVariation(0).FallthroughVariation(0).Variations(value);
+        }
+
         internal FeatureFlagBuilder BooleanWithClauses(params Clause[] clauses)
         {
             return On(true).OffVariation(0)


### PR DESCRIPTION
This PR updates `AllFlagsState` to track prerequisite evaluations. 

This didn't require modifying the Evaluator interface, as it already returns prerequisites as part of the `EvalResult`. 

When the returned `FlagState` is marshaled to JSON, it will now contain the prerequisite info for each flag.