### PR TITLE
chore: Bump artifact actions version

### DIFF
--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -58,14 +58,14 @@ jobs:
           workspace_path: ${{ env.WORKSPACE_PATH }}
 
       - name: Retain build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-bin-release
           path: ${{ env.BUILD_OUTPUT_PATH }}
           retention-days: 1
 
       - name: Retain docs artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-docs
           path: ${{ env.WORKSPACE_PATH }}/docs
@@ -86,7 +86,7 @@ jobs:
         run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
 
       - name: Restore release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-bin-release
           path: ${{ env.BUILD_OUTPUT_PATH }}
@@ -104,7 +104,7 @@ jobs:
           dll_name: ${{ env.BUILD_OUTPUT_DLL_NAME }}
 
       - name: Retain signed artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-bin-release-signed
           path: ${{ env.BUILD_OUTPUT_PATH }}
@@ -127,13 +127,13 @@ jobs:
         run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
 
       - name: Restore release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-bin-release-signed
           path: ${{ env.BUILD_OUTPUT_PATH }}
 
       - name: Restore docs artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: dir-docs
           path: ${{ env.WORKSPACE_PATH }}/docs


### PR DESCRIPTION
V3 of artifact upload / download was deprecated on Jan 30th 2025 and no longer works.