### PR TITLE
chore: remove release-as for server-ai

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,6 @@
     },
     "pkgs/sdk/server-ai": {
       "package-name": "LaunchDarkly.ServerSdk.Ai",
-      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj"


### PR DESCRIPTION
Now that we've released the package, we can remove release-as.