### PR TITLE
chore: Add permissions to release jobs in workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,9 @@ jobs:
 
   release-sdk-client:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-client-released == 'true'}}
     uses: ./.github/workflows/release-sdk-client.yml
     with:
@@ -40,6 +43,9 @@ jobs:
   # Server packages using the shared release workflow
   release-sdk-server:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -49,6 +55,9 @@ jobs:
 
   release-sdk-server-ai:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-ai-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -58,6 +67,9 @@ jobs:
 
   release-telemetry:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -67,6 +79,9 @@ jobs:
 
   release-sdk-server-redis:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-redis-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -85,6 +100,9 @@ jobs:
 
   release-sdk-server-dynamodb:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -94,6 +112,9 @@ jobs:
 
   release-shared-common:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-shared-common-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -103,6 +124,9 @@ jobs:
 
   release-shared-common-json-net:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-shared-common-json-net-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,6 +91,9 @@ jobs:
 
   release-sdk-server-consul:
     needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.package-sdk-server-consul-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-client-released == 'true'}}
     uses: ./.github/workflows/release-sdk-client.yml
     with:
@@ -46,6 +47,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -58,6 +60,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-ai-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -70,6 +73,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-telemetry-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -82,6 +86,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-redis-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -94,6 +99,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-consul-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -106,6 +112,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-sdk-server-dynamodb-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -118,6 +125,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-shared-common-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:
@@ -130,6 +138,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     if: ${{ needs.release-please.outputs.package-shared-common-json-net-released == 'true'}}
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      pull-requests: write
       attestations: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions job permissions for release/publish workflows; misconfiguration could break publishing or provenance attestation. Also alters token scopes for sensitive release jobs, so reviewers should verify the required permissions are still correct and not overly broad.
> 
> **Overview**
> **Release workflows now declare explicit permissions for publishing and provenance.** `release-please.yml` adds `permissions` to each package release job (`id-token: write`, `contents: write`, `attestations: write`) to support OIDC-based publishing and build provenance attestation.
> 
> **Tightens the shared release workflow token scope.** `.github/workflows/release.yml` removes `pull-requests: write` from the `release` job permissions, leaving only the permissions needed to publish and attest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c82dd6d5b672f3b61d11430e683baabce4b2211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->