### PR TITLE
refactor!: rename _ldMeta.versionKey to variationKey

### DIFF
--- a/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
@@ -222,7 +222,7 @@ public record LdAiConfig
         Model = new ModelConfiguration(model?.Id ?? "", model?.Parameters ?? new Dictionary<string, LdValue>(),
             model?.Custom ?? new Dictionary<string, LdValue>());
         Messages = messages?.ToList() ?? new List<Message>();
-        VersionKey = meta?.VersionKey ?? "";
+        VariationKey = meta?.VariationKey ?? "";
         Enabled = enabled;
         Provider = new ModelProvider(provider?.Id ?? "");
     }
@@ -233,7 +233,7 @@ public record LdAiConfig
             { "_ldMeta", LdValue.ObjectFrom(
                 new Dictionary<string, LdValue>
                 {
-                    { "versionKey", LdValue.Of(VersionKey) },
+                    { "variationKey", LdValue.Of(VariationKey) },
                     { "enabled", LdValue.Of(Enabled) }
                 }) },
             { "messages", LdValue.ArrayFrom(Messages.Select(m => LdValue.ObjectFrom(new Dictionary<string, LdValue>
@@ -269,7 +269,7 @@ public record LdAiConfig
     /// <summary>
     /// This field meant for internal LaunchDarkly usage.
     /// </summary>
-    public string VersionKey { get; }
+    public string VariationKey { get; }
 
     /// <summary>
     /// Convenient helper that returns a disabled LdAiConfig.

--- a/pkgs/sdk/server-ai/src/DataModel/DataModel.cs
+++ b/pkgs/sdk/server-ai/src/DataModel/DataModel.cs
@@ -30,8 +30,8 @@ public class Meta
     /// <summary>
     /// The version key.
     /// </summary>
-    [JsonPropertyName("versionKey")]
-    public string VersionKey { get; set; }
+    [JsonPropertyName("variationKey")]
+    public string VariationKey { get; set; }
 
     /// <summary>
     /// If the config is enabled.

--- a/pkgs/sdk/server-ai/src/DataModel/DataModel.cs
+++ b/pkgs/sdk/server-ai/src/DataModel/DataModel.cs
@@ -28,7 +28,7 @@ public enum Role
 public class Meta
 {
     /// <summary>
-    /// The version key.
+    /// The variation key.
     /// </summary>
     [JsonPropertyName("variationKey")]
     public string VariationKey { get; set; }

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -41,7 +41,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         _context = context;
         _trackData =  LdValue.ObjectFrom(new Dictionary<string, LdValue>
         {
-            { "versionKey", LdValue.Of(Config.VersionKey)},
+            { "variationKey", LdValue.Of(config.VariationKey)},
             { "configKey" , LdValue.Of(configKey ?? throw new ArgumentNullException(nameof(configKey))) }
         });
     }

--- a/pkgs/sdk/server-ai/test/InterpolationTests.cs
+++ b/pkgs/sdk/server-ai/test/InterpolationTests.cs
@@ -21,7 +21,7 @@ public class InterpolationTests
         // The replacement is done this way because to use string.Format, we'd need to escape the curly braces.
         var configJson = """
                         {
-                            "_ldMeta": {"versionKey": "1", "enabled": true},
+                            "_ldMeta": {"variationKey": "1", "enabled": true},
                             "model": {},
                             "messages": [
                                 {
@@ -126,7 +126,7 @@ public class InterpolationTests
 
         const string configJson = """
                                   {
-                                      "_ldMeta": {"versionKey": "1", "enabled": true},
+                                      "_ldMeta": {"variationKey": "1", "enabled": true},
                                       "model": {},
                                       "messages": [
                                           {

--- a/pkgs/sdk/server-ai/test/LdAiClientTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientTest.cs
@@ -51,7 +51,7 @@ public class LdAiClientTest
 
     private const string MetaDisabledExplicitly = """
                                                   {
-                                                    "_ldMeta": {"versionKey": "1", "enabled": false},
+                                                    "_ldMeta": {"variationKey": "1", "enabled": false},
                                                     "model": {},
                                                     "messages": []
                                                   }
@@ -59,7 +59,7 @@ public class LdAiClientTest
 
     private const string MetaDisabledImplicitly = """
                                                   {
-                                                    "_ldMeta": {"versionKey": "1"},
+                                                    "_ldMeta": {"variationKey": "1"},
                                                     "model": {},
                                                     "messages": []
                                                   }
@@ -146,7 +146,7 @@ public class LdAiClientTest
 
         const string json = """
                             {
-                              "_ldMeta": {"versionKey": "1", "enabled": true},
+                              "_ldMeta": {"variationKey": "1", "enabled": true},
                               "messages": [{"content": "Hello!", "role": "system"}]
                             }
                             """;
@@ -187,7 +187,7 @@ public class LdAiClientTest
 
         const string json = """
                             {
-                              "_ldMeta": {"versionKey": "1", "enabled": true},
+                              "_ldMeta": {"variationKey": "1", "enabled": true},
                               "model" : {
                                 "id": "model-foo",
                                 "parameters": {
@@ -232,7 +232,7 @@ public class LdAiClientTest
 
         const string json = """
                             {
-                              "_ldMeta": {"versionKey": "1", "enabled": true},
+                              "_ldMeta": {"variationKey": "1", "enabled": true},
                               "provider": {
                                 "id": "amazing-provider"
                               }

--- a/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
@@ -42,7 +42,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
             var tracker = new LdAiConfigTracker(mockClient.Object, flagKey, config, context);
@@ -61,7 +61,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 
@@ -80,7 +80,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 
@@ -114,7 +114,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 
@@ -135,7 +135,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 
@@ -163,7 +163,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 
@@ -204,7 +204,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = LdAiConfig.Disabled;
             var data = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
-                { "versionKey", LdValue.Of(config.VersionKey) },
+                { "variationKey", LdValue.Of(config.VariationKey) },
                 { "configKey", LdValue.Of(flagKey) }
             });
 


### PR DESCRIPTION
This renames `_ldMeta.versionKey` field to `variationKey` following the latest spec changes. 