### PR TITLE
fix: catch exceptions thrown by template interpolation

### DIFF
--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -86,7 +86,8 @@ public sealed class LdAiClient : ILdAiClient
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error($"AI model config prompt has malformed message at index {i}: {ex.Message} (returning default config)");
+                    _logger.Error(
+                        $"AI model config prompt has malformed message at index {i}: {ex.Message} (returning default config, which will not contain interpolated prompt messages)");
                     return new LdAiConfigTracker(_client, key, defaultValue, context);
                 }
             }
@@ -154,7 +155,8 @@ public sealed class LdAiClient : ILdAiClient
         }
         catch (JsonException e)
         {
-            _logger.Error("Unable to parse AI model config for key {0}: {1}", key, e.Message);
+            _logger.Error(
+                $"Unable to parse AI model config for key {key}: {e.Message} (returning default config, which will not contain interpolated prompt messages)");
             return null;
         }
     }

--- a/pkgs/sdk/server-ai/test/InterpolationTests.cs
+++ b/pkgs/sdk/server-ai/test/InterpolationTests.cs
@@ -143,6 +143,8 @@ public class InterpolationTests
 
         mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
 
+        mockLogger.Setup(x => x.Error(It.IsAny<string>()));
+
         var client = new LdAiClient(mockClient.Object);
         var tracker = client.ModelConfig("foo", Context.New("key"), LdAiConfig.Disabled);
         Assert.False(tracker.Config.Enabled);

--- a/pkgs/sdk/server-ai/test/InterpolationTests.cs
+++ b/pkgs/sdk/server-ai/test/InterpolationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -117,6 +118,35 @@ public class InterpolationTests
         Assert.Equal("hello world ! ", result);
     }
 
+    [Fact]
+    public void TestInterpolationMalformed()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+
+        const string configJson = """
+                                  {
+                                      "_ldMeta": {"versionKey": "1", "enabled": true},
+                                      "model": {},
+                                      "prompt": [
+                                          {
+                                              "content": "This is a {{ malformed }]} prompt",
+                                              "role": "System"
+                                          }
+                                      ]
+                                  }
+                                  """;
+
+
+        mockClient.Setup(x =>
+            x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>())).Returns(LdValue.Parse(configJson));
+
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+
+        var client = new LdAiClient(mockClient.Object);
+        var tracker = client.ModelConfig("foo", Context.New("key"), LdAiConfig.Disabled);
+        Assert.False(tracker.Config.Enabled);
+    }
 
     [Fact]
     public void TestInterpolationWithBasicContext()


### PR DESCRIPTION
This is a first pass at catching exceptions generated by the interpolation process. It wraps each call to interpolate with a try/catch and individually reports an error via the logger.

I know that the exception message in this particular case (in unit test) is pretty useless, but it also seems bad to simply swallow the error with no extra context. 