### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`. The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` now declares `pull-requests: read` at the job level (via launchdarkly/gh-actions#86). A reusable workflow can only request a subset of the caller's granted permissions, so without an explicit `permissions` block here, the called job fails to start (`startup_failure`).

Same fix as launchdarkly/sdk-meta#429, applied across SDK repositories.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` check on this PR exits `success` rather than `startup_failure`

### Notes

- `launchdarkly/php-server-sdk-otel` could not be updated due to a push permission issue (403) and will need to be fixed separately.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow permission tweak; it only expands the action’s read access to PR metadata and doesn’t affect application code or deployments.
> 
> **Overview**
> Ensures the `Lint PR title` reusable workflow can run by explicitly granting **workflow-level** `permissions: pull-requests: read` in `.github/workflows/lint-pr-title.yml`, avoiding `startup_failure` when the called workflow requests PR read access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484a4bff01ba7b61487c7c5370f4bc8bab716d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->