### PR TITLE
chore: Simulate initialization delay to reduce flaky test

### DIFF
--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientDataSourceStatusTests.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientDataSourceStatusTests.cs
@@ -150,7 +150,7 @@ namespace LaunchDarkly.Sdk.Client
         [Fact]
         public void DataSourceStatusIsRestoredWhenNoLongerSetOffline()
         {
-            var testData = TestData.DataSource();
+            var testData = TestData.DataSource().WithInitializationDelay(TimeSpan.FromMilliseconds(100));
             var config = BasicConfig().DataSource(testData).Offline(true).Build();
 
             using (var client = TestUtil.CreateClient(config, BasicUser))
@@ -187,7 +187,7 @@ namespace LaunchDarkly.Sdk.Client
         [Fact]
         public void DataSourceStatusIsRestoredWhenNetworkIsAvailableAgain()
         {
-            var testData = TestData.DataSource();
+            var testData = TestData.DataSource().WithInitializationDelay(TimeSpan.FromMilliseconds(100));
             var connectivity = new MockConnectivityStateManager(false);
             var config = BasicConfig()
                 .DataSource(testData)
@@ -247,7 +247,7 @@ namespace LaunchDarkly.Sdk.Client
         [Fact]
         public void BackgroundDisabledState()
         {
-            var testData = TestData.DataSource();
+            var testData = TestData.DataSource().WithInitializationDelay(TimeSpan.FromMilliseconds(100));
             var backgrounder = new MockBackgroundModeManager();
             var config = BasicConfig()
                 .BackgroundModeManager(backgrounder)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional initialization delay to TestData and update status tests to observe Initializing before Valid.
> 
> - **Test data source (`TestData`)**:
>   - Add `WithInitializationDelay(TimeSpan)` to configure artificial init delay.
>   - Pass delay into `DataSourceImpl`; make `Start` async and `await` delay before `_updateSink.Init`.
> - **Tests**:
>   - Use `WithInitializationDelay(TimeSpan.FromMilliseconds(100))` in status transition tests (`LdClientDataSourceStatusTests`) to ensure `Initializing` is observed before `Valid` in offline/network/background scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf8dd4ea7233657c2abae0553c1bf30f81ad367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->