### PR TITLE
feat: Add environment ID support for hooks.

### DIFF
--- a/pkgs/sdk/server/src/Hooks/EvaluationSeriesContext.cs
+++ b/pkgs/sdk/server/src/Hooks/EvaluationSeriesContext.cs
@@ -26,17 +26,25 @@ namespace LaunchDarkly.Sdk.Server.Hooks
         public string Method { get;  }
 
         /// <summary>
+        /// The environment ID for the evaluation, or null if not available.
+        /// </summary>
+        public string EnvironmentId { get; }
+
+        /// <summary>
         /// Constructs a new EvaluationSeriesContext.
         /// </summary>
         /// <param name="flagKey">the flag key</param>
         /// <param name="context">the context</param>
         /// <param name="defaultValue">the default value</param>
         /// <param name="method">the variation method</param>
-        public EvaluationSeriesContext(string flagKey, Context context, LdValue defaultValue, string method) {
+        /// <param name="environmentId">the environment ID</param>
+        public EvaluationSeriesContext(string flagKey, Context context, LdValue defaultValue, string method,
+            string environmentId = null) {
             FlagKey = flagKey;
             Context = context;
             DefaultValue = defaultValue;
             Method = method;
+            EnvironmentId = environmentId;
         }
     }
 }

--- a/pkgs/sdk/server/src/Internal/DataSources/IFeatureRequestor.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/IFeatureRequestor.cs
@@ -1,12 +1,26 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 {
+    internal class DataSetWithHeaders
+    {
+        public readonly FullDataSet<ItemDescriptor>? DataSet;
+        public readonly IEnumerable<KeyValuePair<string, IEnumerable<string>>> Headers;
+
+        public DataSetWithHeaders(FullDataSet<ItemDescriptor>? dataSet,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers)
+        {
+            DataSet = dataSet;
+            Headers = headers;
+        }
+    }
+
     internal interface IFeatureRequestor : IDisposable
     {
-        Task<FullDataSet<ItemDescriptor>?> GetAllDataAsync();
+        Task<DataSetWithHeaders> GetAllDataAsync();
     }
 }

--- a/pkgs/sdk/server/src/Internal/HeaderConstants.cs
+++ b/pkgs/sdk/server/src/Internal/HeaderConstants.cs
@@ -1,0 +1,16 @@
+namespace LaunchDarkly.Sdk.Server.Internal
+{
+    /// <summary>
+    /// Constants for headers returned from, or sent to, LaunchDarkly.
+    /// <para>
+    /// All header keys should be lowercase.
+    /// </para>
+    /// </summary>
+    public static class HeaderConstants
+    {
+        /// <summary>
+        /// The LaunchDarkly environment ID. This is included in responses from streaming and polling endpoints.
+        /// </summary>
+        public static string EnvironmentId = "x-ld-envid";
+    }
+}

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.0.0" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="5.1.0" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="5.2.0" />
     <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.4.0" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />

--- a/pkgs/sdk/server/src/LdClient.cs
+++ b/pkgs/sdk/server/src/LdClient.cs
@@ -428,7 +428,7 @@ namespace LaunchDarkly.Sdk.Server
         private (EvaluationDetail<T>, FeatureFlag) EvaluateWithHooks<T>(string method, string key, Context context, LdValue defaultValue, LdValue.Converter<T> converter,
             bool checkType, EventFactory eventFactory)
         {
-            var evalSeriesContext = new EvaluationSeriesContext(key, context, defaultValue, method);
+            var evalSeriesContext = new EvaluationSeriesContext(key, context, defaultValue, method, GetEnvironmentId());
             return _hookExecutor.EvaluationSeries(
                 evalSeriesContext,
                 converter,
@@ -679,6 +679,19 @@ namespace LaunchDarkly.Sdk.Server
                 _dataSource.Dispose();
                 _bigSegmentStoreWrapper?.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Get the environment ID.
+        /// </summary>
+        /// <returns>The environment ID, or null if one is not available</returns>
+        private string GetEnvironmentId()
+        {
+            if (_dataStore is IDataStoreMetadata dataStoreMetadata)
+            {
+                return dataStoreMetadata.GetMetadata()?.EnvironmentId;
+            }
+            return null;
         }
 
         #endregion

--- a/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
+++ b/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
@@ -155,7 +155,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 return "DataKind(" + _name + ")";
             }
         }
-        
+
         /// <summary>
         /// A versioned item (or placeholder) storeable in an <see cref="IDataStore"/>.
         /// </summary>
@@ -303,7 +303,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
             /// Shortcut for constructing an empty data set.
             /// </summary>
             /// <returns>an instance containing no data</returns>
-            public static FullDataSet<TDescriptor> Empty() => new FullDataSet<TDescriptor>(null);                
+            public static FullDataSet<TDescriptor> Empty() => new FullDataSet<TDescriptor>(null);
         }
 
         /// <summary>
@@ -340,6 +340,23 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
             /// </summary>
             /// <returns>an instance containing no data</returns>
             public static KeyedItems<TDescriptor> Empty() => new KeyedItems<TDescriptor>(null);
+        }
+
+        /// <summary>
+        /// Meta-data associated with feature store initialization.
+        /// </summary>
+        public sealed class InitMetadata
+        {
+            internal InitMetadata() {}
+            internal InitMetadata(string environmentId)
+            {
+                EnvironmentId = environmentId;
+            }
+
+            /// <summary>
+            /// The environment ID for the associated payload or null if the environment ID is not available.
+            /// </summary>
+            public string EnvironmentId { get; }
         }
     }
 }

--- a/pkgs/sdk/server/src/Subsystems/IDataStoreMetadata.cs
+++ b/pkgs/sdk/server/src/Subsystems/IDataStoreMetadata.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace LaunchDarkly.Sdk.Server.Subsystems
+{
+    /// <summary>
+    /// This interface is to allow extending init without a major version.
+    /// This interface should be removed in the next major version of the SDK and headers
+    /// should be added in the IDataStore interface.
+    /// </summary>
+    public interface IDataStoreMetadata
+    {
+        /// <summary>
+        /// Overwrites the store's contents with a set of items for each collection.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// All previous data should be discarded, regardless of versioning.
+        /// </para>
+        /// <para>
+        /// The update should be done atomically. If it cannot be done atomically, then the store
+        /// must first add or update each item in the same order that they are given in the input
+        /// data, and then delete any previously stored items that were not in the input data.
+        /// </para>
+        /// </remarks>
+        /// <param name="allData">a list of <see cref="DataStoreTypes.DataKind"/> instances and their
+        /// corresponding data sets</param>
+        /// <param name="metadata">metadata assciated with the payload</param>
+        void InitWithMetadata(DataStoreTypes.FullDataSet<DataStoreTypes.ItemDescriptor> allData, DataStoreTypes.InitMetadata metadata);
+
+        /// <summary>
+        /// Metadata associated with the data store content.
+        /// </summary>
+        /// <returns>metadata associated with the store content</returns>
+        DataStoreTypes.InitMetadata GetMetadata();
+    }
+}

--- a/pkgs/sdk/server/src/Subsystems/IDataStoreUpdatesHeaders.cs
+++ b/pkgs/sdk/server/src/Subsystems/IDataStoreUpdatesHeaders.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Server.Subsystems
+{
+    /// <summary>
+    /// This interface is to allow extending init without a major version.
+    /// This interface should be removed in the next major version of the SDK and headers
+    /// should be added in the IDataStore interface.
+    /// </summary>
+    public interface IDataSourceUpdatesHeaders
+    {
+        /// <summary>
+        /// Completely overwrites the current contents of the data store with a set of items for each collection.
+        /// </summary>
+        /// <param name="allData">a list of <see cref="DataStoreTypes.DataKind"/> instances and their
+        /// corresponding data sets</param>
+        /// <param name="headers">response headers for the connection</param>
+        /// <returns>true if the update succeeded, false if it failed</returns>
+        bool InitWithHeaders(DataStoreTypes.FullDataSet<DataStoreTypes.ItemDescriptor> allData,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers);
+    }
+}


### PR DESCRIPTION
This PR pipes the support for the environment ID header from the event source, through the data sources, and into the data store, and then exposes it to the evaluation series hook context.

Each step can optionally support the environment ID/headers for compatibility.

This PR will be held for back-end support and testing.