### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/full-release/action.yml
+++ b/.github/actions/full-release/action.yml
@@ -40,11 +40,6 @@ inputs:
     description: 'Run an instance of Redis'
     required: false
     default: false
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.publish.outputs.hashes }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -7,11 +7,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.hash.outputs.hashes }}
-
 runs:
   using: composite
   steps:
@@ -41,13 +36,6 @@ runs:
           dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
           echo "published ${pkg}"
         done
-
-    - name: Hash nuget packages
-      id: hash
-      if: ${{ inputs.dry_run == 'false' }}
-      shell: bash
-      run: |
-        echo "hashes=$(sha256sum ./nupkgs/*.nupkg ./nupkgs/*.snupkg | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Dry Run Publish
       if: ${{ inputs.dry_run == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,24 +14,14 @@ jobs:
 
     outputs:
       package-sdk-client-released: ${{ steps.release.outputs['pkgs/sdk/client--release_created'] }}
-      package-sdk-client-tag_name: ${{ steps.release.outputs['pkgs/sdk/client--tag_name'] }}
       package-sdk-server-ai-released: ${{ steps.release.outputs['pkgs/sdk/server-ai--release_created'] }}
-      package-sdk-server-ai-tag_name: ${{ steps.release.outputs['pkgs/sdk/server-ai--tag_name'] }}
       package-sdk-server-consul-released: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-consul--release_created'] }}
-      package-sdk-server-consul-tag_name: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-consul--tag_name'] }}
       package-sdk-server-dynamodb-released: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-dynamodb--release_created'] }}
-      package-sdk-server-dynamodb-tag_name: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-dynamodb--tag_name'] }}
       package-sdk-server-redis-released: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-redis--release_created'] }}
-      package-sdk-server-redis-tag_name: ${{ steps.release.outputs['pkgs/dotnet-server-sdk-redis--tag_name'] }}
       package-sdk-server-released: ${{ steps.release.outputs['pkgs/sdk/server--release_created'] }}
-      package-sdk-server-tag_name: ${{ steps.release.outputs['pkgs/sdk/server--tag_name'] }}
       package-sdk-server-telemetry-released: ${{ steps.release.outputs['pkgs/telemetry--release_created'] }}
-      package-sdk-server-telemetry-tag_name: ${{ steps.release.outputs['pkgs/telemetry--tag_name'] }}
       package-shared-common-released: ${{ steps.release.outputs['pkgs/shared/common--release_created'] }}
-      package-shared-common-tag_name: ${{ steps.release.outputs['pkgs/shared/common--tag_name'] }}
       package-shared-common-json-net-released: ${{ steps.release.outputs['pkgs/shared/common-json-net--release_created'] }}
-      package-shared-common-json-net-tag_name: ${{ steps.release.outputs['pkgs/shared/common-json-net--tag_name'] }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
@@ -56,7 +46,6 @@ jobs:
       package_path: pkgs/sdk/server
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
 
   release-sdk-server-ai:
     needs: ['release-please']
@@ -66,7 +55,6 @@ jobs:
       package_path: pkgs/sdk/server-ai
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
 
   release-telemetry:
     needs: ['release-please']
@@ -76,7 +64,6 @@ jobs:
       package_path: pkgs/telemetry
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
 
   release-sdk-server-redis:
     needs: ['release-please']
@@ -86,7 +73,6 @@ jobs:
       package_path: pkgs/dotnet-server-sdk-redis
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
 
   release-sdk-server-consul:
     needs: ['release-please']
@@ -96,7 +82,6 @@ jobs:
       package_path: pkgs/dotnet-server-sdk-consul
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
 
   release-sdk-server-dynamodb:
     needs: ['release-please']
@@ -106,7 +91,6 @@ jobs:
       package_path: pkgs/dotnet-server-sdk-dynamodb
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
 
   release-shared-common:
     needs: ['release-please']
@@ -116,7 +100,6 @@ jobs:
       package_path: pkgs/shared/common
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
 
   release-shared-common-json-net:
     needs: ['release-please']
@@ -126,4 +109,3 @@ jobs:
       package_path: pkgs/shared/common-json-net
       dry_run: false
       generate_provenance: true
-      tag_name: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,78 +40,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
 
-  create-tags:
-    needs: release-please
-    if: >-
-      needs.release-please.outputs.package-sdk-client-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-ai-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-telemetry-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-redis-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-consul-released == 'true' ||
-      needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true' ||
-      needs.release-please.outputs.package-shared-common-released == 'true' ||
-      needs.release-please.outputs.package-shared-common-json-net-released == 'true'
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tags
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
-          TAG_SERVER: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
-          TAG_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
-          TAG_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
-          TAG_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
-          TAG_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
-          TAG_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
-          TAG_COMMON: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
-          TAG_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
-          RELEASED_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-released }}
-          RELEASED_SERVER: ${{ needs.release-please.outputs.package-sdk-server-released }}
-          RELEASED_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-released }}
-          RELEASED_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released }}
-          RELEASED_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-released }}
-          RELEASED_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-released }}
-          RELEASED_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released }}
-          RELEASED_COMMON: ${{ needs.release-please.outputs.package-shared-common-released }}
-          RELEASED_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-released }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          create_tag() {
-            local tag="$1"
-            local released="$2"
-            if [ "$released" = "true" ] && [ -n "$tag" ]; then
-              if gh api "repos/${{ github.repository }}/git/ref/tags/${tag}" >/dev/null 2>&1; then
-                echo "Tag ${tag} already exists, skipping creation."
-              else
-                echo "Creating tag ${tag}."
-                git tag "${tag}"
-                git push origin "${tag}"
-              fi
-            fi
-          }
-
-          create_tag "$TAG_CLIENT" "$RELEASED_CLIENT"
-          create_tag "$TAG_SERVER" "$RELEASED_SERVER"
-          create_tag "$TAG_SERVER_AI" "$RELEASED_SERVER_AI"
-          create_tag "$TAG_TELEMETRY" "$RELEASED_TELEMETRY"
-          create_tag "$TAG_REDIS" "$RELEASED_REDIS"
-          create_tag "$TAG_CONSUL" "$RELEASED_CONSUL"
-          create_tag "$TAG_DYNAMODB" "$RELEASED_DYNAMODB"
-          create_tag "$TAG_COMMON" "$RELEASED_COMMON"
-          create_tag "$TAG_COMMON_JSON_NET" "$RELEASED_COMMON_JSON_NET"
-
-  # this job calls to the release-sdk-client workflow because the client SDK has to be built on macos
   release-sdk-client:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-client-released == 'true'}}
     uses: ./.github/workflows/release-sdk-client.yml
     with:
@@ -119,7 +49,7 @@ jobs:
 
   # Server packages using the shared release workflow
   release-sdk-server:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -129,7 +59,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
 
   release-sdk-server-ai:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-ai-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -139,7 +69,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
 
   release-telemetry:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -149,7 +79,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
 
   release-sdk-server-redis:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-redis-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -159,7 +89,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
 
   release-sdk-server-consul:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-consul-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -169,7 +99,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
 
   release-sdk-server-dynamodb:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -179,7 +109,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
 
   release-shared-common:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-shared-common-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -189,7 +119,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
 
   release-shared-common-json-net:
-    needs: ['release-please', 'create-tags']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.package-shared-common-json-net-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -197,73 +127,3 @@ jobs:
       dry_run: false
       generate_provenance: true
       tag_name: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
-
-  publish-release:
-    needs:
-      - release-please
-      - release-sdk-client
-      - release-sdk-server
-      - release-sdk-server-ai
-      - release-telemetry
-      - release-sdk-server-redis
-      - release-sdk-server-consul
-      - release-sdk-server-dynamodb
-      - release-shared-common
-      - release-shared-common-json-net
-    if: always()
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    steps:
-      - name: Publish released drafts
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
-          TAG_SERVER: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
-          TAG_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
-          TAG_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
-          TAG_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
-          TAG_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
-          TAG_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
-          TAG_COMMON: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
-          TAG_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
-          RELEASED_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-released }}
-          RELEASED_SERVER: ${{ needs.release-please.outputs.package-sdk-server-released }}
-          RELEASED_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-released }}
-          RELEASED_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released }}
-          RELEASED_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-released }}
-          RELEASED_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-released }}
-          RELEASED_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released }}
-          RELEASED_COMMON: ${{ needs.release-please.outputs.package-shared-common-released }}
-          RELEASED_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-released }}
-          RESULT_CLIENT: ${{ needs.release-sdk-client.result }}
-          RESULT_SERVER: ${{ needs.release-sdk-server.result }}
-          RESULT_SERVER_AI: ${{ needs.release-sdk-server-ai.result }}
-          RESULT_TELEMETRY: ${{ needs.release-telemetry.result }}
-          RESULT_REDIS: ${{ needs.release-sdk-server-redis.result }}
-          RESULT_CONSUL: ${{ needs.release-sdk-server-consul.result }}
-          RESULT_DYNAMODB: ${{ needs.release-sdk-server-dynamodb.result }}
-          RESULT_COMMON: ${{ needs.release-shared-common.result }}
-          RESULT_COMMON_JSON_NET: ${{ needs.release-shared-common-json-net.result }}
-        run: |
-          publish_release() {
-            local tag="$1"
-            local released="$2"
-            local result="$3"
-            if [ "$released" = "true" ] && [ "$result" = "success" ] && [ -n "$tag" ]; then
-              echo "Publishing release for tag ${tag}."
-              gh release edit "$tag" \
-                --repo ${{ github.repository }} \
-                --draft=false
-            fi
-          }
-
-          publish_release "$TAG_CLIENT" "$RELEASED_CLIENT" "$RESULT_CLIENT"
-          publish_release "$TAG_SERVER" "$RELEASED_SERVER" "$RESULT_SERVER"
-          publish_release "$TAG_SERVER_AI" "$RELEASED_SERVER_AI" "$RESULT_SERVER_AI"
-          publish_release "$TAG_TELEMETRY" "$RELEASED_TELEMETRY" "$RESULT_TELEMETRY"
-          publish_release "$TAG_REDIS" "$RELEASED_REDIS" "$RESULT_REDIS"
-          publish_release "$TAG_CONSUL" "$RELEASED_CONSUL" "$RESULT_CONSUL"
-          publish_release "$TAG_DYNAMODB" "$RELEASED_DYNAMODB" "$RESULT_DYNAMODB"
-          publish_release "$TAG_COMMON" "$RELEASED_COMMON" "$RESULT_COMMON"
-          publish_release "$TAG_COMMON_JSON_NET" "$RELEASED_COMMON_JSON_NET" "$RESULT_COMMON_JSON_NET"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,31 +40,86 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
 
+  create-tags:
+    needs: release-please
+    if: >-
+      needs.release-please.outputs.package-sdk-client-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-ai-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-telemetry-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-redis-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-consul-released == 'true' ||
+      needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true' ||
+      needs.release-please.outputs.package-shared-common-released == 'true' ||
+      needs.release-please.outputs.package-shared-common-json-net-released == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
+          TAG_SERVER: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
+          TAG_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
+          TAG_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
+          TAG_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
+          TAG_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
+          TAG_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
+          TAG_COMMON: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
+          TAG_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
+          RELEASED_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-released }}
+          RELEASED_SERVER: ${{ needs.release-please.outputs.package-sdk-server-released }}
+          RELEASED_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-released }}
+          RELEASED_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released }}
+          RELEASED_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-released }}
+          RELEASED_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-released }}
+          RELEASED_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released }}
+          RELEASED_COMMON: ${{ needs.release-please.outputs.package-shared-common-released }}
+          RELEASED_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-released }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          create_tag() {
+            local tag="$1"
+            local released="$2"
+            if [ "$released" = "true" ] && [ -n "$tag" ]; then
+              if gh api "repos/${{ github.repository }}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+                echo "Tag ${tag} already exists, skipping creation."
+              else
+                echo "Creating tag ${tag}."
+                git tag "${tag}"
+                git push origin "${tag}"
+              fi
+            fi
+          }
+
+          create_tag "$TAG_CLIENT" "$RELEASED_CLIENT"
+          create_tag "$TAG_SERVER" "$RELEASED_SERVER"
+          create_tag "$TAG_SERVER_AI" "$RELEASED_SERVER_AI"
+          create_tag "$TAG_TELEMETRY" "$RELEASED_TELEMETRY"
+          create_tag "$TAG_REDIS" "$RELEASED_REDIS"
+          create_tag "$TAG_CONSUL" "$RELEASED_CONSUL"
+          create_tag "$TAG_DYNAMODB" "$RELEASED_DYNAMODB"
+          create_tag "$TAG_COMMON" "$RELEASED_COMMON"
+          create_tag "$TAG_COMMON_JSON_NET" "$RELEASED_COMMON_JSON_NET"
+
   # this job calls to the release-sdk-client workflow because the client SDK has to be built on macos
   release-sdk-client:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-client-released == 'true'}}
     uses: ./.github/workflows/release-sdk-client.yml
     with:
       dry_run: false
-    
-  # Client SDK provenance job (since it uses a different workflow)
-  release-sdk-client-provenance:
-    needs: ['release-please', 'release-sdk-client']
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: "${{ needs.release-sdk-client.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
-      provenance-name: ${{ format('LaunchDarkly.ClientSdk-{0}_provenance.intoto.jsonl', needs.release-please.outputs.package-sdk-client-tag_name) }}
 
   # Server packages using the shared release workflow
   release-sdk-server:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -74,7 +129,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
 
   release-sdk-server-ai:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-ai-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -84,7 +139,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
 
   release-telemetry:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -94,7 +149,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
 
   release-sdk-server-redis:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-redis-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -104,7 +159,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
 
   release-sdk-server-consul:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-consul-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -114,7 +169,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
 
   release-sdk-server-dynamodb:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -124,7 +179,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
 
   release-shared-common:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-shared-common-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -134,7 +189,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
 
   release-shared-common-json-net:
-    needs: release-please
+    needs: ['release-please', 'create-tags']
     if: ${{ needs.release-please.outputs.package-shared-common-json-net-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -142,3 +197,73 @@ jobs:
       dry_run: false
       generate_provenance: true
       tag_name: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
+
+  publish-release:
+    needs:
+      - release-please
+      - release-sdk-client
+      - release-sdk-server
+      - release-sdk-server-ai
+      - release-telemetry
+      - release-sdk-server-redis
+      - release-sdk-server-consul
+      - release-sdk-server-dynamodb
+      - release-shared-common
+      - release-shared-common-json-net
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Publish released drafts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-tag_name }}
+          TAG_SERVER: ${{ needs.release-please.outputs.package-sdk-server-tag_name }}
+          TAG_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-tag_name }}
+          TAG_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-tag_name }}
+          TAG_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-tag_name }}
+          TAG_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-tag_name }}
+          TAG_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-tag_name }}
+          TAG_COMMON: ${{ needs.release-please.outputs.package-shared-common-tag_name }}
+          TAG_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-tag_name }}
+          RELEASED_CLIENT: ${{ needs.release-please.outputs.package-sdk-client-released }}
+          RELEASED_SERVER: ${{ needs.release-please.outputs.package-sdk-server-released }}
+          RELEASED_SERVER_AI: ${{ needs.release-please.outputs.package-sdk-server-ai-released }}
+          RELEASED_TELEMETRY: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released }}
+          RELEASED_REDIS: ${{ needs.release-please.outputs.package-sdk-server-redis-released }}
+          RELEASED_CONSUL: ${{ needs.release-please.outputs.package-sdk-server-consul-released }}
+          RELEASED_DYNAMODB: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released }}
+          RELEASED_COMMON: ${{ needs.release-please.outputs.package-shared-common-released }}
+          RELEASED_COMMON_JSON_NET: ${{ needs.release-please.outputs.package-shared-common-json-net-released }}
+          RESULT_CLIENT: ${{ needs.release-sdk-client.result }}
+          RESULT_SERVER: ${{ needs.release-sdk-server.result }}
+          RESULT_SERVER_AI: ${{ needs.release-sdk-server-ai.result }}
+          RESULT_TELEMETRY: ${{ needs.release-telemetry.result }}
+          RESULT_REDIS: ${{ needs.release-sdk-server-redis.result }}
+          RESULT_CONSUL: ${{ needs.release-sdk-server-consul.result }}
+          RESULT_DYNAMODB: ${{ needs.release-sdk-server-dynamodb.result }}
+          RESULT_COMMON: ${{ needs.release-shared-common.result }}
+          RESULT_COMMON_JSON_NET: ${{ needs.release-shared-common-json-net.result }}
+        run: |
+          publish_release() {
+            local tag="$1"
+            local released="$2"
+            local result="$3"
+            if [ "$released" = "true" ] && [ "$result" = "success" ] && [ -n "$tag" ]; then
+              echo "Publishing release for tag ${tag}."
+              gh release edit "$tag" \
+                --repo ${{ github.repository }} \
+                --draft=false
+            fi
+          }
+
+          publish_release "$TAG_CLIENT" "$RELEASED_CLIENT" "$RESULT_CLIENT"
+          publish_release "$TAG_SERVER" "$RELEASED_SERVER" "$RESULT_SERVER"
+          publish_release "$TAG_SERVER_AI" "$RELEASED_SERVER_AI" "$RESULT_SERVER_AI"
+          publish_release "$TAG_TELEMETRY" "$RELEASED_TELEMETRY" "$RESULT_TELEMETRY"
+          publish_release "$TAG_REDIS" "$RELEASED_REDIS" "$RESULT_REDIS"
+          publish_release "$TAG_CONSUL" "$RELEASED_CONSUL" "$RESULT_CONSUL"
+          publish_release "$TAG_DYNAMODB" "$RELEASED_DYNAMODB" "$RESULT_DYNAMODB"
+          publish_release "$TAG_COMMON" "$RELEASED_COMMON" "$RESULT_COMMON"
+          publish_release "$TAG_COMMON_JSON_NET" "$RELEASED_COMMON_JSON_NET" "$RESULT_COMMON_JSON_NET"

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -13,10 +13,6 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-    outputs:
-      hashes:
-        description: sha256sum hashes of built artifacts
-        value: ${{ jobs.publish.outputs.hashes }}
 
 jobs:
 # Building is done on mac runner due to xcode build dependencies
@@ -121,8 +117,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    outputs:
-      hashes: ${{ steps.publish.outputs.hashes }}
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -159,6 +154,17 @@ jobs:
         with:
           project_file: ${{ env.PROJECT_FILE }}
           dry_run: ${{ inputs.dry_run }}
+
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.publish.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
 
       - name: Publish Documentation
         if: ${{ inputs.dry_run == 'false' }}

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -156,12 +156,14 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Generate checksums file
+        if: ${{ inputs.dry_run == 'false' }}
         env:
           HASHES: ${{ steps.publish.outputs.hashes }}
         run: |
           echo "$HASHES" | base64 -d > checksums.txt
 
       - name: Attest build provenance
+        if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -156,13 +156,13 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'
 
       - name: Publish Documentation
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: ./.github/actions/publish-docs
         with:
           workspace_path: ${{ env.WORKSPACE_PATH }}

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -155,18 +155,11 @@ jobs:
           project_file: ${{ env.PROJECT_FILE }}
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ inputs.dry_run == 'false' }}
-        env:
-          HASHES: ${{ steps.publish.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'
 
       - name: Publish Documentation
         if: ${{ inputs.dry_run == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
       - name: Attest build provenance
-        if: ${{ inputs.generate_provenance && inputs.dry_run == false }}
+        if: ${{ inputs.generate_provenance && format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,6 @@ on:
         description: 'Whether to generate provenance for this publish.'
         type: boolean
         default: true
-      tag_name:
-        description: 'The tag name to use for the provenance file'
-        type: string
-        required: true
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
       - name: Attest build provenance
-        if: ${{ inputs.generate_provenance && !inputs.dry_run }}
+        if: ${{ inputs.generate_provenance && inputs.dry_run == false }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,14 @@ jobs:
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
       - name: Generate checksums file
-        if: ${{ inputs.generate_provenance }}
+        if: ${{ inputs.generate_provenance && !inputs.dry_run }}
         env:
           HASHES: ${{ steps.full-release.outputs.hashes }}
         run: |
           echo "$HASHES" | base64 -d > checksums.txt
 
       - name: Attest build provenance
-        if: ${{ inputs.generate_provenance }}
+        if: ${{ inputs.generate_provenance && !inputs.dry_run }}
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,15 +75,8 @@ jobs:
           run_dynamodb: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-dynamodb' }}
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
-      - name: Generate checksums file
-        if: ${{ inputs.generate_provenance && !inputs.dry_run }}
-        env:
-          HASHES: ${{ steps.full-release.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.generate_provenance && !inputs.dry_run }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
       - name: Attest build provenance
-        if: ${{ inputs.generate_provenance && format('{0}', inputs.dry_run) == 'false' }}
+        if: ${{ format('{0}', inputs.generate_provenance) == 'true' && format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,7 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    outputs:
-      hashes: ${{ steps.full-release.outputs.hashes }}
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -76,16 +75,15 @@ jobs:
           run_dynamodb: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-dynamodb' }}
           run_redis: ${{ inputs.package_path == 'pkgs/dotnet-server-sdk-redis' }}
 
-  release-provenance:
-    needs: ['release']
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    if: inputs.generate_provenance
-    with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ inputs.tag_name }}
-      provenance-name: ${{ format('{0}_provenance.intoto.jsonl', inputs.tag_name) }}
+      - name: Generate checksums file
+        if: ${{ inputs.generate_provenance }}
+        env:
+          HASHES: ${{ steps.full-release.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ inputs.generate_provenance }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,61 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below. This repository contains multiple packages; the example below uses the Server SDK as a reference.
+
+```
+# Set the version of the SDK to verify
+SDK_VERSION=8.11.1
+```
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.${SDK_VERSION}/LaunchDarkly.ServerSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.8.11.1.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+The same verification process applies to all packages published from this repository:
+
+| Package | NuGet Name |
+|---------|-----------|
+| Server SDK | `LaunchDarkly.ServerSdk` |
+| Server SDK AI | `LaunchDarkly.ServerSdk.Ai` |
+| Client SDK | `LaunchDarkly.ClientSdk` |
+| Common SDK | `LaunchDarkly.CommonSdk` |
+| Common SDK JsonNet | `LaunchDarkly.CommonSdk.JsonNet` |
+| Server SDK Telemetry | `LaunchDarkly.ServerSdk.Telemetry` |
+| Server SDK Consul | `LaunchDarkly.ServerSdk.Consul` |
+| Server SDK DynamoDB | `LaunchDarkly.ServerSdk.DynamoDB` |
+| Server SDK Redis | `LaunchDarkly.ServerSdk.Redis` |
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ We run integration tests for all our SDKs using a centralized test harness. This
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this repository.
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We encourage pull requests and other contributions from the community. Check out
 
 ## Verifying build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. Each package in this repository contains its own provenance guide with verification instructions.
 
 ## About LaunchDarkly
  

--- a/pkgs/dotnet-server-sdk-consul/PROVENANCE.md
+++ b/pkgs/dotnet-server-sdk-consul/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=5.0.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk.Consul -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.Consul.${SDK_VERSION}/LaunchDarkly.ServerSdk.Consul.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.Consul.5.0.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/dotnet-server-sdk-consul/README.md
+++ b/pkgs/dotnet-server-sdk-consul/README.md
@@ -31,6 +31,11 @@ The published version of this assembly is digitally signed with Authenticode and
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/dotnet-server-sdk-dynamodb/PROVENANCE.md
+++ b/pkgs/dotnet-server-sdk-dynamodb/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=5.0.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk.DynamoDB -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.DynamoDB.${SDK_VERSION}/LaunchDarkly.ServerSdk.DynamoDB.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.DynamoDB.5.0.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/dotnet-server-sdk-dynamodb/README.md
+++ b/pkgs/dotnet-server-sdk-dynamodb/README.md
@@ -45,6 +45,11 @@ The published version of this assembly is digitally signed with Authenticode and
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/dotnet-server-sdk-redis/PROVENANCE.md
+++ b/pkgs/dotnet-server-sdk-redis/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=5.1.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk.Redis -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.Redis.${SDK_VERSION}/LaunchDarkly.ServerSdk.Redis.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.Redis.5.1.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/dotnet-server-sdk-redis/README.md
+++ b/pkgs/dotnet-server-sdk-redis/README.md
@@ -33,6 +33,11 @@ Building the code locally in the default Debug configuration does not sign the a
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/sdk/client/PROVENANCE.md
+++ b/pkgs/sdk/client/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=5.7.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ClientSdk -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ClientSdk.${SDK_VERSION}/LaunchDarkly.ClientSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ClientSdk.5.7.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/sdk/client/README.md
+++ b/pkgs/sdk/client/README.md
@@ -48,6 +48,11 @@ We run integration tests for all our SDKs using a centralized test harness. This
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/sdk/server-ai/PROVENANCE.md
+++ b/pkgs/sdk/server-ai/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=0.9.3
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk.Ai -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.Ai.${SDK_VERSION}/LaunchDarkly.ServerSdk.Ai.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.Ai.0.9.3.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/sdk/server-ai/README.md
+++ b/pkgs/sdk/server-ai/README.md
@@ -61,6 +61,11 @@ The authoritative description of all types, properties, and methods is in the [g
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/sdk/server/PROVENANCE.md
+++ b/pkgs/sdk/server/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=8.11.1
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.${SDK_VERSION}/LaunchDarkly.ServerSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.8.11.1.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/sdk/server/README.md
+++ b/pkgs/sdk/server/README.md
@@ -58,6 +58,11 @@ We run integration tests for all our SDKs using a centralized test harness. This
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/shared/common-json-net/PROVENANCE.md
+++ b/pkgs/shared/common-json-net/PROVENANCE.md
@@ -1,28 +1,30 @@
-## Verifying SDK build provenance with GitHub artifact attestations
+## Verifying build provenance with GitHub artifact attestations
 
 LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
 LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
 
-To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below. This repository contains multiple packages; the example below uses the Server SDK as a reference.
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
 
+<!-- x-release-please-start-version -->
 ```
 # Set the version of the SDK to verify
-SDK_VERSION=8.11.1
+SDK_VERSION=7.0.2
 ```
+<!-- x-release-please-end -->
 
 ```
 # Download the nupkg from NuGet
-$ nuget install LaunchDarkly.ServerSdk -Version $SDK_VERSION -OutputDirectory ./packages
+$ nuget install LaunchDarkly.CommonSdk.JsonNet -Version $SDK_VERSION -OutputDirectory ./packages
 
 # Verify provenance using the GitHub CLI
-$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.${SDK_VERSION}/LaunchDarkly.ServerSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+$ gh attestation verify ./packages/LaunchDarkly.CommonSdk.JsonNet.${SDK_VERSION}/LaunchDarkly.CommonSdk.JsonNet.${SDK_VERSION}.nupkg --owner launchdarkly
 ```
 
 Below is a sample of expected output.
 
 ```
-Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.8.11.1.nupkg
+Loaded digest sha256:... for file://LaunchDarkly.CommonSdk.JsonNet.7.0.2.nupkg
 Loaded 1 attestation from GitHub API
 
 The following policy criteria will be enforced:
@@ -41,20 +43,6 @@ The following 1 attestation matched the policy criteria
   - Signer repo:.... launchdarkly/dotnet-core
   - Signer workflow: .github/workflows/release-please.yml
 ```
-
-The same verification process applies to all packages published from this repository:
-
-| Package | NuGet Name |
-|---------|-----------|
-| Server SDK | `LaunchDarkly.ServerSdk` |
-| Server SDK AI | `LaunchDarkly.ServerSdk.Ai` |
-| Client SDK | `LaunchDarkly.ClientSdk` |
-| Common SDK | `LaunchDarkly.CommonSdk` |
-| Common SDK JsonNet | `LaunchDarkly.CommonSdk.JsonNet` |
-| Server SDK Telemetry | `LaunchDarkly.ServerSdk.Telemetry` |
-| Server SDK Consul | `LaunchDarkly.ServerSdk.Consul` |
-| Server SDK DynamoDB | `LaunchDarkly.ServerSdk.DynamoDB` |
-| Server SDK Redis | `LaunchDarkly.ServerSdk.Redis` |
 
 For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
 

--- a/pkgs/shared/common-json-net/README.md
+++ b/pkgs/shared/common-json-net/README.md
@@ -32,3 +32,8 @@ It is always possible to encode or decode these types explicitly using the `Laun
 ```csharp
     JsonConvert.DefaultSettings = () => settings;
 ```
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+

--- a/pkgs/shared/common/PROVENANCE.md
+++ b/pkgs/shared/common/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=7.1.1
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.CommonSdk -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.CommonSdk.${SDK_VERSION}/LaunchDarkly.CommonSdk.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.CommonSdk.7.1.1.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/pkgs/shared/common/README.md
+++ b/pkgs/shared/common/README.md
@@ -24,6 +24,11 @@ d4b4320e820f32e024ad50a786f86d37ea45e0c25ec431a7a0f3e93575a0d2ad
 Public Key Token: 45ef1738a929a7df
 ```
 
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
 
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/pkgs/telemetry/PROVENANCE.md
+++ b/pkgs/telemetry/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying this package is included below.
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=1.4.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.ServerSdk.Telemetry -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.ServerSdk.Telemetry.${SDK_VERSION}/LaunchDarkly.ServerSdk.Telemetry.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.ServerSdk.Telemetry.1.4.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-core
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-core
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
     "pkgs/dotnet-server-sdk-consul": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Consul",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Consul.csproj"
       ]
@@ -14,7 +13,6 @@
     "pkgs/dotnet-server-sdk-dynamodb": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.DynamoDB",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.DynamoDB.csproj"
       ]
@@ -22,7 +20,6 @@
     "pkgs/dotnet-server-sdk-redis": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Redis",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Redis.csproj"
       ]
@@ -30,7 +27,6 @@
     "pkgs/sdk/server": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.csproj"
       ]
@@ -39,7 +35,6 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Ai",
       "bump-minor-pre-major": true,
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj",
         "src/SdkInfo.cs"
@@ -48,7 +43,6 @@
     "pkgs/sdk/client": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ClientSdk",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ClientSdk.csproj"
       ]
@@ -56,7 +50,6 @@
     "pkgs/telemetry": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Telemetry",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Telemetry.csproj"
       ]
@@ -64,7 +57,6 @@
     "pkgs/shared/common": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.csproj"
       ]
@@ -72,7 +64,6 @@
     "pkgs/shared/common-json-net": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk.JsonNet",
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.JsonNet.csproj"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
     "pkgs/dotnet-server-sdk-consul": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Consul",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Consul.csproj"
@@ -15,7 +14,6 @@
     "pkgs/dotnet-server-sdk-dynamodb": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.DynamoDB",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.DynamoDB.csproj"
@@ -24,7 +22,6 @@
     "pkgs/dotnet-server-sdk-redis": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Redis",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Redis.csproj"
@@ -33,7 +30,6 @@
     "pkgs/sdk/server": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.csproj"
@@ -43,7 +39,6 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Ai",
       "bump-minor-pre-major": true,
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj",
@@ -53,7 +48,6 @@
     "pkgs/sdk/client": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ClientSdk",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ClientSdk.csproj"
@@ -62,7 +56,6 @@
     "pkgs/telemetry": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Telemetry",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Telemetry.csproj"
@@ -71,7 +64,6 @@
     "pkgs/shared/common": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.csproj"
@@ -80,7 +72,6 @@
     "pkgs/shared/common-json-net": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk.JsonNet",
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.JsonNet.csproj"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     "pkgs/dotnet-server-sdk-consul": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Consul",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Consul.csproj"
       ]
@@ -13,6 +14,7 @@
     "pkgs/dotnet-server-sdk-dynamodb": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.DynamoDB",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.DynamoDB.csproj"
       ]
@@ -20,6 +22,7 @@
     "pkgs/dotnet-server-sdk-redis": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Redis",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Redis.csproj"
       ]
@@ -27,6 +30,7 @@
     "pkgs/sdk/server": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.csproj"
       ]
@@ -35,6 +39,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Ai",
       "bump-minor-pre-major": true,
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj",
         "src/SdkInfo.cs"
@@ -43,6 +48,7 @@
     "pkgs/sdk/client":{
       "release-type": "simple",
       "package-name": "LaunchDarkly.ClientSdk",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ClientSdk.csproj"
       ]
@@ -50,6 +56,7 @@
     "pkgs/telemetry": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Telemetry",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Telemetry.csproj"
       ]
@@ -57,6 +64,7 @@
     "pkgs/shared/common": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.csproj"
       ]
@@ -64,6 +72,7 @@
     "pkgs/shared/common-json-net": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk.JsonNet",
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.JsonNet.csproj"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,28 +7,32 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Consul",
       "extra-files": [
-        "src/LaunchDarkly.ServerSdk.Consul.csproj"
+        "src/LaunchDarkly.ServerSdk.Consul.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/dotnet-server-sdk-dynamodb": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.DynamoDB",
       "extra-files": [
-        "src/LaunchDarkly.ServerSdk.DynamoDB.csproj"
+        "src/LaunchDarkly.ServerSdk.DynamoDB.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/dotnet-server-sdk-redis": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Redis",
       "extra-files": [
-        "src/LaunchDarkly.ServerSdk.Redis.csproj"
+        "src/LaunchDarkly.ServerSdk.Redis.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/sdk/server": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk",
       "extra-files": [
-        "src/LaunchDarkly.ServerSdk.csproj"
+        "src/LaunchDarkly.ServerSdk.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/sdk/server-ai": {
@@ -37,35 +41,40 @@
       "bump-minor-pre-major": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj",
-        "src/SdkInfo.cs"
+        "src/SdkInfo.cs",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/sdk/client": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ClientSdk",
       "extra-files": [
-        "src/LaunchDarkly.ClientSdk.csproj"
+        "src/LaunchDarkly.ClientSdk.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/telemetry": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Telemetry",
       "extra-files": [
-        "src/LaunchDarkly.ServerSdk.Telemetry.csproj"
+        "src/LaunchDarkly.ServerSdk.Telemetry.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/shared/common": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk",
       "extra-files": [
-        "src/LaunchDarkly.CommonSdk.csproj"
+        "src/LaunchDarkly.CommonSdk.csproj",
+        "PROVENANCE.md"
       ]
     },
     "pkgs/shared/common-json-net": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk.JsonNet",
       "extra-files": [
-        "src/LaunchDarkly.CommonSdk.JsonNet.csproj"
+        "src/LaunchDarkly.CommonSdk.JsonNet.csproj",
+        "PROVENANCE.md"
       ]
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Consul",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Consul.csproj"
       ]
@@ -15,6 +16,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.DynamoDB",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.DynamoDB.csproj"
       ]
@@ -23,6 +25,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Redis",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Redis.csproj"
       ]
@@ -31,6 +34,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.csproj"
       ]
@@ -40,15 +44,17 @@
       "package-name": "LaunchDarkly.ServerSdk.Ai",
       "bump-minor-pre-major": true,
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Ai.csproj",
         "src/SdkInfo.cs"
       ]
     },
-    "pkgs/sdk/client":{
+    "pkgs/sdk/client": {
       "release-type": "simple",
       "package-name": "LaunchDarkly.ClientSdk",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ClientSdk.csproj"
       ]
@@ -57,6 +63,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.ServerSdk.Telemetry",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.ServerSdk.Telemetry.csproj"
       ]
@@ -65,6 +72,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.csproj"
       ]
@@ -73,6 +81,7 @@
       "release-type": "simple",
       "package-name": "LaunchDarkly.CommonSdk.JsonNet",
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.CommonSdk.JsonNet.csproj"
       ]


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only changes (plus new documentation), no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Reference implementation: `launchdarkly/ld-relay` (branch `v8`).

**Describe the solution you've provided**

GitHub's immutable releases feature prevents modifying a release after it is published. The old SLSA provenance generator (`slsa-framework/slsa-github-generator`) uploaded `.intoto.jsonl` files as release assets via `upload-assets: true`, which would fail under immutable releases. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API rather than as release assets, so the release can be published directly by release-please.

**SLSA → `actions/attest@v4` with `subject-path`** — Replaced the separate `release-provenance` job in `release.yml` and the `release-sdk-client-provenance` job in `release-please.yml` with inline `actions/attest@v4` steps. Attestation uses `subject-path: 'nupkgs/*'` to reference the built `.nupkg` and `.snupkg` files directly on disk, eliminating the previous base64 encode/decode round-trip through `subject-checksums` entirely. The `hashes` output and "Hash nuget packages" step have been removed from both composite actions (`publish-package/action.yml` and `full-release/action.yml`), and the "Generate checksums file" workflow steps have been removed. Added `attestations: write` permission to the `publish` and `release` jobs.

**Dead `tag_name` outputs removed** — Removed 9 package-specific `tag_name` outputs and the plain `tag_name` output from the `release-please` job in `release-please.yml`, and removed the `tag_name` input from `release.yml`. These were only consumed by the now-deleted SLSA provenance jobs.

**`dry_run` and `generate_provenance` conditions use `format()` for type safety** — All `dry_run` condition checks now use `format('{0}', inputs.dry_run) == 'false'` instead of direct comparison, and the `generate_provenance` gate uses `format('{0}', inputs.generate_provenance) == 'true'`. This ensures correct behavior regardless of whether the input arrives as a boolean (`workflow_call`) or a string (`workflow_dispatch`). The `format()` function stringifies the value before comparison, avoiding GitHub Actions' silent type coercion pitfalls.

**Documentation** — Added per-package `PROVENANCE.md` files with instructions for verifying build provenance using `gh attestation verify`, including sample verification commands and expected output. Added a "Verifying build provenance with the SLSA framework" section to `README.md` and per-package `README.md` files linking to the relevant `PROVENANCE.md`. Registered `PROVENANCE.md` as an `extra-files` entry in `release-please-config.json` so the version placeholder stays in sync with releases.

Additional minor cleanup: normalized `needs` from bare strings to array syntax in `release-please.yml`, fixed whitespace on the `pkgs/sdk/client` key in `release-please-config.json`.

### Updates since last revision

- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release` with inline tag creation) that was briefly added. This pattern is only needed for repos that upload artifacts to releases (which require draft releases). Since this repo is attestation-only, standard single-pass release-please is correct.

**Describe alternatives you've considered**

- **`subject-checksums` with base64 round-trip**: An earlier revision decoded base64-encoded hashes from the composite actions into a checksums file for `actions/attest`. This worked but was unnecessarily complex — the artifact files are already on disk in the same job, so `subject-path` lets `actions/attest@v4` compute checksums directly.
- **Draft release pattern**: An earlier revision used draft releases with `create-tags` and `publish-release` jobs to un-draft after completion. This was simplified since this repo only uses attestation (not artifact uploads), making draft releases unnecessary.
- **Split release-please pattern**: An earlier revision ran release-please in two passes (releases first, then PRs) with inline tag creation. This is needed for repos with artifact uploads that require draft releases, but is unnecessary overhead for attestation-only repos.
- **Keep SLSA generator**: Could keep the separate reusable workflow jobs, but `actions/attest@v4` is the org-standard replacement and runs inline without requiring extra jobs.
- **Direct boolean comparison for `dry_run`**: `inputs.dry_run == false` works for `workflow_call` but silently fails for `workflow_dispatch` (where booleans arrive as strings). `format('{0}', ...)` stringifies the value first, making the comparison safe for both trigger types.

**Additional context**

### Human review checklist

1. **`subject-path: 'nupkgs/*'` glob correctness** — The composite actions run `dotnet pack --output nupkgs`, producing `.nupkg` and `.snupkg` files. Verify this glob resolves correctly from the workflow's working directory (the repo root). If the path is wrong, attestation will silently produce no subjects.

2. **`hashes` / `tag_name` outputs fully removed** — The `hashes` output was removed from both composite actions, and 10 `tag_name` outputs were removed from `release-please.yml`. The `tag_name` input was removed from `release.yml`. The only consumers were the now-deleted SLSA provenance jobs. Confirm no other callers of these reusable workflows depend on these outputs/inputs.

3. **`format('{0}', ...)` pattern consistency** — Verify this pattern is used consistently for all boolean input comparisons across `release.yml` (`dry_run` and `generate_provenance`), `release-sdk-client.yml` (`dry_run`), and the `Publish Documentation` step.

4. **`actions/attest@v4` on macOS** — The client SDK publish job (`release-sdk-client.yml`) runs on `macos-latest`. The attest step should work (JS-based action) but has not been runtime-tested on macOS.

5. **`generate_provenance` gate in `release.yml`** — The new attest step is gated on `format('{0}', inputs.generate_provenance) == 'true' && format('{0}', inputs.dry_run) == 'false'`, matching the old `release-provenance` job's condition plus the dry-run guard. Verify all callers pass this input correctly.

6. **`PROVENANCE.md` accuracy** — Each per-package `PROVENANCE.md` uses `x-release-please-start-version` markers so the version stays in sync. Verify the NuGet package names in the verification commands match the actual published package names.

7. **No `.intoto.jsonl` release assets going forward** — The old SLSA generator uploaded provenance files as release assets. These will no longer be produced. Confirm no downstream tooling or verification processes depend on those specific assets being present on the GitHub release.

8. **No runtime test possible** — These workflow changes can only be fully validated by an actual release run. YAML syntax has been validated.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84