### PR TITLE
fix: Prevent using incompatible AWS version

### DIFF
--- a/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.3.15.2,]" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="[3.3.15.2,4.0.0.0)" />
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.0.0,9.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Constrain `AWSSDK.DynamoDBv2` dependency to `<4.0.0` by adding an upper version bound in `LaunchDarkly.ServerSdk.DynamoDB.csproj`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 164d23860e55b9c2a65f8462d391bda385c07c54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->