### PR TITLE
chore: Update data system notes for EAP.

### DIFF
--- a/pkgs/sdk/server/src/Configuration.cs
+++ b/pkgs/sdk/server/src/Configuration.cs
@@ -121,7 +121,7 @@ namespace LaunchDarkly.Sdk.Server
         /// Contains the data system configuration.
         /// <para>
         /// This property is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is not suitable for production usage. Do not use it. You have been warned.
+        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
         /// </para>
         /// </summary>
         /// TODO: SDK-1678: Internal until ready for use.

--- a/pkgs/sdk/server/src/ConfigurationBuilder.cs
+++ b/pkgs/sdk/server/src/ConfigurationBuilder.cs
@@ -407,7 +407,7 @@ namespace LaunchDarkly.Sdk.Server
         /// Configure the data system.
         /// <para>
         /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is not suitable for production usage. Do not use it. You have been warned.
+        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
         /// </para>
         /// </summary>
         /// <remarks>

--- a/pkgs/sdk/server/src/Integrations/DataSystemBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemBuilder.cs
@@ -8,7 +8,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// Configuration builder for the SDK's data acquisition and storage strategy.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     internal sealed class DataSystemBuilder

--- a/pkgs/sdk/server/src/Integrations/DataSystemComponents.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemComponents.cs
@@ -7,7 +7,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// Components for use with the data system.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     internal static class DataSystemComponents

--- a/pkgs/sdk/server/src/Integrations/DataSystemModes.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemModes.cs
@@ -6,7 +6,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// A set of different data system modes which provided pre-configured <see cref="DataSystemBuilder"/>s.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     internal sealed class DataSystemModes

--- a/pkgs/sdk/server/src/Integrations/FDv2PollingDataSourceBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/FDv2PollingDataSourceBuilder.cs
@@ -11,7 +11,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// Contains methods for configuring the polling data source.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     /// <example>

--- a/pkgs/sdk/server/src/Integrations/FDv2StreamingDataSourceBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/FDv2StreamingDataSourceBuilder.cs
@@ -11,7 +11,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     /// Contains methods for configuring the streaming data source.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     /// <example>

--- a/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
+++ b/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
@@ -385,7 +385,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
         /// Enumeration that indicates if this change is a full or partial change.
         /// <para>
         /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is not suitable for production usage. Do not use it. You have been warned.
+        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
         /// </para>
         /// </summary>
         public enum ChangeSetType
@@ -410,7 +410,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
         /// Represents a set of changes to apply to a store.
         /// <para>
         /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is not suitable for production usage. Do not use it. You have been warned.
+        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
         /// </para>
         /// </summary>
         public struct ChangeSet<TItemDescriptor>

--- a/pkgs/sdk/server/src/Subsystems/DataSystemConfiguration.cs
+++ b/pkgs/sdk/server/src/Subsystems/DataSystemConfiguration.cs
@@ -6,7 +6,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// Configuration for the SDK's data acquisition and storage strategy.
     /// <para>
     /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     internal sealed class DataSystemConfiguration

--- a/pkgs/sdk/server/src/Subsystems/ITransactionalDataSourceUpdates.cs
+++ b/pkgs/sdk/server/src/Subsystems/ITransactionalDataSourceUpdates.cs
@@ -17,7 +17,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// </remarks>
     /// <para>
     /// This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     public interface ITransactionalDataSourceUpdates
     {

--- a/pkgs/sdk/server/src/Subsystems/ITransactionalDataStore.cs
+++ b/pkgs/sdk/server/src/Subsystems/ITransactionalDataStore.cs
@@ -19,7 +19,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// <seealso cref="IPersistentDataStoreAsync"/>
     /// <para>
     /// This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     public interface ITransactionalDataStore
     {

--- a/pkgs/sdk/server/src/Subsystems/Selector.cs
+++ b/pkgs/sdk/server/src/Subsystems/Selector.cs
@@ -4,7 +4,7 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// A selector can either be empty or it can contain state and a version.
     /// <para>
     /// This struct is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is not suitable for production usage. Do not use it. You have been warned.
+    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
     /// </para>
     /// </summary>
     public struct Selector


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Marks data system-related APIs as early access and adds an EAP link in XML documentation comments. No runtime or behavioral changes.
> 
> - Updates doc comments in `Configuration`, `ConfigurationBuilder`, and `Integrations` builders (`DataSystemBuilder`, `DataSystemComponents`, `DataSystemModes`, `FDv2PollingDataSourceBuilder`, `FDv2StreamingDataSourceBuilder`)
> - Updates doc comments in `Subsystems` types (`DataStoreTypes` including `ChangeSetType`/`ChangeSet`, `DataSystemConfiguration`, `ITransactionalDataSourceUpdates`, `ITransactionalDataStore`, `Selector`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cbec58ecc19bad3247e814c6a011739ea468cc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->