### PR TITLE
fix: rename ModelConfig method to Config

### DIFF
--- a/pkgs/sdk/server-ai/docs-src/namespaces/LaunchDarkly.Sdk.Server.Ai.md
+++ b/pkgs/sdk/server-ai/docs-src/namespaces/LaunchDarkly.Sdk.Server.Ai.md
@@ -17,5 +17,5 @@ var aiClient = new LdAiClient(new LdClientAdapter(baseClient));
 
 // Pass in the key of the AI config, a context, and a default value in case the config can't be
 // retrieved from LaunchDarkly.
-var myModelConfig = aiClient.ModelConfig("my-model-config", Context.New("user-key"), LdAiConfig.Disabled);
+var myModelConfig = aiClient.Config("my-model-config", Context.New("user-key"), LdAiConfig.Disabled);
 ```

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
@@ -79,7 +79,7 @@ public record LdAiConfig
 
     /// <summary>
     /// Builder for constructing an LdAiConfig instance, which can be passed as the default
-    /// value to the AI Client's <see cref="LdAiClient.ModelConfig"/> method.
+    /// value to the AI Client's <see cref="LdAiClient.Config"/> method.
     /// </summary>
     public class Builder
     {

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
@@ -24,6 +24,6 @@ public interface ILdAiClient
     /// <param name="defaultValue">the default config, if unable to retrieve from LaunchDarkly</param>
     /// <param name="variables">the list of variables used when interpolating the prompt</param>
     /// <returns>an AI config tracker</returns>
-    public ILdAiConfigTracker ModelConfig(string key, Context context, LdAiConfig defaultValue,
+    public ILdAiConfigTracker Config(string key, Context context, LdAiConfig defaultValue,
         IReadOnlyDictionary<string, object> variables = null);
 }

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -44,7 +44,7 @@ public sealed class LdAiClient : ILdAiClient
     private const string LdContextVariable = "ldctx";
 
     /// <inheritdoc/>
-    public ILdAiConfigTracker ModelConfig(string key, Context context, LdAiConfig defaultValue,
+    public ILdAiConfigTracker Config(string key, Context context, LdAiConfig defaultValue,
         IReadOnlyDictionary<string, object> variables = null)
     {
 

--- a/pkgs/sdk/server-ai/test/InterpolationTests.cs
+++ b/pkgs/sdk/server-ai/test/InterpolationTests.cs
@@ -39,7 +39,7 @@ public class InterpolationTests
         mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
 
         var client = new LdAiClient(mockClient.Object);
-        var tracker = client.ModelConfig("foo", context, LdAiConfig.Disabled, variables);
+        var tracker = client.Config("foo", context, LdAiConfig.Disabled, variables);
 
         return tracker.Config.Messages[0].Content;
     }
@@ -146,7 +146,7 @@ public class InterpolationTests
         mockLogger.Setup(x => x.Error(It.IsAny<string>()));
 
         var client = new LdAiClient(mockClient.Object);
-        var tracker = client.ModelConfig("foo", Context.New("key"), LdAiConfig.Disabled);
+        var tracker = client.Config("foo", Context.New("key"), LdAiConfig.Disabled);
         Assert.False(tracker.Config.Enabled);
     }
 

--- a/pkgs/sdk/server-ai/test/LdAiClientTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientTest.cs
@@ -16,7 +16,7 @@ public class LdAiClientTest
     {
         var client = new LdClientAdapter(new LdClient(Configuration.Builder("key").Offline(true).Build()));
         var aiClient = new LdAiClient(client);
-        var result= aiClient.ModelConfig("foo", Context.New("key"), LdAiConfig.Disabled);
+        var result= aiClient.Config("foo", Context.New("key"), LdAiConfig.Disabled);
         Assert.False(result.Config.Enabled);
     }
 
@@ -44,7 +44,7 @@ public class LdAiClientTest
 
         var defaultConfig = LdAiConfig.New().AddMessage("Hello").Build();
 
-        var tracker = client.ModelConfig("foo", Context.New(ContextKind.Default, "key"), defaultConfig);
+        var tracker = client.Config("foo", Context.New(ContextKind.Default, "key"), defaultConfig);
 
         Assert.Equal(defaultConfig, tracker.Config);
     }
@@ -95,7 +95,7 @@ public class LdAiClientTest
         // All the JSON inputs here are considered disabled, either due to lack of the 'enabled' property,
         // or if present, it is set to false. Therefore, if the default was returned, we'd see the assertion fail
         // (since calling LdAiConfig.New() constructs an enabled config by default.)
-        var tracker = client.ModelConfig("foo", Context.New(ContextKind.Default, "key"),
+        var tracker = client.Config("foo", Context.New(ContextKind.Default, "key"),
             LdAiConfig.New().AddMessage("foo").Build());
 
         Assert.False(tracker.Config.Enabled);
@@ -115,7 +115,7 @@ public class LdAiClientTest
 
         var client = new LdAiClient(mockClient.Object);
 
-        var tracker = client.ModelConfig("foo", Context.New(ContextKind.Default, "key"),
+        var tracker = client.Config("foo", Context.New(ContextKind.Default, "key"),
             LdAiConfig.New().
                 AddMessage("foo").
                 SetModelParam("foo", LdValue.Of("bar")).
@@ -158,7 +158,7 @@ public class LdAiClientTest
         var client = new LdAiClient(mockClient.Object);
 
         // We shouldn't get this default.
-        var tracker = client.ModelConfig("foo", context,
+        var tracker = client.Config("foo", context,
             LdAiConfig.New().AddMessage("Goodbye!").Build());
 
         Assert.Collection(tracker.Config.Messages,
@@ -210,7 +210,7 @@ public class LdAiClientTest
         var client = new LdAiClient(mockClient.Object);
 
         // We shouldn't get this default.
-        var tracker = client.ModelConfig("foo", context,
+        var tracker = client.Config("foo", context,
             LdAiConfig.New().AddMessage("Goodbye!").Build());
 
         Assert.Equal("model-foo", tracker.Config.Model.Id);
@@ -247,7 +247,7 @@ public class LdAiClientTest
         var client = new LdAiClient(mockClient.Object);
 
         // We shouldn't get this default.
-        var tracker = client.ModelConfig("foo", context,
+        var tracker = client.Config("foo", context,
             LdAiConfig.New().AddMessage("Goodbye!").Build());
 
         Assert.Equal("amazing-provider", tracker.Config.Provider.Id);


### PR DESCRIPTION
The latest specification renames `ModelConfig` to `Config`. 