### PR TITLE
chore: Ensure the FDv2 data system honors the offline configuration.

### DIFF
--- a/pkgs/sdk/server/src/Internal/DataSystem/FDv2DataSystem.cs
+++ b/pkgs/sdk/server/src/Internal/DataSystem/FDv2DataSystem.cs
@@ -69,10 +69,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSystem
             var dataSourceUpdates = new DataSourceUpdatesImpl(writeThroughStore, dataStoreStatusProvider,
                 clientContext.TaskExecutor, logger, logConfig.LogDataSourceOutageAsErrorAfter);
 
-
             var contextWithSelectorSource =
                 clientContext.WithSelectorSource(new SelectorSourceFacade(writeThroughStore));
-            var compositeDataSource = FDv2DataSource.CreateFDv2DataSource(
+            var compositeDataSource = configuration.Offline ? Components.ExternalUpdatesOnly.Build(contextWithSelectorSource) : FDv2DataSource.CreateFDv2DataSource(
                 dataSourceUpdates,
                 dataSystemConfiguration.Initializers.Select(FactoryWithContext(contextWithSelectorSource)).ToList(),
                 dataSystemConfiguration.Synchronizers.Select(FactoryWithContext(contextWithSelectorSource)).ToList(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures FDv2 respects offline mode by switching data source construction based on `configuration.Offline`.
> 
> - In `FDv2DataSystem.Create`, when `configuration.Offline` is true, builds `Components.ExternalUpdatesOnly` with `contextWithSelectorSource`; otherwise constructs the standard FDv2 composite data source via `FDv2DataSource.CreateFDv2DataSource`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0319dfe3fd8825515edf0d946d487b94aa933895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->