### PR TITLE
chore: Update provenance generator action.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -128,7 +128,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
     with:
       base64-subjects: "${{ needs.release-sdk-server.outputs.hashes }}"
       upload-assets: true
@@ -141,7 +141,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
     with:
       base64-subjects: "${{ needs.release-telemetry.outputs.hashes }}"
       upload-assets: true
@@ -154,7 +154,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
     with:
       base64-subjects: "${{ needs.release-sdk-client.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -128,7 +128,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release-sdk-server.outputs.hashes }}"
       upload-assets: true
@@ -141,7 +141,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release-telemetry.outputs.hashes }}"
       upload-assets: true
@@ -154,7 +154,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release-sdk-client.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -58,14 +58,14 @@ jobs:
           workspace_path: ${{ env.WORKSPACE_PATH }}
 
       - name: Retain build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dir-bin-release
           path: ${{ env.BUILD_OUTPUT_PATH }}
           retention-days: 1
 
       - name: Retain docs artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dir-docs
           path: ${{ env.WORKSPACE_PATH }}/docs
@@ -104,7 +104,7 @@ jobs:
           dll_name: ${{ env.BUILD_OUTPUT_DLL_NAME }}
 
       - name: Retain signed artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dir-bin-release-signed
           path: ${{ env.BUILD_OUTPUT_PATH }}


### PR DESCRIPTION
Update to the latest version and use a SHA instead of a tag.