### PR TITLE
chore: update SDK metadata to account for release tag prefixes

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -12,6 +12,9 @@
         "hooks": {
           "introduced": "8.3"
         }
+      },
+      "releases": {
+        "tag-prefix": "LaunchDarkly.ServerSdk-"
       }
     },
     "dotnet-client-sdk": {
@@ -20,7 +23,10 @@
       "path": "pkgs/sdk/client",
       "languages": [
         "C#"
-      ]
+      ],
+      "releases": {
+        "tag-prefix": "LaunchDarkly.ClientSdk-"
+      }
     }
   }
 }


### PR DESCRIPTION
Although sdk-meta was scanning this repo, it wasn't picking up the latest releases because I had forgotten to define the "tag prefix" for each SDK. 

This is what sdk-meta uses to parse out the semver tag. 