### PR TITLE
chore: Address stale TODO items.

### DIFF
--- a/pkgs/sdk/server/src/Internal/DataSystem/FDv2DataSystem.cs
+++ b/pkgs/sdk/server/src/Internal/DataSystem/FDv2DataSystem.cs
@@ -72,9 +72,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSystem
 
             var writeThroughStore = new WriteThroughStore(memoryStore, persistentStore,
                 dataSystemConfiguration.PersistentDataStoreMode);
-
-            // TODO: When a persistent store is available we monitor it, is this a consistent choice.
-            // TODO: Update the responses data store monitoring?
+            
             var dataStoreStatusProvider = new DataStoreStatusProviderImpl(writeThroughStore, dataStoreUpdates);
             var dataSourceUpdates = new DataSourceUpdatesImpl(writeThroughStore, dataStoreStatusProvider,
                 clientContext.TaskExecutor, logger, logConfig.LogDataSourceOutageAsErrorAfter);

--- a/pkgs/sdk/server/src/Internal/FDv2DataSources/FDv2StreamingDataSource.cs
+++ b/pkgs/sdk/server/src/Internal/FDv2DataSources/FDv2StreamingDataSource.cs
@@ -224,9 +224,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.FDv2DataSources
                     if (!storeError)
                     {
                         _lastStoreUpdateFailed.GetAndSet(false);
-
-                        // TODO: This may be more nuanced or not required once we have the composite
-                        // data source.
                         MaybeMarkInitialized();
                     }
                     else

--- a/pkgs/sdk/server/test/Internal/FDv2DataSources/FDv2DataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/FDv2DataSources/FDv2DataSourceTest.cs
@@ -164,8 +164,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             Assert.Equal(DataSourceState.Valid, statusUpdates[4].State);
 
             // Verify that the data source is initialized
-            // TODO: uncomment this check once Initialized is implemented
-            // Assert.True(dataSource.Initialized);
+            Assert.True(dataSource.Initialized);
 
             // Verify that Apply was called twice: once for second initializer, once for synchronizer
             // Verify the first Apply call was with second initializer dummy data
@@ -333,8 +332,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             Assert.Equal(DataSourceState.Valid, statusUpdates[6].State);
 
             // Verify that the data source is initialized
-            // TODO: uncomment this check once Initialized is implemented
-            // Assert.True(dataSource.Initialized);
+            Assert.True(dataSource.Initialized);
 
             // Verify that Apply was called twice: once for second initializer, once for synchronizer
             // Verify the first Apply call was with second initializer dummy data
@@ -600,8 +598,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
             Assert.Equal(DataSourceState.Valid, statusUpdates[4].State);
 
             // Verify that the data source is initialized
-            // TODO: uncomment this check once Initialized is implemented
-            // Assert.True(dataSource.Initialized);
+            Assert.True(dataSource.Initialized);
 
             // Verify that Apply was called once with synchronizer dummy data
             var changeSet = capturingSink.Applies.ExpectValue(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
Addressed some TODO items which are stale, or which for the implementation has already been handled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Cleanup and test tightening**
> 
> - Removes stale TODO comments in `FDv2DataSystem.cs` and `FDv2StreamingDataSource.cs`
> - Enables `dataSource.Initialized` assertions in multiple `FDv2DataSource` tests to verify initialization state
> - No functional code changes to production paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91e919859dbe8a6905b5ebe34cb076178d19fcac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->