### PR TITLE
chore: Update publish-pages action to version 1.0.3

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.1
+    - uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.3
       name: 'Publish to Github pages'
       with:
         docs_path: ${{ inputs.workspace_path }}/docs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pins the docs publishing workflow to a newer patch version of an external GitHub Action; behavioral changes depend on that action but scope is limited to CI docs deployment.
> 
> **Overview**
> Updates the internal `publish-docs` composite action to use `launchdarkly/gh-actions/actions/publish-pages` **v1.0.3** instead of **v1.0.1** when publishing documentation to GitHub Pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7f100b4df17af640f965245a4dd13765492c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->