### PR TITLE
test: Wait start task for SuccessfulRequestCausesDataToBeStoredAndDataSourceInitialized.

### DIFF
--- a/pkgs/sdk/server/test/Internal/DataSources/PollingDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/PollingDataSourceTest.cs
@@ -66,7 +66,8 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                     var receivedData = _updateSink.Inits.ExpectValue();
                     AssertHelpers.DataSetsEqual(AllData, receivedData);
-
+                    
+                    initTask.Wait(TimeSpan.FromSeconds(1));
                     Assert.True(dataSource.Initialized);
 
                     Assert.True(initTask.IsCompleted);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Waits for the `Start()` task to complete (with timeout) before asserting `Initialized` in `SuccessfulRequestCausesDataToBeStoredAndDataSourceInitialized`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cbc0a065e9eae5c3f93f89e4005fd9c640ac217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->