### PR TITLE
chore: Prevent race condition in DynamoDB Tests

### DIFF
--- a/pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBBigSegmentStoreTest.cs
+++ b/pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBBigSegmentStoreTest.cs
@@ -11,6 +11,7 @@ using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
+    [Collection("DynamoDB Tests")]
     public class DynamoDBBigSegmentStoreTest : BigSegmentStoreBaseTests, IAsyncLifetime
     {
         override protected BigSegmentStoreTestConfig Configuration => new BigSegmentStoreTestConfig

--- a/pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBDataStoreTest.cs
+++ b/pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBDataStoreTest.cs
@@ -13,6 +13,7 @@ using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
+    [Collection("DynamoDB Tests")]
     public class DynamoDBDataStoreTest : PersistentDataStoreBaseTests, IAsyncLifetime
     {
         const string BadItemKey = "baditem";


### PR DESCRIPTION
DynamoDB tests share a database / table and reset it for each test. XUnit tests can run in parallel causing one test to reset the table in the middle of another test executing and triggering a failure. This can be observed by adding a delay after a write and before a read.

Collections will ensure the specific tests are not run in parallel. I tested using a unique prefix for each test but still observed the error. Ideally these should be able to run in parallel but this is a compromise of invested time to fix it vs more stable tests now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Annotates DynamoDB test classes with a shared xUnit collection to prevent parallel execution.
> 
> - **Tests**:
>   - Annotate `pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBBigSegmentStoreTest.cs` and `pkgs/dotnet-server-sdk-dynamodb/test/DynamoDBDataStoreTest.cs` with `[Collection("DynamoDB Tests")]` to run these tests in a shared, non-parallel collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f11700b913075d39755188a1f1c5be5494af79e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->