### PR TITLE
feat: Support 9x of System.Diagnostics.DiagnosticSource.

### DIFF
--- a/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
+++ b/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
     <!-- Use any 5.x to 8.x.  It's a built-in package in net8.0, hence conditional for targets -->
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[5,9)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[5,10)" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Aside from this version now existing, the primary reason for this update it: https://github.com/open-telemetry/opentelemetry-dotnet/issues/5973

The o11y plugin will work as is, but will generate a warning without this change, and would require binding redirects when working with classic ASP.