### PR TITLE
fix: Retry after partial file reads.

### DIFF
--- a/pkgs/sdk/server/src/Integrations/FileDataSourceBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/FileDataSourceBuilder.cs
@@ -111,7 +111,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         /// Whenever possible, you should update a file's entire contents in one atomic operation; in Unix-like OSes,
         /// that can be done by creating a temporary file, writing to it, and then renaming it to replace the original
         /// file. In Windows, that is not always possible, so FileDataSource might detect an update before the file has
-        /// been fully written; in that case it will retry until it succeeds.
+        /// been fully written; in that case it will retry several times until the file can be parsed, giving up after
+        /// repeated failures until another change to the file is detected.
         /// </para>
         /// <para>
         /// Note that auto-updating may not work if any of the files you specified has an invalid directory path.

--- a/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
@@ -25,11 +25,13 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         private readonly Logger _logger;
         private volatile bool _started;
         private volatile bool _loadedValidData;
+        private volatile bool _disposed;
         private volatile int _lastVersion;
         private object _updateLock = new object();
 
         private const int MaxRetries = 5;
-        private readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(0.6);
+        private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(600);
+        // Per-path JSON-parse retry counters. Only touched inside _updateLock.
         private readonly Dictionary<string, int> _retryCounts = new Dictionary<string, int>();
 
         public FileDataSource(IDataSourceUpdates dataSourceUpdates, FileDataTypes.IFileReader fileReader,
@@ -87,6 +89,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         {
             if (disposing)
             {
+                _disposed = true;
                 _reloader?.Dispose();
             }
         }
@@ -95,6 +98,10 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         {
             lock (_updateLock)
             {
+                if (_disposed)
+                {
+                    return;
+                }
                 var version = Interlocked.Increment(ref _lastVersion);
                 var flags = new Dictionary<string, ItemDescriptor>();
                 var segments = new Dictionary<string, ItemDescriptor>();
@@ -106,7 +113,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                         _logger.Debug("file data: {0}", content);
                         var data = _parser.Parse(content, version);
                         _dataMerger.AddToData(data, flags, segments);
-                        // Remove any retry count associated with this path.
                         _retryCounts.Remove(path);
                     }
                     catch (FileNotFoundException) when (_skipMissingPaths)
@@ -115,10 +121,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     }
                     catch (System.Text.Json.JsonException)
                     {
-                        // We may have received the notification of a file change while the file was being written.
-                        // So we may read an empty or partially written file. So, when we encounter a JSON parsing issue
-                        // we will retry after a short delay.
-                        // We will retry up to MaxRetries times before giving up.
+                        // A file-change notification can fire while the file is mid-write, so we may read an
+                        // empty or partially written file. Retry up to MaxRetries times before giving up; the
+                        // counter is cleared on the next successful load.
                         if (!_retryCounts.ContainsKey(path))
                         {
                             _retryCounts[path] = 0;
@@ -127,16 +132,20 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                         if (_retryCounts[path] < MaxRetries)
                         {
-                            _logger.Warn("{0}: {1}", path, "Failed to parse file, retrying in " + RetryDelay.TotalMilliseconds + " milliseconds");
+                            _logger.Warn("{0}: Failed to parse file, retrying in {1} ms", path, RetryDelay.TotalMilliseconds);
                             Task.Run(async () =>
                             {
-                                await Task.Delay(RetryDelay);
+                                await Task.Delay(RetryDelay).ConfigureAwait(false);
+                                if (_disposed)
+                                {
+                                    return;
+                                }
                                 LoadAll();
                             });
                         }
                         else
                         {
-                            _logger.Error("{0}: {1}", path, "Failed to parse file after " + MaxRetries + " retries");
+                            _logger.Error("{0}: Failed to parse file after {1} retries", path, MaxRetries);
                         }
 
                         return;
@@ -147,10 +156,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                         return;
                     }
                 }
-                
-                // If any files failed to load, from anything other than not existing, then that
-                // update would fail. This behavior is retained with the addition of the retry. But it should be
-                // examined.
 
                 var allData = new FullDataSet<ItemDescriptor>(
                     ImmutableDictionary.Create<DataKind, KeyedItems<ItemDescriptor>>()

--- a/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
@@ -32,8 +32,8 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
         private const int MaxParseAttempts = 5;
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(600);
-        // Consecutive parse failures per path within the current failure episode. A failure seen on
-        // an externally triggered load (Start or a file-change notification) starts a new episode,
+        // Consecutive parse failures per path within the current failure episode. An externally
+        // triggered load (Start or a file-change notification) starts a new episode and clears this,
         // so the retry budget is per-episode, not per-lifetime. Only touched inside _updateLock.
         private readonly Dictionary<string, int> _parseFailureCounts = new Dictionary<string, int>();
         // Whether a delayed retry is already scheduled; at most one retry chain exists at a time,
@@ -109,6 +109,13 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 {
                     return;
                 }
+                if (!isRetry)
+                {
+                    // An externally triggered load starts a new failure episode: parse failures
+                    // observed from here on get a fresh retry budget, and any state left over
+                    // from a previous episode is discarded.
+                    _parseFailureCounts.Clear();
+                }
                 var version = Interlocked.Increment(ref _lastVersion);
                 var flags = new Dictionary<string, ItemDescriptor>();
                 var segments = new Dictionary<string, ItemDescriptor>();
@@ -129,11 +136,11 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                             // failure may just mean we read an empty or partially written file. This applies
                             // to any configured parser (JSON or alternate), so we treat every failure of
                             // Parse — as opposed to reading the file — as potentially transient.
-                            HandleParseFailure(path, e, isRetry);
+                            HandleParseFailure(path, e);
                             return;
                         }
-                        _dataMerger.AddToData(data, flags, segments);
                         _parseFailureCounts.Remove(path);
+                        _dataMerger.AddToData(data, flags, segments);
                     }
                     catch (FileNotFoundException) when (_skipMissingPaths)
                     {
@@ -156,8 +163,10 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
         }
 
-        // Called under _updateLock when parsing a path's content fails.
-        private void HandleParseFailure(string path, Exception e, bool isRetry)
+        // Called under _updateLock when parsing a path's content fails. Since an externally
+        // triggered load clears _parseFailureCounts before reading, any existing count for the
+        // path belongs to the current episode.
+        private void HandleParseFailure(string path, Exception e)
         {
             if (!_autoUpdate)
             {
@@ -167,24 +176,32 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 return;
             }
 
-            var attempts = 1;
-            if (isRetry && _parseFailureCounts.TryGetValue(path, out var previousAttempts))
-            {
-                attempts = previousAttempts + 1;
-            }
+            var attempts = _parseFailureCounts.TryGetValue(path, out var previousAttempts)
+                ? previousAttempts + 1
+                : 1;
 
             if (attempts < MaxParseAttempts)
             {
                 _parseFailureCounts[path] = attempts;
-                _logger.Warn("{0}: failed to parse file ({1}); will retry in {2} ms in case it was incompletely written",
+                _logger.Warn("{0}: Failed to parse file ({1}); will retry in {2} ms in case it was incompletely written",
                     path, LogValues.ExceptionSummary(e), RetryDelay.TotalMilliseconds);
+                _logger.Debug("{0}", LogValues.ExceptionTrace(e));
                 ScheduleRetry();
             }
             else
             {
+                // This path kept failing, so the retry chain ends until the next external trigger.
+                // Every attempt stopped at this path, so any other paths with recorded failures
+                // were never re-attempted; their episodes end here too.
                 _parseFailureCounts.Remove(path);
+                foreach (var abandoned in _parseFailureCounts.Keys)
+                {
+                    _logger.Error("{0}: Will not be retried because {1} repeatedly failed to parse; both will be re-read on the next detected file change",
+                        abandoned, path);
+                }
+                _parseFailureCounts.Clear();
                 LogHelpers.LogException(_logger,
-                    string.Format("{0}: failed to parse file after {1} attempts", path, MaxParseAttempts), e);
+                    string.Format("{0}: Failed to parse file after {1} attempts", path, MaxParseAttempts), e);
             }
         }
 
@@ -218,9 +235,10 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 _retryPending = false;
                 if (_disposed || _parseFailureCounts.Count == 0)
                 {
-                    // Disposed, or an externally triggered load already succeeded in the meantime
-                    // (success clears the failure counts) — a reload would be redundant and would
-                    // re-Init identical data at bumped versions, firing spurious change events.
+                    // Disposed, or the failure state was cleared in the meantime (an externally
+                    // triggered load succeeded, or the chain gave up) — a reload would be redundant
+                    // and would re-Init identical data at bumped versions, firing spurious change
+                    // events.
                     return;
                 }
                 LoadAll(isRetry: true);

--- a/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
@@ -30,16 +30,30 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         private volatile int _lastVersion;
         private object _updateLock = new object();
 
-        private const int MaxParseAttempts = 5;
+        private const int MaxLoadAttempts = 5;
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(600);
-        // Consecutive parse failures per path within the current failure episode. An externally
-        // triggered load (Start or a file-change notification) starts a new episode and clears this,
-        // so the retry budget is per-episode, not per-lifetime. Only touched inside _updateLock.
-        private readonly Dictionary<string, int> _parseFailureCounts = new Dictionary<string, int>();
+        // Consecutive load failures (parse or read) per path within the current failure episode.
+        // An externally triggered load (Start or a file-change notification) starts a new episode
+        // and clears this, so the retry budget is per-episode, not per-lifetime. Only touched
+        // inside _updateLock.
+        private readonly Dictionary<string, int> _loadFailureCounts = new Dictionary<string, int>();
         // Whether a delayed retry is already scheduled; at most one retry chain exists at a time,
         // since each retry re-reads every path anyway. Only touched inside _updateLock.
         private bool _retryPending;
 
+        /// <summary>
+        /// Constructs a file data source that loads flag and segment data from local files.
+        /// </summary>
+        /// <param name="dataSourceUpdates">receives the data set produced by each successful load</param>
+        /// <param name="fileReader">reads file contents; injectable for testing</param>
+        /// <param name="paths">the file paths to load, in order</param>
+        /// <param name="autoUpdate">true to watch the files and reload on changes; also enables the
+        /// bounded retry of loads that fail while a file is being written</param>
+        /// <param name="alternateParser">optional parser for non-JSON content (for example YAML);
+        /// null to parse JSON only</param>
+        /// <param name="skipMissingPaths">true to skip missing files instead of failing the load</param>
+        /// <param name="duplicateKeysHandling">how to handle a key that appears in more than one file</param>
+        /// <param name="logger">the destination for log output</param>
         public FileDataSource(IDataSourceUpdates dataSourceUpdates, FileDataTypes.IFileReader fileReader,
             List<string> paths, bool autoUpdate, Func<string, object> alternateParser, bool skipMissingPaths,
             FileDataTypes.DuplicateKeysHandling duplicateKeysHandling,
@@ -111,10 +125,22 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 }
                 if (!isRetry)
                 {
-                    // An externally triggered load starts a new failure episode: parse failures
+                    // An externally triggered load starts a new failure episode: failures
                     // observed from here on get a fresh retry budget, and any state left over
                     // from a previous episode is discarded.
-                    _parseFailureCounts.Clear();
+                    _loadFailureCounts.Clear();
+                }
+                else
+                {
+                    _retryPending = false;
+                    if (_loadFailureCounts.Count == 0)
+                    {
+                        // The failure state was cleared in the meantime (an externally triggered
+                        // load succeeded, or the chain gave up) — a reload would be redundant and
+                        // would re-Init identical data at bumped versions, firing spurious change
+                        // events.
+                        return;
+                    }
                 }
                 var version = Interlocked.Increment(ref _lastVersion);
                 var flags = new Dictionary<string, ItemDescriptor>();
@@ -139,7 +165,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                             HandleParseFailure(path, e);
                             return;
                         }
-                        _parseFailureCounts.Remove(path);
+                        _loadFailureCounts.Remove(path);
                         _dataMerger.AddToData(data, flags, segments);
                     }
                     catch (FileNotFoundException) when (_skipMissingPaths)
@@ -148,15 +174,19 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     }
                     catch (Exception e)
                     {
-                        LogHelpers.LogException(_logger, "Failed to load " + path, e);
                         if (isRetry)
                         {
                             // A transient read error (for example, a writer replacing the file)
                             // must not end a retry episode early: paths that were promised
                             // retries would keep stale data with budget remaining, and another
                             // file-change notification is not guaranteed. Charge the failure to
-                            // the same per-path budget and continue the chain.
-                            HandleRetryLoadFailure(path);
+                            // the same per-path budget and continue the chain; it logs a Warn
+                            // while retrying and an Error only on give-up.
+                            HandleRetryLoadFailure(path, e);
+                        }
+                        else
+                        {
+                            LogHelpers.LogException(_logger, "Failed to load " + path, e);
                         }
                         return;
                     }
@@ -173,7 +203,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         }
 
         // Called under _updateLock when parsing a path's content fails. Since an externally
-        // triggered load clears _parseFailureCounts before reading, any existing count for the
+        // triggered load clears _loadFailureCounts before reading, any existing count for the
         // path belongs to the current episode.
         private void HandleParseFailure(string path, Exception e)
         {
@@ -185,13 +215,12 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 return;
             }
 
-            var attempts = _parseFailureCounts.TryGetValue(path, out var previousAttempts)
-                ? previousAttempts + 1
-                : 1;
+            _loadFailureCounts.TryGetValue(path, out var previousAttempts);
+            var attempts = previousAttempts + 1;
+            _loadFailureCounts[path] = attempts;
 
-            if (attempts < MaxParseAttempts)
+            if (attempts < MaxLoadAttempts)
             {
-                _parseFailureCounts[path] = attempts;
                 _logger.Warn("{0}: Failed to parse file ({1}); will retry in {2} ms in case it was incompletely written",
                     path, LogValues.ExceptionSummary(e), RetryDelay.TotalMilliseconds);
                 _logger.Debug("{0}", LogValues.ExceptionTrace(e));
@@ -201,31 +230,32 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             {
                 EndEpisode(path);
                 LogHelpers.LogException(_logger,
-                    string.Format("{0}: Failed to parse file after {1} attempts", path, MaxParseAttempts), e);
+                    string.Format("{0}: Failed to parse file after {1} attempts", path, MaxLoadAttempts), e);
             }
         }
 
         // Called under _updateLock when a retry attempt fails before parsing (for example, a
-        // transient read error). The caller has already logged the exception; this charges the
-        // failure to the path's per-episode budget and continues or ends the retry chain.
-        private void HandleRetryLoadFailure(string path)
+        // transient read error). Charges the failure to the path's per-episode budget and
+        // continues or ends the retry chain.
+        private void HandleRetryLoadFailure(string path, Exception e)
         {
-            var attempts = _parseFailureCounts.TryGetValue(path, out var previousAttempts)
-                ? previousAttempts + 1
-                : 1;
+            _loadFailureCounts.TryGetValue(path, out var previousAttempts);
+            var attempts = previousAttempts + 1;
+            _loadFailureCounts[path] = attempts;
 
-            if (attempts < MaxParseAttempts)
+            if (attempts < MaxLoadAttempts)
             {
-                _parseFailureCounts[path] = attempts;
-                _logger.Warn("{0}: Failed to read file on a retry; will retry again in {1} ms",
-                    path, RetryDelay.TotalMilliseconds);
+                _logger.Warn("{0}: Failed to read file on a retry ({1}); will retry again in {2} ms",
+                    path, LogValues.ExceptionSummary(e), RetryDelay.TotalMilliseconds);
+                _logger.Debug("{0}", LogValues.ExceptionTrace(e));
                 ScheduleRetry();
             }
             else
             {
                 EndEpisode(path);
-                _logger.Error("{0}: Failed to load file after {1} attempts; will not retry until the next detected file change",
-                    path, MaxParseAttempts);
+                LogHelpers.LogException(_logger,
+                    string.Format("{0}: Failed to load file after {1} attempts; will not retry until the next detected file change",
+                        path, MaxLoadAttempts), e);
             }
         }
 
@@ -234,13 +264,13 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         // never re-attempted and their promised retries cannot happen.
         private void EndEpisode(string failedPath)
         {
-            _parseFailureCounts.Remove(failedPath);
-            foreach (var abandoned in _parseFailureCounts.Keys)
+            _loadFailureCounts.Remove(failedPath);
+            foreach (var abandoned in _loadFailureCounts.Keys)
             {
                 _logger.Error("{0}: Will not be retried because {1} repeatedly failed to load; both will be re-read on the next detected file change",
                     abandoned, failedPath);
             }
-            _parseFailureCounts.Clear();
+            _loadFailureCounts.Clear();
         }
 
         // Called under _updateLock.
@@ -256,7 +286,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                 await Task.Delay(RetryDelay).ConfigureAwait(false);
                 try
                 {
-                    RetryLoadAll();
+                    LoadAll(isRetry: true);
                 }
                 catch (Exception e)
                 {
@@ -264,23 +294,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     LogHelpers.LogException(_logger, "Unexpected error while retrying file data load", e);
                 }
             });
-        }
-
-        private void RetryLoadAll()
-        {
-            lock (_updateLock)
-            {
-                _retryPending = false;
-                if (_disposed || _parseFailureCounts.Count == 0)
-                {
-                    // Disposed, or the failure state was cleared in the meantime (an externally
-                    // triggered load succeeded, or the chain gave up) — a reload would be redundant
-                    // and would re-Init identical data at bumped versions, firing spurious change
-                    // events.
-                    return;
-                }
-                LoadAll(isRetry: true);
-            }
         }
 
         private void TriggerReload()

--- a/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
@@ -22,6 +22,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         private readonly FlagFileDataMerger _dataMerger;
         private readonly FileDataTypes.IFileReader _fileReader;
         private readonly bool _skipMissingPaths;
+        private readonly bool _autoUpdate;
         private readonly Logger _logger;
         private volatile bool _started;
         private volatile bool _loadedValidData;
@@ -29,10 +30,15 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         private volatile int _lastVersion;
         private object _updateLock = new object();
 
-        private const int MaxRetries = 5;
+        private const int MaxParseAttempts = 5;
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(600);
-        // Per-path JSON-parse retry counters. Only touched inside _updateLock.
-        private readonly Dictionary<string, int> _retryCounts = new Dictionary<string, int>();
+        // Consecutive parse failures per path within the current failure episode. A failure seen on
+        // an externally triggered load (Start or a file-change notification) starts a new episode,
+        // so the retry budget is per-episode, not per-lifetime. Only touched inside _updateLock.
+        private readonly Dictionary<string, int> _parseFailureCounts = new Dictionary<string, int>();
+        // Whether a delayed retry is already scheduled; at most one retry chain exists at a time,
+        // since each retry re-reads every path anyway. Only touched inside _updateLock.
+        private bool _retryPending;
 
         public FileDataSource(IDataSourceUpdates dataSourceUpdates, FileDataTypes.IFileReader fileReader,
             List<string> paths, bool autoUpdate, Func<string, object> alternateParser, bool skipMissingPaths,
@@ -46,6 +52,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             _dataMerger = new FlagFileDataMerger(duplicateKeysHandling);
             _fileReader = fileReader;
             _skipMissingPaths = skipMissingPaths;
+            _autoUpdate = autoUpdate;
             _lastVersion = 0;
             if (autoUpdate)
             {
@@ -68,7 +75,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         public Task<bool> Start()
         {
             _started = true;
-            LoadAll();
+            LoadAll(isRetry: false);
 
             // We always complete the start task regardless of whether we successfully loaded data or not;
             // if the data files were bad, they're unlikely to become good within the short interval that
@@ -94,7 +101,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
         }
 
-        private void LoadAll()
+        private void LoadAll(bool isRetry)
         {
             lock (_updateLock)
             {
@@ -111,44 +118,26 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     {
                         var content = _fileReader.ReadAllText(path);
                         _logger.Debug("file data: {0}", content);
-                        var data = _parser.Parse(content, version);
+                        FullDataSet<ItemDescriptor> data;
+                        try
+                        {
+                            data = _parser.Parse(content, version);
+                        }
+                        catch (Exception e)
+                        {
+                            // A file-change notification can fire while the file is mid-write, so a parse
+                            // failure may just mean we read an empty or partially written file. This applies
+                            // to any configured parser (JSON or alternate), so we treat every failure of
+                            // Parse — as opposed to reading the file — as potentially transient.
+                            HandleParseFailure(path, e, isRetry);
+                            return;
+                        }
                         _dataMerger.AddToData(data, flags, segments);
-                        _retryCounts.Remove(path);
+                        _parseFailureCounts.Remove(path);
                     }
                     catch (FileNotFoundException) when (_skipMissingPaths)
                     {
                         _logger.Debug("{0}: {1}", path, "File not found");
-                    }
-                    catch (System.Text.Json.JsonException)
-                    {
-                        // A file-change notification can fire while the file is mid-write, so we may read an
-                        // empty or partially written file. Retry up to MaxRetries times before giving up; the
-                        // counter is cleared on the next successful load.
-                        if (!_retryCounts.ContainsKey(path))
-                        {
-                            _retryCounts[path] = 0;
-                        }
-                        _retryCounts[path]++;
-
-                        if (_retryCounts[path] < MaxRetries)
-                        {
-                            _logger.Warn("{0}: Failed to parse file, retrying in {1} ms", path, RetryDelay.TotalMilliseconds);
-                            Task.Run(async () =>
-                            {
-                                await Task.Delay(RetryDelay).ConfigureAwait(false);
-                                if (_disposed)
-                                {
-                                    return;
-                                }
-                                LoadAll();
-                            });
-                        }
-                        else
-                        {
-                            _logger.Error("{0}: Failed to parse file after {1} retries", path, MaxRetries);
-                        }
-
-                        return;
                     }
                     catch (Exception e)
                     {
@@ -167,12 +156,83 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
         }
 
+        // Called under _updateLock when parsing a path's content fails.
+        private void HandleParseFailure(string path, Exception e, bool isRetry)
+        {
+            if (!_autoUpdate)
+            {
+                // With auto-update off, files are documented to be loaded only once, so we don't
+                // retry in the background — Start()'s result stays final.
+                LogHelpers.LogException(_logger, "Failed to parse " + path, e);
+                return;
+            }
+
+            var attempts = 1;
+            if (isRetry && _parseFailureCounts.TryGetValue(path, out var previousAttempts))
+            {
+                attempts = previousAttempts + 1;
+            }
+
+            if (attempts < MaxParseAttempts)
+            {
+                _parseFailureCounts[path] = attempts;
+                _logger.Warn("{0}: failed to parse file ({1}); will retry in {2} ms in case it was incompletely written",
+                    path, LogValues.ExceptionSummary(e), RetryDelay.TotalMilliseconds);
+                ScheduleRetry();
+            }
+            else
+            {
+                _parseFailureCounts.Remove(path);
+                LogHelpers.LogException(_logger,
+                    string.Format("{0}: failed to parse file after {1} attempts", path, MaxParseAttempts), e);
+            }
+        }
+
+        // Called under _updateLock.
+        private void ScheduleRetry()
+        {
+            if (_retryPending)
+            {
+                return; // the already-scheduled retry will re-read every path
+            }
+            _retryPending = true;
+            Task.Run(async () =>
+            {
+                await Task.Delay(RetryDelay).ConfigureAwait(false);
+                try
+                {
+                    RetryLoadAll();
+                }
+                catch (Exception e)
+                {
+                    // Nothing observes this task, so any escaping exception would otherwise vanish.
+                    LogHelpers.LogException(_logger, "Unexpected error while retrying file data load", e);
+                }
+            });
+        }
+
+        private void RetryLoadAll()
+        {
+            lock (_updateLock)
+            {
+                _retryPending = false;
+                if (_disposed || _parseFailureCounts.Count == 0)
+                {
+                    // Disposed, or an externally triggered load already succeeded in the meantime
+                    // (success clears the failure counts) — a reload would be redundant and would
+                    // re-Init identical data at bumped versions, firing spurious change events.
+                    return;
+                }
+                LoadAll(isRetry: true);
+            }
+        }
+
         private void TriggerReload()
         {
             if (_started)
             {
                 _logger.Info("detected file modification, reloading");
-                LoadAll();
+                LoadAll(isRetry: false);
             }
         }
     }

--- a/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/DataSources/FileDataSource.cs
@@ -149,6 +149,15 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     catch (Exception e)
                     {
                         LogHelpers.LogException(_logger, "Failed to load " + path, e);
+                        if (isRetry)
+                        {
+                            // A transient read error (for example, a writer replacing the file)
+                            // must not end a retry episode early: paths that were promised
+                            // retries would keep stale data with budget remaining, and another
+                            // file-change notification is not guaranteed. Charge the failure to
+                            // the same per-path budget and continue the chain.
+                            HandleRetryLoadFailure(path);
+                        }
                         return;
                     }
                 }
@@ -190,19 +199,48 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
             else
             {
-                // This path kept failing, so the retry chain ends until the next external trigger.
-                // Every attempt stopped at this path, so any other paths with recorded failures
-                // were never re-attempted; their episodes end here too.
-                _parseFailureCounts.Remove(path);
-                foreach (var abandoned in _parseFailureCounts.Keys)
-                {
-                    _logger.Error("{0}: Will not be retried because {1} repeatedly failed to parse; both will be re-read on the next detected file change",
-                        abandoned, path);
-                }
-                _parseFailureCounts.Clear();
+                EndEpisode(path);
                 LogHelpers.LogException(_logger,
                     string.Format("{0}: Failed to parse file after {1} attempts", path, MaxParseAttempts), e);
             }
+        }
+
+        // Called under _updateLock when a retry attempt fails before parsing (for example, a
+        // transient read error). The caller has already logged the exception; this charges the
+        // failure to the path's per-episode budget and continues or ends the retry chain.
+        private void HandleRetryLoadFailure(string path)
+        {
+            var attempts = _parseFailureCounts.TryGetValue(path, out var previousAttempts)
+                ? previousAttempts + 1
+                : 1;
+
+            if (attempts < MaxParseAttempts)
+            {
+                _parseFailureCounts[path] = attempts;
+                _logger.Warn("{0}: Failed to read file on a retry; will retry again in {1} ms",
+                    path, RetryDelay.TotalMilliseconds);
+                ScheduleRetry();
+            }
+            else
+            {
+                EndEpisode(path);
+                _logger.Error("{0}: Failed to load file after {1} attempts; will not retry until the next detected file change",
+                    path, MaxParseAttempts);
+            }
+        }
+
+        // Called under _updateLock. Ends the current failure episode for every path: the chain
+        // stopped at failedPath on every attempt, so any other paths with recorded failures were
+        // never re-attempted and their promised retries cannot happen.
+        private void EndEpisode(string failedPath)
+        {
+            _parseFailureCounts.Remove(failedPath);
+            foreach (var abandoned in _parseFailureCounts.Keys)
+            {
+                _logger.Error("{0}: Will not be retried because {1} repeatedly failed to load; both will be re-read on the next detected file change",
+                    abandoned, failedPath);
+            }
+            _parseFailureCounts.Clear();
         }
 
         // Called under _updateLock.

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -151,50 +151,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                     file.SetContentFromPath(TestUtils.TestFilePath("segment-only.json"));
 
-                    AssertHelpers.ExpectPredicate(_updateSink.Inits, actual =>
-                        {
-                            var segments = actual.Data.First(item => item.Key == DataModel.Segments);
-                            var features = actual.Data.First(item => item.Key == DataModel.Features);
-                            if (!features.Value.Items.IsNullOrEmpty())
-                            {
-                                return false;
-                            }
-
-                            var segmentItems = segments.Value.Items.ToList();
-
-                            if (segmentItems.Count != 1)
-                            {
-                                return false;
-                            }
-
-                            var segmentDescriptor = segmentItems[0];
-                            if (segmentDescriptor.Key != "seg1")
-                            {
-                                return false;
-                            }
-
-                            if (segmentDescriptor.Value.Version == 1)
-                            {
-                                return false;
-                            }
-
-                            if (!(segmentDescriptor.Value.Item is Segment segment))
-                            {
-                                return false;
-                            }
-
-                            if (segment.Deleted)
-                            {
-                                return false;
-                            }
-
-                            if (segment.Included.Count != 1)
-                            {
-                                return false;
-                            }
-
-                            return segment.Included[0] == "user1";
-                        },
+                    AssertHelpers.ExpectPredicate(_updateSink.Inits, IsSegmentOnlyDataAfterReload,
                         "Did not receive expected update from the file data source.",
                         TimeSpan.FromSeconds(30));
                 }
@@ -270,16 +227,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                     file1.SetContentFromPath(TestUtils.TestFilePath("segment-only.json"));
 
-                    // Use ExpectJsonValue to handle potential race conditions where the file watcher
-                    // may trigger multiple reload events. This keeps checking events until one matches
-                    // the expected JSON or the timeout expires.
-                    var newData = AssertHelpers.ExpectJsonValue(
-                        _updateSink.Inits,
-                        DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2)),
-                        DataSetAsJson,
+                    AssertHelpers.ExpectPredicate(_updateSink.Inits, IsSegmentOnlyDataAfterReload,
+                        "Did not receive expected update from the file data source.",
                         TimeSpan.FromSeconds(30));
-
-                    AssertJsonEqual(DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2)), DataSetAsJson(newData));
                 }
             }
         }
@@ -298,18 +248,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                     file.SetContentFromPath(TestUtils.TestFilePath("segment-only.json"));
 
-                    // Use ExpectJsonValue to handle potential race conditions where the file watcher
-                    // may trigger multiple reload events. This keeps checking events until one matches
-                    // the expected JSON or the timeout expires.
-                    // Note that the expected version is 2 because we increment the version on each
-                    // *attempt* to load the files, not on each successful load.
-                    var newData = AssertHelpers.ExpectJsonValue(
-                        _updateSink.Inits,
-                        DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2)),
-                        DataSetAsJson,
+                    AssertHelpers.ExpectPredicate(_updateSink.Inits, IsSegmentOnlyDataAfterReload,
+                        "Did not receive expected update from the file data source.",
                         TimeSpan.FromSeconds(30));
-
-                    AssertJsonEqual(DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2)), DataSetAsJson(newData));
                 }
             }
         }
@@ -365,5 +306,38 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     new SegmentBuilder("seg1").Version(version).Included("user1").Build()
                 )
                 .Build();
+
+        // Predicate that matches the structure of segment-only.json reloaded after the initial load.
+        // We deliberately don't pin the exact version: with the file watcher firing on truncate-then-write
+        // and the JsonException retry, the version of the successful load is non-deterministic, so we
+        // only require that it isn't the initial version 1.
+        private static bool IsSegmentOnlyDataAfterReload(FullDataSet<ItemDescriptor> actual)
+        {
+            var features = actual.Data.First(item => item.Key == DataModel.Features);
+            if (!features.Value.Items.IsNullOrEmpty())
+            {
+                return false;
+            }
+
+            var segments = actual.Data.First(item => item.Key == DataModel.Segments);
+            var segmentItems = segments.Value.Items.ToList();
+            if (segmentItems.Count != 1)
+            {
+                return false;
+            }
+
+            var segmentDescriptor = segmentItems[0];
+            if (segmentDescriptor.Key != "seg1" || segmentDescriptor.Value.Version == 1)
+            {
+                return false;
+            }
+
+            if (!(segmentDescriptor.Value.Item is Segment segment) || segment.Deleted)
+            {
+                return false;
+            }
+
+            return segment.Included.Count == 1 && segment.Included[0] == "user1";
+        }
     }
 }

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -255,6 +255,150 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
         }
 
+        private const string ValidFlagJson = @"{""flagValues"":{""flag1"":""a""}}";
+        private const string TruncatedFlagJson = @"{""flagValues"": {"; // invalid as JSON and as YAML
+
+        // Simulates reading a file that is mid-write: returns truncated content until Bad is
+        // cleared, and counts reads so tests can observe retry attempts deterministically
+        // without depending on real file-watcher timing.
+        private class ScriptedFileReader : FileDataTypes.IFileReader
+        {
+            private int _reads;
+            public volatile bool Bad = true;
+            public int Reads => Volatile.Read(ref _reads);
+
+            public string ReadAllText(string path)
+            {
+                Interlocked.Increment(ref _reads);
+                return Bad ? TruncatedFlagJson : ValidFlagJson;
+            }
+        }
+
+        private static void WaitForReads(ScriptedFileReader reader, int count)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (reader.Reads < count && DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(50);
+            }
+        }
+
+        [Fact]
+        public void ParseFailureFromPartialReadIsRetriedUntilContentIsComplete()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start();
+                    WaitForReads(reader, 2);
+                    reader.Bad = false; // as if the write completed, with no further notification
+                    _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
+                    Assert.True(fp.Initialized);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParseRetryStopsAfterMaxAttemptsAndDoesNotInit()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start();
+                    WaitForReads(reader, 5); // initial attempt + 4 retries
+                    Thread.Sleep(1500); // longer than two retry delays
+                    Assert.Equal(5, reader.Reads); // budget exhausted, no further attempts
+                    _updateSink.Inits.ExpectNoValue();
+                    Assert.False(fp.Initialized);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParseRetryBudgetResetsForANewFailureEpisode()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start();
+                    WaitForReads(reader, 5); // episode 1: all attempts fail
+                    Thread.Sleep(1500);
+                    Assert.Equal(5, reader.Reads); // episode 1 exhausted, nothing pending
+
+                    // A new file-change notification starts a new episode with a fresh retry
+                    // budget, even though its first read still sees partial content.
+                    file.SetContent("trigger-new-episode");
+                    WaitForReads(reader, 6);
+
+                    reader.Bad = false; // write completed; no further notification arrives
+                    _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        [Fact]
+        public void ParseRetryAppliesWhenAlternateParserIsConfigured()
+        {
+            var yaml = new DeserializerBuilder().Build();
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader)
+                    .Parser(s => yaml.Deserialize<object>(s));
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start();
+                    reader.Bad = false;
+                    _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        [Fact]
+        public void ParseFailureIsNotRetriedIfAutoUpdateIsOff()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(false).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    var task = fp.Start();
+                    Assert.True(task.IsCompleted);
+                    Assert.False(fp.Initialized);
+                    reader.Bad = false;
+                    _updateSink.Inits.ExpectNoValue(TimeSpan.FromSeconds(2));
+                    Assert.False(fp.Initialized);
+                    Assert.Equal(1, reader.Reads);
+                }
+            }
+        }
+
+        [Fact]
+        public void PendingParseRetryIsCanceledByDispose()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                var fp = MakeDataSource();
+                fp.Start(); // schedules a retry
+                Assert.Equal(1, reader.Reads);
+                fp.Dispose();
+                Thread.Sleep(1500);
+                Assert.Equal(1, reader.Reads); // the pending retry observed the disposal and did nothing
+            }
+        }
+
         [Fact]
         public void FullFlagDefinitionEvaluatesAsExpected()
         {

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Castle.Core.Internal;
@@ -267,11 +268,16 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         {
             private int _reads;
             public volatile bool Bad = true;
+            public volatile bool Throw = false;
             public int Reads => Volatile.Read(ref _reads);
 
             public string ReadAllText(string path)
             {
                 Interlocked.Increment(ref _reads);
+                if (Throw)
+                {
+                    throw new IOException("simulated transient read error");
+                }
                 return Bad ? TruncatedFlagJson : ValidFlagJson;
             }
         }
@@ -385,6 +391,30 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     _updateSink.Inits.ExpectNoValue(TimeSpan.FromSeconds(2));
                     Assert.False(fp.Initialized);
                     Assert.Equal(1, reader.Reads);
+                }
+            }
+        }
+
+        [Fact]
+        public void TransientReadErrorDuringRetryDoesNotEndTheEpisode()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start(); // parse fails, schedules a retry
+                    // The retry's read fails transiently (e.g. a writer is replacing the file);
+                    // the content itself is complete from here on.
+                    reader.Bad = false;
+                    reader.Throw = true;
+                    WaitForReads(reader, 2);
+                    reader.Throw = false;
+
+                    // The episode still has budget, so the chain must continue and load the data
+                    // instead of dying on the non-parse failure.
+                    _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
                 }
             }
         }

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using Castle.Core.Internal;
+using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk.Server.Integrations;
 using LaunchDarkly.Sdk.Server.Interfaces;
 using LaunchDarkly.Sdk.Server.Internal.Model;
@@ -274,14 +276,18 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             }
         }
 
-        private static void WaitForReads(ScriptedFileReader reader, int count)
+        private static void WaitUntil(Func<bool> condition, string description)
         {
-            var deadline = DateTime.UtcNow.AddSeconds(10);
-            while (reader.Reads < count && DateTime.UtcNow < deadline)
+            var deadline = DateTime.UtcNow.AddSeconds(15);
+            while (!condition() && DateTime.UtcNow < deadline)
             {
-                Thread.Sleep(50);
+                Thread.Sleep(20);
             }
+            Assert.True(condition(), "timed out waiting for " + description);
         }
+
+        private static void WaitForReads(ScriptedFileReader reader, int count) =>
+            WaitUntil(() => reader.Reads >= count, count + " file reads");
 
         [Fact]
         public void ParseFailureFromPartialReadIsRetriedUntilContentIsComplete()
@@ -390,12 +396,126 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             using (var file = TempFile.Create())
             {
                 factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
-                var fp = MakeDataSource();
-                fp.Start(); // schedules a retry
-                Assert.Equal(1, reader.Reads);
-                fp.Dispose();
-                Thread.Sleep(1500);
-                Assert.Equal(1, reader.Reads); // the pending retry observed the disposal and did nothing
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start(); // schedules a retry
+                    fp.Dispose();
+                    // No new load may start after Dispose; any retry scheduled before it must
+                    // observe the disposal and do nothing. (Reads are captured after Dispose so
+                    // the test stays valid even if a retry fired before Dispose ran.)
+                    var readsAtDispose = reader.Reads;
+                    Thread.Sleep(1500);
+                    Assert.Equal(readsAtDispose, reader.Reads);
+                }
+            }
+        }
+
+        // The multi-path tests below use paths in a directory that does not exist, so the file
+        // watcher fails to construct (logged and swallowed, _reloader == null). That makes the
+        // load sequence fully deterministic: the only externally triggered loads are the Start()
+        // calls, which exercise the same code path as a file-change notification.
+        private const string MultiPathA = "/nonexistent-ld-filedatasource-test-dir/a.json";
+        private const string MultiPathB = "/nonexistent-ld-filedatasource-test-dir/b.json";
+
+        private class PerPathScriptedReader : FileDataTypes.IFileReader
+        {
+            private readonly ConcurrentDictionary<string, int> _reads = new ConcurrentDictionary<string, int>();
+            private readonly ConcurrentDictionary<string, bool> _bad = new ConcurrentDictionary<string, bool>();
+
+            public void SetBad(string path, bool bad) { _bad[path] = bad; }
+            public int Reads(string path) => _reads.TryGetValue(path, out var n) ? n : 0;
+
+            public string ReadAllText(string path)
+            {
+                _reads.AddOrUpdate(path, 1, (_, n) => n + 1);
+                if (_bad.TryGetValue(path, out var bad) && bad)
+                {
+                    return TruncatedFlagJson;
+                }
+                // distinct flag keys per path, so a successful merge of both files can't throw
+                // on duplicate keys (the builder default is DuplicateKeysHandling.Throw)
+                return path == MultiPathA
+                    ? @"{""flagValues"":{""flagA"":""a""}}"
+                    : @"{""flagValues"":{""flagB"":""b""}}";
+            }
+        }
+
+        [Fact]
+        public void PendingParseRetryIsSkippedIfAnExternalReloadAlreadySucceeded()
+        {
+            var reader = new ScriptedFileReader();
+            using (var file = TempFile.Create())
+            {
+                factory.FilePaths(file.Path).AutoUpdate(true).FileReader(reader);
+                using (var fp = MakeDataSource())
+                {
+                    fp.Start(); // fails, schedules a retry
+
+                    // An externally triggered load (same code path as a file-change notification)
+                    // succeeds before the pending retry fires.
+                    reader.Bad = false;
+                    fp.Start();
+                    _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(1));
+                    var readsAfterSuccess = reader.Reads;
+
+                    Thread.Sleep(1500); // past the retry delay
+                    // The pending retry saw that the load already succeeded and did not reload,
+                    // so no redundant Init (which would fire spurious change events) occurred.
+                    Assert.Equal(readsAfterSuccess, reader.Reads);
+                    _updateSink.Inits.ExpectNoValue();
+                }
+            }
+        }
+
+        [Fact]
+        public void ParseFailureInANewEpisodeGetsAFullRetryBudgetAfterAnotherPathGaveUp()
+        {
+            var reader = new PerPathScriptedReader();
+            reader.SetBad(MultiPathB, true);
+            factory.FilePaths(MultiPathA, MultiPathB).AutoUpdate(true).FileReader(reader);
+            using (var fp = MakeDataSource())
+            {
+                fp.Start(); // A parses, B fails; B accumulates failures across retries
+                WaitUntil(() => reader.Reads(MultiPathB) >= 4, "4 reads of path B");
+                reader.SetBad(MultiPathA, true); // now every attempt stops at A
+                WaitUntil(() => reader.Reads(MultiPathA) >= 9, "A to exhaust its retry budget");
+                Thread.Sleep(1500); // the retry chain is dead
+                Assert.Equal(9, reader.Reads(MultiPathA));
+
+                // A new externally triggered load fails at A; A recovers before the retry fires.
+                fp.Start();
+                reader.SetBad(MultiPathA, false);
+                WaitUntil(() => reader.Reads(MultiPathB) >= 5, "the retry to reach path B");
+                reader.SetBad(MultiPathB, false);
+
+                // B's failure was its first in the new episode, so it gets a fresh retry budget
+                // instead of inheriting the dead episode's count and giving up immediately.
+                _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Fact]
+        public void PathAbandonedWhenAnotherPathGivesUpGetsATerminalLogMessage()
+        {
+            var reader = new PerPathScriptedReader();
+            reader.SetBad(MultiPathB, true);
+            factory.FilePaths(MultiPathA, MultiPathB).AutoUpdate(true).FileReader(reader);
+            using (var fp = MakeDataSource())
+            {
+                fp.Start();
+                WaitUntil(() => reader.Reads(MultiPathB) >= 4, "4 reads of path B");
+                reader.SetBad(MultiPathA, true);
+                WaitUntil(() => reader.Reads(MultiPathA) >= 9, "A to exhaust its retry budget");
+                Thread.Sleep(1500); // the retry chain is dead
+
+                // B was last warned "will retry in 600 ms", but A's give-up ended the chain.
+                // That promise must be either fulfilled (B re-read) or terminated with an
+                // error log naming B.
+                var bRetried = reader.Reads(MultiPathB) >= 5;
+                var bTerminallyLogged = LogCapture.GetMessages().Any(m =>
+                    m.Level == LogLevel.Error && m.Text.Contains(MultiPathB));
+                Assert.True(bRetried || bTerminallyLogged,
+                    "path B was promised a retry but was never re-read and got no terminal error log");
             }
         }
 


### PR DESCRIPTION
When we detect a file has been written there isn't any promise that the file content itself will actually be complete, or that a subsequent notification for that file will be received when it is. 

Currently sometimes the file update will trigger, and the JSON parsing will fail, and then it won't get re-triggered. Which causes some tests to fail.

This introduces a retry for any failed JSON parsing up to a maximum number of times.

Ideally we would extract the file watcher and abstract the file system API so we could simulate these conditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> When **auto-update** is enabled, `FileDataSource` no longer treats a failed parse (or transient read error during a retry) as final if the file may have been read mid-write. It retries up to **5 times** with a **600 ms** delay, then stops until the next file-change notification or another external load (`Start` / watcher).
> 
> Retry logic is **per failure episode**: each watcher-triggered or `Start`-driven load clears per-path failure counts. A single scheduled retry chain re-reads all paths; redundant retries are skipped if a successful load already cleared failure state. **Dispose** blocks further loads from pending retries. With **auto-update off**, behavior stays one-shot (no background retries).
> 
> Public docs on `FileDataSourceBuilder.AutoUpdate` are updated to describe give-up-after-repeated-failures instead of indefinite retry.
> 
> Tests add scripted file readers and cover retry success, max attempts, budget reset, alternate parsers, read errors during retry, dispose, multi-path abandonment, and looser reload assertions where watcher timing makes exact versions non-deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9fcb6368e0e520895be494b9aa324bbf8d6a514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->