### PR TITLE
fix: Handling exceptions that occur during string.Format in the iOS ChannelImpl Logs

### DIFF
--- a/pkgs/sdk/client/src/PlatformSpecific/Logging.ios.cs
+++ b/pkgs/sdk/client/src/PlatformSpecific/Logging.ios.cs
@@ -70,14 +70,45 @@ namespace LaunchDarkly.Sdk.Client.PlatformSpecific
                 public void Log(LogLevel level, object message) =>
                     LogString(level, message.ToString());
 
-                public void Log(LogLevel level, string format, object param) =>
-                    LogString(level, string.Format(format, param));
+                public void Log(LogLevel level, string format, object param)
+                {
+                    try
+                    {
+                        LogString(level, string.Format(format, param));
+                    }
+                    catch (FormatException)
+                    {
+                        // Fallback: log the format string and parameters separately if formatting fails
+                        LogString(level, $"[Format Error] {format} | Param: {param}");
+                    }
+                }
 
-                public void Log(LogLevel level, string format, object param1, object param2) =>
-                    LogString(level, string.Format(format, param1, param2));
+                public void Log(LogLevel level, string format, object param1, object param2)
+                {
+                    try
+                    {
+                        LogString(level, string.Format(format, param1, param2));
+                    }
+                    catch (FormatException)
+                    {
+                        // Fallback: log the format string and parameters separately if formatting fails
+                        LogString(level, $"[Format Error] {format} | Param1: {param1} | Param2: {param2}");
+                    }
+                }
 
-                public void Log(LogLevel level, string format, params object[] allParams) =>
-                    LogString(level, string.Format(format, allParams));
+                public void Log(LogLevel level, string format, params object[] allParams)
+                {
+                    try
+                    {
+                        LogString(level, string.Format(format, allParams));
+                    }
+                    catch (FormatException)
+                    {
+                        // Fallback: log the format string and parameters separately if formatting fails
+                        var paramsStr = allParams != null ? string.Join(", ", allParams) : "null";
+                        LogString(level, $"[Format Error] {format} | Params: {paramsStr}");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
We have multiple MAUI and .Net for iOS/Android based apps using the LaunchDarkly SDK, and have ran into thousands of crashes from this SDK due to a string.Format exception occurring in the Log methods of ChannelImpl on iOS.

We don't log anything to LaunchDarkly, so it seems logical that it's something internal that LaunchDarkly is logging.

This is a simple fix that prevents the crash on our apps, while providing LaunchDarkly with information relevant to fix the underlying format issue (if it's internal).

It's a non-breaking change.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

[Issue 89](https://github.com/launchdarkly/dotnet-core/issues/89)

**Describe the solution you've provided**

In the case where string.Format would throw an exception, it'll gracefully fall back to a log event showing the provided format and params for further diagnosis.

**Describe alternatives you've considered**

I cannot find any alternatives without understanding what log event is causing the exception internally in the SDK.

**Additional context**

<img width="946" height="475" alt="image" src="https://github.com/user-attachments/assets/3f447c8b-5795-4595-a8ee-4d6c59407658" />

We only see this issue on iOS, it does not happen on Android.
