### PR TITLE
feat: client-side prerequisite events

### DIFF
--- a/pkgs/sdk/client/contract-tests/TestService.cs
+++ b/pkgs/sdk/client/contract-tests/TestService.cs
@@ -40,7 +40,8 @@ namespace TestService
             "tags",
             "auto-env-attributes",
             "inline-context",
-            "anonymous-redaction"
+            "anonymous-redaction",
+            "client-prereq-events"
         };
 
         public readonly Handler Handler;

--- a/pkgs/sdk/client/src/DataModel.cs
+++ b/pkgs/sdk/client/src/DataModel.cs
@@ -155,9 +155,9 @@ namespace LaunchDarkly.Sdk.Client
                             debugEventsUntilDate = JsonSerializer.Deserialize<UnixMillisecondTime?>(ref reader);
                             break;
                         case "prerequisites":
-                            prerequisites = new List<string>();
-                            for (var array = RequireArray(ref reader); array.Next(ref reader);)
+                            for (var array = RequireArrayOrNull(ref reader); array.Next(ref reader);)
                             {
+                                prerequisites ??= new List<string>();
                                 prerequisites.Add(reader.GetString());
                             }
                             break;
@@ -199,6 +199,16 @@ namespace LaunchDarkly.Sdk.Client
                 if (value.DebugEventsUntilDate.HasValue)
                 {
                     writer.WriteNumber("debugEventsUntilDate", value.DebugEventsUntilDate.Value.Value);
+                }
+
+                if (value.Prerequisites != null && value.Prerequisites.Count > 0)
+                {
+                    writer.WriteStartArray("prerequisites");
+                    foreach (var p in value.Prerequisites)
+                    {
+                        writer.WriteStringValue(p);
+                    }
+                    writer.WriteEndArray();
                 }
 
                 writer.WriteEndObject();

--- a/pkgs/sdk/client/src/DataModel.cs
+++ b/pkgs/sdk/client/src/DataModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using LaunchDarkly.Sdk.Internal;
@@ -36,6 +38,8 @@ namespace LaunchDarkly.Sdk.Client
             internal bool TrackReason { get; }
             internal UnixMillisecondTime? DebugEventsUntilDate { get; }
 
+            internal IReadOnlyList<string> Prerequisites { get; }
+
             internal FeatureFlag(
                 LdValue value,
                 int? variation,
@@ -44,8 +48,8 @@ namespace LaunchDarkly.Sdk.Client
                 int? flagVersion,
                 bool trackEvents,
                 bool trackReason,
-                UnixMillisecondTime? debugEventsUntilDate
-                )
+                UnixMillisecondTime? debugEventsUntilDate,
+                IReadOnlyList<string> prerequisites)
             {
                 Value = value;
                 Variation = variation;
@@ -55,21 +59,42 @@ namespace LaunchDarkly.Sdk.Client
                 TrackEvents = trackEvents;
                 TrackReason = trackReason;
                 DebugEventsUntilDate = debugEventsUntilDate;
+                Prerequisites = prerequisites;
             }
 
             /// <inheritdoc/>
             public override bool Equals(object obj) =>
-                Equals(obj as FeatureFlag);
+                obj is FeatureFlag other && Equals(other);
 
             /// <inheritdoc/>
-            public bool Equals(FeatureFlag otherFlag) =>
-                Value.Equals(otherFlag.Value)
-                && Variation == otherFlag.Variation
-                && Reason.Equals(otherFlag.Reason)
-                && Version == otherFlag.Version
-                && FlagVersion == otherFlag.FlagVersion
-                && TrackEvents == otherFlag.TrackEvents
-                && DebugEventsUntilDate == otherFlag.DebugEventsUntilDate;
+            public bool Equals(FeatureFlag otherFlag)
+            {
+
+                if (otherFlag is null)
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(this, otherFlag))
+                {
+                    return true;
+                }
+
+                if (GetType() != otherFlag.GetType())
+                {
+                    return false;
+                }
+
+                return Variation == otherFlag.Variation
+                       && Reason.Equals(otherFlag.Reason)
+                       && Version == otherFlag.Version
+                       && FlagVersion == otherFlag.FlagVersion
+                       && TrackEvents == otherFlag.TrackEvents
+                       && DebugEventsUntilDate == otherFlag.DebugEventsUntilDate
+                       && (Prerequisites == null && otherFlag.Prerequisites == null ||
+                           Prerequisites != null && otherFlag.Prerequisites != null &&
+                           Prerequisites.SequenceEqual(otherFlag.Prerequisites));
+            }
 
             /// <inheritdoc/>
             public override int GetHashCode() =>
@@ -77,8 +102,8 @@ namespace LaunchDarkly.Sdk.Client
 
             /// <inheritdoc/>
             public override string ToString() =>
-                string.Format("({0},{1},{2},{3},{4},{5},{6},{7})",
-                    Value, Variation, Reason, Version, FlagVersion, TrackEvents, TrackReason, DebugEventsUntilDate);
+                string.Format("({0},{1},{2},{3},{4},{5},{6},{7},{8})",
+                    Value, Variation, Reason, Version, FlagVersion, TrackEvents, TrackReason, DebugEventsUntilDate, Prerequisites);
 
             internal ItemDescriptor ToItemDescriptor() =>
                 new ItemDescriptor(Version, this);
@@ -99,6 +124,7 @@ namespace LaunchDarkly.Sdk.Client
                 bool trackEvents = false;
                 bool trackReason = false;
                 UnixMillisecondTime? debugEventsUntilDate = null;
+                List<string> prerequisites = null;
 
                 for (var obj = RequireObject(ref reader); obj.Next(ref reader);)
                 {
@@ -128,6 +154,14 @@ namespace LaunchDarkly.Sdk.Client
                         case "debugEventsUntilDate":
                             debugEventsUntilDate = JsonSerializer.Deserialize<UnixMillisecondTime?>(ref reader);
                             break;
+                        case "prerequisites":
+                            prerequisites = new List<string>();
+                            for (var array = RequireArray(ref reader); array.Next(ref reader);)
+                            {
+                                prerequisites.Add(reader.GetString());
+                            }
+                            break;
+
                     }
                 }
 
@@ -139,8 +173,9 @@ namespace LaunchDarkly.Sdk.Client
                     flagVersion,
                     trackEvents,
                     trackReason,
-                    debugEventsUntilDate
-                    );
+                    debugEventsUntilDate,
+                    prerequisites
+                );
             }
 
             public override void Write(Utf8JsonWriter writer, FeatureFlag value, JsonSerializerOptions options) =>

--- a/pkgs/sdk/client/src/DataModel.cs
+++ b/pkgs/sdk/client/src/DataModel.cs
@@ -59,7 +59,7 @@ namespace LaunchDarkly.Sdk.Client
                 TrackEvents = trackEvents;
                 TrackReason = trackReason;
                 DebugEventsUntilDate = debugEventsUntilDate;
-                Prerequisites = prerequisites;
+                Prerequisites = prerequisites != null ? new List<string>(prerequisites) : null;
             }
 
             /// <inheritdoc/>

--- a/pkgs/sdk/client/src/DataModel.cs
+++ b/pkgs/sdk/client/src/DataModel.cs
@@ -49,7 +49,7 @@ namespace LaunchDarkly.Sdk.Client
                 bool trackEvents,
                 bool trackReason,
                 UnixMillisecondTime? debugEventsUntilDate,
-                IReadOnlyList<string> prerequisites)
+                IReadOnlyList<string> prerequisites = null)
             {
                 Value = value;
                 Variation = variation;

--- a/pkgs/sdk/client/src/Integrations/TestData.cs
+++ b/pkgs/sdk/client/src/Integrations/TestData.cs
@@ -592,7 +592,8 @@ namespace LaunchDarkly.Sdk.Client.Integrations
                         _preconfiguredFlag.FlagVersion,
                         _preconfiguredFlag.TrackEvents,
                         _preconfiguredFlag.TrackReason,
-                        _preconfiguredFlag.DebugEventsUntilDate));
+                        _preconfiguredFlag.DebugEventsUntilDate,
+                        _preconfiguredFlag.Prerequisites));
                 }
                 int variation;
                 if (!_variationByContextKey.TryGetValue(context.Kind, out var keys) ||

--- a/pkgs/sdk/client/src/LdClient.cs
+++ b/pkgs/sdk/client/src/LdClient.cs
@@ -761,6 +761,22 @@ namespace LaunchDarkly.Sdk.Client
                 }
             }
 
+            // The flag.Prerequisites array represents the evaluated prerequisites of this flag. We need to generate
+            // events for both this flag and its prerequisites (recursively), which is necessary to ensure LaunchDarkly
+            // analytics functions properly.
+            //
+            // We're using JsonVariationDetail because the type of the prerequisite is both unknown and irrelevant
+            // to emitting the events.
+            //
+            // We're passing LdValue.Null to match a server-side SDK's behavior when evaluating prerequisites.
+            if (flag.Prerequisites != null)
+            {
+                foreach (var prerequisiteKey in flag.Prerequisites)
+                {
+                    JsonVariationDetail(prerequisiteKey, LdValue.Null);
+                }
+            }
+
             EvaluationDetail<T> result;
             LdValue valueJson;
             if (flag.Value.IsNull)

--- a/pkgs/sdk/client/src/LdClient.cs
+++ b/pkgs/sdk/client/src/LdClient.cs
@@ -769,6 +769,9 @@ namespace LaunchDarkly.Sdk.Client
             // to emitting the events.
             //
             // We're passing LdValue.Null to match a server-side SDK's behavior when evaluating prerequisites.
+            //
+            // NOTE: if "hooks" functionality is implemented into this SDK, take care that evaluating prerequisites
+            // does not trigger hooks. This may require refactoring the code below to not use JsonVariationDetail.
             if (flag.Prerequisites != null)
             {
                 foreach (var prerequisiteKey in flag.Prerequisites)

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
@@ -359,12 +359,6 @@ namespace LaunchDarkly.Sdk.Client
                 client.BoolVariation("flagAC");
                 client.BoolVariation("flagABD");
 
-                _testOutput.WriteLine("Events:");
-                foreach (var e in eventProcessor.Events)
-                {
-                    _testOutput.WriteLine(e.ToString());
-                }
-
                 Assert.Collection(eventProcessor.Events,
                 e => CheckIdentifyEvent(e, user),
                     e => CheckEvaluationEvent(e, "flagA"),

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
@@ -14,10 +14,12 @@ namespace LaunchDarkly.Sdk.Client
         private readonly TestData _testData = TestData.DataSource();
         private MockEventProcessor eventProcessor = new MockEventProcessor();
         private IComponentConfigurer<IEventProcessor> _factory;
+        private ITestOutputHelper _testOutput;
 
         public LdClientEventTests(ITestOutputHelper testOutput) : base(testOutput)
         {
             _factory = eventProcessor.AsSingletonFactory<IEventProcessor>();
+            _testOutput = testOutput;
         }
 
         private LdClient MakeClient(Context c) =>
@@ -356,6 +358,12 @@ namespace LaunchDarkly.Sdk.Client
                 client.BoolVariation("flagAB");
                 client.BoolVariation("flagAC");
                 client.BoolVariation("flagABD");
+
+                _testOutput.WriteLine("Events:");
+                foreach (var e in eventProcessor.Events)
+                {
+                    _testOutput.WriteLine(e.ToString());
+                }
 
                 Assert.Collection(eventProcessor.Events,
                 e => CheckIdentifyEvent(e, user),

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
@@ -333,11 +333,55 @@ namespace LaunchDarkly.Sdk.Client
             }
         }
 
+        [Fact]
+        public void VariationSendsFeatureEventForPrerequisites()
+        {
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1000)
+                .TrackEvents(false).TrackReason(false).Build();
+            var flagAB = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1000)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            var flagAC = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1000)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            var flagABD = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1000)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagAB").Build();
+
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+            _testData.Update(_testData.Flag("flagAB").PreconfiguredFlag(flagAB));
+            _testData.Update(_testData.Flag("flagAC").PreconfiguredFlag(flagAC));
+            _testData.Update(_testData.Flag("flagABD").PreconfiguredFlag(flagABD));
+
+            using (LdClient client = MakeClient(user))
+            {
+                client.BoolVariation("flagA");
+                client.BoolVariation("flagAB");
+                client.BoolVariation("flagAC");
+                client.BoolVariation("flagABD");
+
+                Assert.Collection(eventProcessor.Events,
+                e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagA"),
+                    e => CheckEvaluationEvent(e, "flagA"),
+                    e => CheckEvaluationEvent(e, "flagAB"),
+                    e => CheckEvaluationEvent(e, "flagA"),
+                    e => CheckEvaluationEvent(e, "flagAC"),
+                    e => CheckEvaluationEvent(e, "flagA"),
+                    e => CheckEvaluationEvent(e, "flagAB"),
+                    e => CheckEvaluationEvent(e, "flagABD")
+                );
+            }
+        }
+
         private void CheckIdentifyEvent(object e, Context c)
         {
             IdentifyEvent ie = Assert.IsType<IdentifyEvent>(e);
             Assert.Equal(c.FullyQualifiedKey, ie.Context.FullyQualifiedKey);
             Assert.NotEqual(0, ie.Timestamp.Value);
+        }
+
+        private void CheckEvaluationEvent(object e, string flagKey)
+        {
+            EvaluationEvent fe = Assert.IsType<EvaluationEvent>(e);
+            Assert.Equal(flagKey, fe.FlagKey);
         }
     }
 }

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/ModelBuilders.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/ModelBuilders.cs
@@ -16,6 +16,7 @@ namespace LaunchDarkly.Sdk.Client
         private bool _trackReason;
         private UnixMillisecondTime? _debugEventsUntilDate;
         private EvaluationReason? _reason;
+        private List<string> _prerequisites;
 
         public FeatureFlagBuilder()
         {
@@ -30,11 +31,12 @@ namespace LaunchDarkly.Sdk.Client
             _trackReason = from.TrackReason;
             _debugEventsUntilDate = from.DebugEventsUntilDate;
             _reason = from.Reason;
+            _prerequisites = from.Prerequisites != null ? new List<string>(from.Prerequisites) : null;
         }
 
         public FeatureFlag Build()
         {
-            return new FeatureFlag(_value, _variation, _reason, _version, _flagVersion, _trackEvents, _trackReason, _debugEventsUntilDate);
+            return new FeatureFlag(_value, _variation, _reason, _version, _flagVersion, _trackEvents, _trackReason, _debugEventsUntilDate, _prerequisites);
         }
 
         public FeatureFlagBuilder Value(LdValue value)
@@ -86,6 +88,18 @@ namespace LaunchDarkly.Sdk.Client
         public FeatureFlagBuilder DebugEventsUntilDate(UnixMillisecondTime? debugEventsUntilDate)
         {
             _debugEventsUntilDate = debugEventsUntilDate;
+            return this;
+        }
+
+        public FeatureFlagBuilder Prerequisites(params string[] prerequisites)
+        {
+            if (prerequisites == null || prerequisites.Length == 0)
+            {
+                _prerequisites = null;
+                return this;
+            }
+
+            _prerequisites = new List<string>(prerequisites);
             return this;
         }
     }


### PR DESCRIPTION
Allows the client SDK to deserialize `prerequisites` from the flag model and then emit prerequisite evaluation events. 