### PR TITLE
feat: Make common sdk AOT safe

### DIFF
--- a/pkgs/shared/common/src/Context.cs
+++ b/pkgs/shared/common/src/Context.cs
@@ -922,7 +922,11 @@ namespace LaunchDarkly.Sdk
             {
                 return "(invalid Context: " + Error + ")";
             }
+#if NET7_0_OR_GREATER
+            return System.Text.Json.JsonSerializer.Serialize(this, LdJsonSerializerContext.Default.Context);
+#else
             return LdJsonSerialization.SerializeObject(this);
+#endif
         }
 
         private LdValue GetTopLevelAddressableAttributeSingleKind(string name)

--- a/pkgs/shared/common/src/Json/LdJsonConverters.cs
+++ b/pkgs/shared/common/src/Json/LdJsonConverters.cs
@@ -196,7 +196,13 @@ namespace LaunchDarkly.Sdk.Json
 
             internal static BigSegmentsStatus FromIdentifier(string value)
             {
-                foreach (BigSegmentsStatus k in Enum.GetValues(typeof(BigSegmentsStatus)))
+                foreach (BigSegmentsStatus k in
+#if NET5_0_OR_GREATER
+                    Enum.GetValues<BigSegmentsStatus>()
+#else
+                    Enum.GetValues(typeof(BigSegmentsStatus))
+#endif
+                )
                 {
                     if (ToIdentifier(k) == value)
                     {
@@ -243,7 +249,13 @@ namespace LaunchDarkly.Sdk.Json
 
             internal static EvaluationErrorKind FromIdentifier(string value)
             {
-                foreach (EvaluationErrorKind k in Enum.GetValues(typeof(EvaluationErrorKind)))
+                foreach (EvaluationErrorKind k in
+#if NET5_0_OR_GREATER
+                    Enum.GetValues<EvaluationErrorKind>()
+#else
+                    Enum.GetValues(typeof(EvaluationErrorKind))
+#endif
+                )
                 {
                     if (ToIdentifier(k) == value)
                     {
@@ -294,7 +306,13 @@ namespace LaunchDarkly.Sdk.Json
 
             internal static EvaluationReasonKind FromIdentifier(string value)
             {
-                foreach (EvaluationReasonKind k in Enum.GetValues(typeof(EvaluationErrorKind)))
+                foreach (EvaluationReasonKind k in
+#if NET5_0_OR_GREATER
+                    Enum.GetValues<EvaluationReasonKind>()
+#else
+                    Enum.GetValues(typeof(EvaluationErrorKind))
+#endif
+                )
                 {
                     if (ToIdentifier(k) == value)
                     {

--- a/pkgs/shared/common/src/Json/LdJsonConverters.cs
+++ b/pkgs/shared/common/src/Json/LdJsonConverters.cs
@@ -310,7 +310,7 @@ namespace LaunchDarkly.Sdk.Json
 #if NET5_0_OR_GREATER
                     Enum.GetValues<EvaluationReasonKind>()
 #else
-                    Enum.GetValues(typeof(EvaluationErrorKind))
+                    Enum.GetValues(typeof(EvaluationReasonKind))
 #endif
                 )
                 {

--- a/pkgs/shared/common/src/Json/LdJsonSerialization.cs
+++ b/pkgs/shared/common/src/Json/LdJsonSerialization.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Text.Json;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace LaunchDarkly.Sdk.Json
 {
@@ -12,6 +15,10 @@ namespace LaunchDarkly.Sdk.Json
     /// </remarks>
     public static class LdJsonSerialization
     {
+#if NET7_0_OR_GREATER
+        internal const string SerializationUnreferencedCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.";
+        internal const string SerializationRequiresDynamicCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.";
+#endif  
         /// <summary>
         /// Converts an object to its JSON representation.
         /// </summary>
@@ -23,6 +30,10 @@ namespace LaunchDarkly.Sdk.Json
         /// <typeparam name="T">type of the object being serialized</typeparam>
         /// <param name="instance">the instance to serialize</param>
         /// <returns>the object's JSON encoding as a string</returns>
+#if NET7_0_OR_GREATER
+        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
+#endif
         public static string SerializeObject<T>(T instance) where T : IJsonSerializable =>
             JsonSerializer.Serialize(instance);
 
@@ -37,6 +48,10 @@ namespace LaunchDarkly.Sdk.Json
         /// <typeparam name="T">type of the object being serialized</typeparam>
         /// <param name="instance">the instance to serialize</param>
         /// <returns>the object's JSON encoding as a byte array</returns>
+#if NET7_0_OR_GREATER
+        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
+#endif
         public static byte[] SerializeObjectToUtf8Bytes<T>(T instance) where T : IJsonSerializable =>
             JsonSerializer.SerializeToUtf8Bytes(instance);
 
@@ -52,6 +67,10 @@ namespace LaunchDarkly.Sdk.Json
         /// <param name="json">the object's JSON encoding as a string</param>
         /// <returns>the deserialized instance</returns>
         /// <exception cref="JsonException">if the JSON encoding was invalid</exception>
+#if NET7_0_OR_GREATER
+        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
+#endif
         public static T DeserializeObject<T>(string json) where T : IJsonSerializable =>
             JsonSerializer.Deserialize<T>(json);
     }

--- a/pkgs/shared/common/src/Json/LdJsonSerializerContext.cs
+++ b/pkgs/shared/common/src/Json/LdJsonSerializerContext.cs
@@ -1,0 +1,13 @@
+#if NET7_0_OR_GREATER
+using System.Text.Json.Serialization;
+
+namespace LaunchDarkly.Sdk.Json
+{
+    [JsonSerializable(typeof(LdValue))]
+    [JsonSerializable(typeof(Context))]
+    internal partial class LdJsonSerializerContext : JsonSerializerContext
+    {
+        
+    }
+}
+#endif

--- a/pkgs/shared/common/src/LaunchDarkly.CommonSdk.csproj
+++ b/pkgs/shared/common/src/LaunchDarkly.CommonSdk.csproj
@@ -13,6 +13,8 @@
     <AssemblyName>LaunchDarkly.CommonSdk</AssemblyName>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
+    <!-- the system.text.json source generator require version 9.0 or greater -->
+    <LangVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">9.0</LangVersion>
     <PackageId>LaunchDarkly.CommonSdk</PackageId>
     <Description>LaunchDarkly common code for .NET and Xamarin clients</Description>
     <Company>LaunchDarkly</Company>
@@ -34,6 +36,7 @@
 
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.CommonSdk.xml</DocumentationFile>
     <RootNamespace>LaunchDarkly.Sdk</RootNamespace>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkgs/shared/common/src/LdValue.cs
+++ b/pkgs/shared/common/src/LdValue.cs
@@ -282,8 +282,11 @@ namespace LaunchDarkly.Sdk
         /// <exception cref="JsonException">if the string could not be parsed as JSON</exception>
         /// <see cref="ToJsonString"/>
         public static LdValue Parse(string jsonString) =>
+#if NET7_0_OR_GREATER
+            JsonSerializer.Deserialize(jsonString, LdJsonSerializerContext.Default.LdValue);
+#else
             LdJsonSerialization.DeserializeObject<LdValue>(jsonString);
-
+#endif
         #endregion
 
         #region Public properties
@@ -550,7 +553,11 @@ namespace LaunchDarkly.Sdk
                 case LdValueType.Bool:
                     return _boolValue ? "true" : "false";
                 default:
+#if NET7_0_OR_GREATER
+                    return JsonSerializer.Serialize(this, LdJsonSerializerContext.Default.LdValue);
+#else
                     return JsonSerializer.Serialize(this);
+#endif
             }
         }
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of #90 
Prerequisite for launchdarkly/dotnet-sdk-internal#49

**Describe the solution you've provided**

I made all targets of the common SDK trim safe using the built in system text json source generators. 

**Describe alternatives you've considered**

The already written converters could be called directly in the places where `LdValue` and `Context` need to be serialized.

**Additional context**

I do have a test console app that can be published with AOT and then ran to make sure that these items can be serialized properly but wasn't totally sure where I should put it. If that is desired I can add it, just need to know where to put it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSON serialization paths for `LdValue` and `Context` and introduces framework-conditional behavior; mistakes could change emitted JSON or break deserialization under specific target frameworks/AOT settings.
> 
> **Overview**
> Improves trim/native-AOT compatibility by switching `LdValue` and `Context` serialization/deserialization to use `System.Text.Json` source generation on `NET7_0_OR_GREATER` via a new `LdJsonSerializerContext`.
> 
> Adds AOT/trimming warning annotations to `LdJsonSerialization` APIs on .NET 7+, updates enum conversion helpers to use generic `Enum.GetValues<T>()` when available, and adjusts the CommonSdk project settings to enable AOT compatibility and set `LangVersion` 9.0 for net7+ builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bfc51148d7c4bdc8a7f9c62c2ee749f46becbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->