### PR TITLE
fix: Ensure PlatformScheduleAction order is preserved

### DIFF
--- a/pkgs/sdk/client/src/PlatformSpecific/AsyncScheduler.netstandard.cs
+++ b/pkgs/sdk/client/src/PlatformSpecific/AsyncScheduler.netstandard.cs
@@ -11,7 +11,7 @@ namespace LaunchDarkly.Sdk.Client.PlatformSpecific
         {
             // Chain the new action to run after the previous one completes
             // This ensures actions run in order while maintaining fire-and-forget behavior
-            _lastScheduledTask = _lastScheduledTask.ContinueWith(_ => a(), TaskContinuationOptions.ExecuteSynchronously);
+            _lastScheduledTask = _lastScheduledTask.ContinueWith(_ => a());
         }
     }
 }


### PR DESCRIPTION
In Android/iOS these action are run on the main thread whereas in netstandard they are run in a thread pool and are not guaranteed to be run in order when we don't wait for the result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure scheduled actions run in order on netstandard by chaining them via a shared Task instead of using Task.Run.
> 
> - **Async scheduling (netstandard)** in `pkgs/sdk/client/src/PlatformSpecific/AsyncScheduler.netstandard.cs`:
>   - Introduce `private static volatile Task _lastScheduledTask = Task.CompletedTask`.
>   - Replace `Task.Run(a)` with chaining: `_lastScheduledTask = _lastScheduledTask.ContinueWith(_ => a());` to enforce ordered, fire-and-forget execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0169d4152f27c01a856fb6f8dedd68e1f7a69bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->