### PR TITLE
feat: Support System.Diagnostics.DiagnosticSource version 10.*

### DIFF
--- a/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
+++ b/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
@@ -54,7 +54,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
     <!-- Use any 5.x to 8.x.  It's a built-in package in net8.0, hence conditional for targets -->
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[5,10)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[5,11)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

Closes #253 

**Describe the solution you've provided**

Raised the upper version range limit on `System.Diagnostics.DiagnosticSource` to 11 instead of 10

**Describe alternatives you've considered**

Considered to completely remove the upper limit, but decided for the upper limit raise as done in an earlier pull request (#149) to support version 9x of the same library.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-range change limited to the telemetry package project file; main risk is unexpected compatibility issues when consumers resolve newer `DiagnosticSource` versions.
> 
> **Overview**
> Updates `LaunchDarkly.ServerSdk.Telemetry.csproj` to widen the `System.Diagnostics.DiagnosticSource` dependency upper bound from `<10` to `<11` for `netstandard2.0`/`net462`, enabling compatibility with `10.x` versions (while keeping `net8.0` relying on the built-in package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3836100b3a38846e8db217bf806596c51f9c0599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->