### PR TITLE
fix: Add usage tracking to config method

### DIFF
--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -47,6 +47,7 @@ public sealed class LdAiClient : ILdAiClient
     public ILdAiConfigTracker Config(string key, Context context, LdAiConfig defaultValue,
         IReadOnlyDictionary<string, object> variables = null)
     {
+        _client.Track("$ld:ai:config:function:single", context, LdValue.Of(key), 1);
 
         var result = _client.JsonVariation(key, context, defaultValue.ToLdValue());
 


### PR DESCRIPTION
Tracking internally in SDK-1414.

## Add usage tracking to config method

This PR implements SDK spec requirement 1.2.3.5 by adding usage tracking to the `config` method across all AI SDK repositories, following the pattern established in [JS Core PR #904](https://github.com/launchdarkly/js-core/pull/904).

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions ⚠️ *See testing notes below*

**Related issues**

- Implements [SDK spec requirement 1.2.3.5](https://github.com/launchdarkly/sdk-specs/tree/main/specs/AITRACK-ai-tracking-%26-performance#requirement-1235)
- Follows pattern from [JS Core PR #904](https://github.com/launchdarkly/js-core/pull/904)

**Describe the solution you've provided**

Added a single tracking call `track('$ld:ai:config:function:single', context, key, 1)` at the beginning of each `config` method across all 4 AI SDK repositories:

- **Ruby**: `@ld_client.track('$ld:ai:config:function:single', context, config_key, 1)`
- **Python**: `self._client.track('$ld:ai:config:function:single', context, key, 1)`
- **Go**: `c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))`
- **.NET**: `_client.Track("$ld:ai:config:function:single", context, LdValue.Of(key), 1)`


Each implementation includes a corresponding unit test to verify the tracking call is made with the correct parameters.

**Critical Review Points**

⚠️ **Testing Limitations**: Due to local environment setup constraints, I was unable to run the full test suites locally. The tests were written based on existing patterns but should be verified to pass in the proper CI environment.

🔍 **Key Items to Review**:
1. **Tracking method signatures**: Each SDK uses different tracking APIs - verify parameter order and types are correct
2. **Event consistency**: Confirm the event name `$ld:ai:config:function:single` is exactly as specified
3. **Method placement**: Tracking call is added at the beginning of each config method - verify this is the intended location
4. **Test validity**: Run tests to ensure they pass and properly verify the tracking functionality

**Describe alternatives you've considered**

- Considered placing tracking calls after input validation, but chose to place them at method entry to ensure all invocations are tracked
- Each SDK's tracking implementation follows its existing patterns rather than trying to standardize the approach

**Additional context**

- Work requested by @jsonbailey in Slack #team-sdks
- Link to Devin session: https://app.devin.ai/sessions/3340d364f83144e0aa1afb9a43870b09
- This change maintains backward compatibility - only adds tracking, no functional changes to config method behavior
- All 4 PRs use identical branch names and commit messages for consistency across repositories

**Cross-SDK Implementation Details**

| SDK | Tracking Method | Parameter Order |
|-----|----------------|----------------|
| Ruby | `track(event, context, key, value)` | Standard LaunchDarkly pattern |
| Python | `track(event, context, key, value)` | Standard LaunchDarkly pattern |
| Go | `TrackMetric(event, context, value, data)` | Go-specific metric tracking |
| .NET | `Track(event, context, data, value)` | .NET-specific parameter order |

**Human Review Checklist**

Please verify the following during review:

- [ ] **Parameter ordering**: Confirm tracking method parameters are in correct order for each SDK
- [ ] **Event name accuracy**: Verify `$ld:ai:config:function:single` matches SDK spec requirement exactly
- [ ] **Test execution**: Run test suites to ensure all new tests pass (especially given CI environment differences)
- [ ] **Integration testing**: Verify tracking doesn't interfere with existing config method functionality
- [ ] **Cross-platform compatibility**: Test against all supported platform versions for each SDK
- [ ] **Mock accuracy**: Ensure test mocks accurately represent real SDK tracking behavior