### PR TITLE
chore: Add per-test hang timeout.

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
       run: |
         dotnet restore ${{ inputs.test_project_file }}
-        dotnet test -v=${{ inputs.test_verbosity }} --framework=${{ inputs.target_test_framework }} ${{ inputs.test_project_file }}
+        dotnet test --blame-hang-timeout=60s -v=${{ inputs.test_verbosity }} --framework=${{ inputs.target_test_framework }} ${{ inputs.test_project_file }}
 
     - name: Remove global.json
       shell: bash


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a 60s per-test hang timeout to the `dotnet test` step in `.github/actions/ci/action.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33dc6c54f6ee934a177dfbf01540687ab5de19ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->