### PR TITLE
chore: init tracker gets updates synchronously before action appliers

### DIFF
--- a/pkgs/sdk/server/src/Internal/FDv2DataSources/FDv2DataSource.cs
+++ b/pkgs/sdk/server/src/Internal/FDv2DataSources/FDv2DataSource.cs
@@ -67,7 +67,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.FDv2DataSources
                         return new CompositeSource(sink, initializerFactory, circular: false);
                     },
                     (actionable) => new CompositeObserver(
-                        blacklistWhenSuccessOrOff(actionable), initializationObserver)
+                        initializationObserver, blacklistWhenSuccessOrOff(actionable))
                 ));
             }
 
@@ -93,8 +93,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.FDv2DataSources
                         // Only attach FDv1 fallback applier if FDv1 synchronizers are actually provided
                         if (fdv1Synchronizers != null && fdv1Synchronizers.Count > 0)
                         {
-                            return new CompositeObserver(fdv1FallbackApplierFactory(actionable),
-                                synchronizationObserver);
+                            return new CompositeObserver(synchronizationObserver, fdv1FallbackApplierFactory(actionable));
                         }
 
                         return synchronizationObserver;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorders CompositeObserver wiring so InitializationObserver processes updates before action appliers, and adds a test covering initializer→synchronizer flow.
> 
> - **FDv2 data source wiring**:
>   - Reorder `CompositeObserver` arguments to place `InitializationObserver` before action appliers in both initializers and synchronizers (`FDv2DataSource.cs`).
> - **Tests**:
>   - Add `OneInitializerOneSynchronizerIsWellBehaved` validating status sequence and apply calls when transitioning from initializer to synchronizer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ffeae940c237fd26cc214b735f094fb190315dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->