### PR TITLE
chore: remove FDv2 pre-release warnings for GA promotion

### DIFF
--- a/pkgs/sdk/server/src/Configuration.cs
+++ b/pkgs/sdk/server/src/Configuration.cs
@@ -119,10 +119,6 @@ namespace LaunchDarkly.Sdk.Server
         
         /// <summary>
         /// Contains the data system configuration.
-        /// <para>
-        /// This property is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-        /// </para>
         /// </summary>
         public DataSystemBuilder DataSystem { get; }
 

--- a/pkgs/sdk/server/src/ConfigurationBuilder.cs
+++ b/pkgs/sdk/server/src/ConfigurationBuilder.cs
@@ -405,10 +405,6 @@ namespace LaunchDarkly.Sdk.Server
 
         /// <summary>
         /// Configure the data system.
-        /// <para>
-        /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-        /// </para>
         /// </summary>
         /// <remarks>
         /// <example>

--- a/pkgs/sdk/server/src/Integrations/DataSystemBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemBuilder.cs
@@ -6,10 +6,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
     /// Configuration builder for the SDK's data acquisition and storage strategy.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     public sealed class DataSystemBuilder
     {

--- a/pkgs/sdk/server/src/Integrations/DataSystemComponents.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemComponents.cs
@@ -5,10 +5,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
     /// Components for use with the data system.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     public static class DataSystemComponents
     {

--- a/pkgs/sdk/server/src/Integrations/DataSystemModes.cs
+++ b/pkgs/sdk/server/src/Integrations/DataSystemModes.cs
@@ -4,10 +4,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
     /// A set of different data system modes which provided pre-configured <see cref="DataSystemBuilder"/>s.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     public sealed class DataSystemModes
     {

--- a/pkgs/sdk/server/src/Integrations/FDv2PollingDataSourceBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/FDv2PollingDataSourceBuilder.cs
@@ -9,10 +9,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
     /// Contains methods for configuring the polling data source.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     /// <example>
     /// <code>

--- a/pkgs/sdk/server/src/Integrations/FDv2StreamingDataSourceBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/FDv2StreamingDataSourceBuilder.cs
@@ -9,10 +9,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 {
     /// <summary>
     /// Contains methods for configuring the streaming data source.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     /// <example>
     /// <code>

--- a/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
+++ b/pkgs/sdk/server/src/Subsystems/DataStoreTypes.cs
@@ -383,10 +383,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
 
         /// <summary>
         /// Enumeration that indicates if this change is a full or partial change.
-        /// <para>
-        /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-        /// </para>
         /// </summary>
         public enum ChangeSetType
         {
@@ -408,10 +404,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
 
         /// <summary>
         /// Represents a set of changes to apply to a store.
-        /// <para>
-        /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-        /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-        /// </para>
         /// </summary>
         public struct ChangeSet<TItemDescriptor>
         {

--- a/pkgs/sdk/server/src/Subsystems/DataSystemConfiguration.cs
+++ b/pkgs/sdk/server/src/Subsystems/DataSystemConfiguration.cs
@@ -4,10 +4,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
 {
     /// <summary>
     /// Configuration for the SDK's data acquisition and storage strategy.
-    /// <para>
-    /// This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     public sealed class DataSystemConfiguration
     {

--- a/pkgs/sdk/server/src/Subsystems/ITransactionalDataSourceUpdates.cs
+++ b/pkgs/sdk/server/src/Subsystems/ITransactionalDataSourceUpdates.cs
@@ -15,10 +15,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// interface in the <see cref="LdClientContext.DataSourceUpdates"/> property of <see cref="LdClientContext"/>.
     /// </para>
     /// </remarks>
-    /// <para>
-    /// This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     public interface ITransactionalDataSourceUpdates
     {
         /// <summary>

--- a/pkgs/sdk/server/src/Subsystems/ITransactionalDataStore.cs
+++ b/pkgs/sdk/server/src/Subsystems/ITransactionalDataStore.cs
@@ -17,10 +17,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
     /// </remarks>
     /// <seealso cref="IPersistentDataStore"/>
     /// <seealso cref="IPersistentDataStoreAsync"/>
-    /// <para>
-    /// This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     public interface ITransactionalDataStore
     {
         /// <summary>

--- a/pkgs/sdk/server/src/Subsystems/Selector.cs
+++ b/pkgs/sdk/server/src/Subsystems/Selector.cs
@@ -2,10 +2,6 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
 {
     /// <summary>
     /// A selector can either be empty or it can contain state and a version.
-    /// <para>
-    /// This struct is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    /// It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    /// </para>
     /// </summary>
     public struct Selector
     {


### PR DESCRIPTION
## Summary

- FDv2 / data-saving mode is going GA per the [SDK Release Standards spec](https://github.com/launchdarkly/sdk-specs/tree/main/specs/RELEASE-sdk-release-standards). GA-stage features must not carry experimental / pre-release warning prose in their public API surface.
- Removes the `<para>...</para>` warning blocks ("not stable, and not subject to any backwards compatibility guarantees", "in early access. Please join the EAP") from XML doc comments on FDv2-related types in `pkgs/sdk/server/src/`. Descriptive `<summary>` and other XML doc tags are preserved.

Tracking: [SDK-2349](https://launchdarkly.atlassian.net/browse/SDK-2349)

## Test plan

- [ ] CI green (`dotnet build` not run locally -- CLI unavailable in cleanup environment; XML doc structure spot-checked)

[SDK-2349]: https://launchdarkly.atlassian.net/browse/SDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-comment-only changes that remove early-access/unstable warnings from FDv2/data system related types; no runtime behavior or API signatures change.
> 
> **Overview**
> Removes the *early-access/unstable* warning `<para>` blocks from XML documentation on FDv2/data system-related public types (e.g., `Configuration.DataSystem`, `ConfigurationBuilder.DataSystem`, `DataSystemBuilder`/`DataSystemComponents`/`DataSystemModes`, FDv2 data source builders, and related subsystem types like `Selector` and `DataStoreTypes.ChangeSet`).
> 
> Keeps the existing summaries/examples/remarks intact while promoting these docs to GA-level wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7511b3ed2c139e0cd0a56b3804365a72c6b47299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->