### PR TITLE
fix: Use thread-safe hash for big segments hashing.

### DIFF
--- a/pkgs/sdk/server/src/Internal/BigSegments/BigSegmentsInternalTypes.cs
+++ b/pkgs/sdk/server/src/Internal/BigSegments/BigSegmentsInternalTypes.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
 using System.Text;
 using LaunchDarkly.Sdk.Server.Internal.Model;
 
@@ -9,11 +8,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.BigSegments
 {
     internal static class BigSegmentsInternalTypes
     {
-        private static readonly SHA256 _hasher = SHA256.Create();
-
         internal static string BigSegmentContextKeyHash(string userKey) =>
             Convert.ToBase64String(
-                _hasher.ComputeHash(Encoding.UTF8.GetBytes(userKey))
+                LdSha256.HashData(Encoding.UTF8.GetBytes(userKey))
                 );
 
         internal static string MakeBigSegmentRef(Segment s) =>

--- a/pkgs/sdk/server/src/Internal/LDSha256.cs
+++ b/pkgs/sdk/server/src/Internal/LDSha256.cs
@@ -1,0 +1,38 @@
+using System.Security.Cryptography;
+
+namespace LaunchDarkly.Sdk.Server.Internal
+{
+    // Hasher which uses HashData on .NET 5.0+ platforms and ComputeHash on older platforms.
+    // HashData is static and thread-safe offering better performance when available.
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Thread-safe hasher using SHA256.HashData for .NET 5.0+ platforms.
+    /// </summary>
+    internal static class LdSha256
+    {
+        public static byte[] HashData(byte[] data) {
+            return SHA256.HashData(data);
+        }
+    }
+#else
+    /// <summary>
+    /// Thread-safe hasher using SHA256.ComputeHash for .NET Framework and .netstandard targets.
+    /// </summary>
+    /// <remarks>
+    /// This hasher creates a SHA256 instance per-call. This is likely to perform better under high parallelism
+    /// than locking. With low parallelism, locking would have lower overhead and exert lower pressure on the GC.
+    /// The pre-existing evaluation algorithm was already using per-call SHA1 instances, so this should have
+    /// reasonable performance characteristics.
+    /// </remarks>
+    internal static class LdSha256
+    {
+        public static byte[] HashData(byte[] data)
+        {
+            using (var hasher = SHA256.Create())
+            {
+                return hasher.ComputeHash(data);
+            }
+        }
+    }
+#endif
+}


### PR DESCRIPTION
SHA256 instances are not thread-safe and under heavy-parallelism will fail.
Newer .Net frameworks have a static method which is higher performance under heavy-parallelism and inherently thread-safe.

This PR introduces a thin abstraction that uses the correct method in a thread-safe way depending on the framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces a shared SHA256 instance with a thread-safe `LdSha256` utility and updates Big Segments hashing to use it.
> 
> - **Internal hashing**:
>   - Add `LdSha256` utility that uses `SHA256.HashData` on .NET 5+ and per-call `ComputeHash` on older targets.
>   - Update `BigSegmentsInternalTypes.BigSegmentContextKeyHash` to use `LdSha256.HashData` instead of a shared `SHA256` instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ab7a03d0c833c43e4bb34c6663145e012b3807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->