### PR TITLE
feat: Make Status ToString() methods format consistent 

### DIFF
--- a/pkgs/sdk/server/src/Interfaces/BigSegmentStoreStatus.cs
+++ b/pkgs/sdk/server/src/Interfaces/BigSegmentStoreStatus.cs
@@ -40,6 +40,6 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
 
         /// <inheritdoc/>
         public override string ToString() =>
-            string.Format("(Available={0},Stale={1})", Available, Stale);
+            string.Format("BigSegmentStoreStatus(Available={0},Stale={1})", Available, Stale);
     }
 }

--- a/pkgs/sdk/server/src/Interfaces/DataSourceStatus.cs
+++ b/pkgs/sdk/server/src/Interfaces/DataSourceStatus.cs
@@ -49,7 +49,7 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
 
         /// <inheritdoc/>
         public override string ToString() =>
-            string.Format("DataSourceStatus({0},{1},{2})", State, StateSince, LastError);
+            string.Format("DataSourceStatus(State={0},StateSince={1},LastError={2})", State, StateSince, LastError);
 
         /// <summary>
         /// A description of an error condition that the data source encountered.
@@ -127,7 +127,7 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
                 s.Append(Kind.Identifier());
                 if (StatusCode > 0 || !string.IsNullOrEmpty(Message))
                 {
-                    s.Append("(");
+                    s.Append('(');
                     if (StatusCode > 0)
                     {
                         s.Append(StatusCode);
@@ -136,13 +136,13 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
                     {
                         if (StatusCode > 0)
                         {
-                            s.Append(",");
+                            s.Append(',');
                         }
                         s.Append(Message);
                     }
-                    s.Append(")");
+                    s.Append(')');
                 }
-                s.Append("@");
+                s.Append('@');
                 s.Append(Time);
                 return s.ToString();
             }

--- a/pkgs/sdk/server/src/Interfaces/DataStoreStatus.cs
+++ b/pkgs/sdk/server/src/Interfaces/DataStoreStatus.cs
@@ -29,6 +29,6 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
 
         /// <inheritdoc/>
         public override string ToString() =>
-            string.Format("DataStoreStatus({0},{1})", Available, RefreshNeeded);
+            string.Format("DataStoreStatus(Available={0},RefreshNeeded={1})", Available, RefreshNeeded);
     }
 }


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

~Provide links to any issues in this repository or elsewhere relating to this pull request.~

N/A

**Describe the solution you've provided**

The different `Status` structs that expose internal state of the client have different formatted when string-ified. If the state is logged or otherwise serialised as a string it is not possible to determine what the values mean without understanding the underlying types. This change aligns 3 status `ToString()` methods to follow a consistent format, including labelling for the different fields exposed.

---

The BigSegmentStoreStatus struct returns data in the format `(Available={0},Stale{1)} ` injecting the fields in allowing the type to be easily string-ified.

DataSourceStatus and DataStoreStatus only output a string of the internal fields without labels, making decoding the results difficult without understanding the details of these types.

e.g. 
`DataStoreStatus(True,False)`
`DataSourceStatus(Initializing,4/10/2026 10:42:08 PM,)`
or
` DataSourceStatus(Initializing,4/10/2026 10:42:08 PM,UNKNOWN(Connection refused (localhost:5279))@4/10/2026 10:42:18 PM)` when errors are present.

`DataSourceStatus` is reasonably understandable as is, however `DataStoreStatus` is not.

This change adds in the labelling of fields so they can be clearly understood when using the default ToString() implementation.

BigSegmentStoreStatus has also been updated to include its type name like the other two status providers. Now all follow the pattern set by the other two providers: `Type(Field=Value,Field2=Value...)`.

`(Available=False,Stale=False)`
to
`BigSegmentStatus(Available=False,Stale=False)`

Also include minor changes to `ErrorInfo`'s `ToString()` method to utilise character append overloads for single characters rather than string variation as it is a cheaper call.

**Describe alternatives you've considered**

I considered applying this logic to `ErrorInfo`'s `ToString()`, however the output of that is fairly clear and can be understood without additional labels.

**Additional context**

Test coverage was ignored as no existing tests exist for these methods, and they are not utilised by the SDK itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects `ToString()` output (logging/diagnostics), with minimal behavioral risk beyond potentially breaking code/tests that assert exact string formats.
> 
> **Overview**
> Makes the string representations of status structs consistent and self-describing by updating `ToString()` in `BigSegmentStoreStatus`, `DataSourceStatus`, and `DataStoreStatus` to include the type name and `Field=Value` labels.
> 
> Also makes a small micro-optimization in `DataSourceStatus.ErrorInfo.ToString()` by using `StringBuilder.Append(char)` for single-character separators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1df38212aefad3070145e0aa0096d2b19a98d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->