### PR TITLE
feat: add X-LaunchDarkly-Instance-Id header (SDK-2351)

### DIFF
--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -39,7 +39,8 @@ namespace TestService
             "anonymous-redaction",
             "evaluation-hooks",
             "client-prereq-events",
-            "fdv1-fallback"
+            "fdv1-fallback",
+            "instance-id"
         };
 
         public readonly Handler Handler;

--- a/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
@@ -64,11 +64,6 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         internal string _wrapperName = null;
         internal string _wrapperVersion = null;
 
-        // Generated once when the builder is constructed so that Build() and DescribeConfiguration()
-        // -- which both call MakeHttpProperties on the same builder -- agree on the value sent in
-        // HTTP headers and reported in diagnostic events. Guid.NewGuid() produces a v4 UUID.
-        private readonly string _instanceId = Guid.NewGuid().ToString();
-
         /// <summary>
         /// Sets the network connection timeout.
         /// </summary>
@@ -268,8 +263,14 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 .WithReadTimeout(_readTimeout)
                 .WithUserAgent("DotNetClient/" + AssemblyVersions.GetAssemblyVersionStringForType(typeof(LdClient)))
                 .WithApplicationTags(context.ApplicationInfo)
-                .WithWrapper(wrapperName, wrapperVersion)
-                .WithHeader(InstanceIdHeader, _instanceId);
+                .WithWrapper(wrapperName, wrapperVersion);
+
+            // The instance id originates on LdClientContext (generated once per LDClient), so
+            // every subsystem built from the same context emits a consistent value.
+            if (!string.IsNullOrEmpty(context.InstanceId))
+            {
+                httpProperties = httpProperties.WithHeader(InstanceIdHeader, context.InstanceId);
+            }
 
             // For consistency with other SDKs, custom headers are allowed to overwrite headers
             // such as User-Agent, Authorization, and the instance id.

--- a/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
@@ -34,6 +34,16 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     public sealed class HttpConfigurationBuilder : IComponentConfigurer<HttpConfiguration>, IDiagnosticDescription
     {
         /// <summary>
+        /// The HTTP header used to identify this SDK instance for the purpose of estimating
+        /// server-connection-minutes when polling. It contains a v4 UUID that is generated once
+        /// per SDK instance and remains constant for the lifetime of the client.
+        /// </summary>
+        /// <remarks>
+        /// See: sdk-specs / SCMP-server-connection-minutes-polling.
+        /// </remarks>
+        internal const string InstanceIdHeader = "X-LaunchDarkly-Instance-Id";
+
+        /// <summary>
         /// The default value for <see cref="ConnectTimeout(TimeSpan)"/>: two seconds.
         /// </summary>
         public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(2);
@@ -256,8 +266,17 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 .WithReadTimeout(_readTimeout)
                 .WithUserAgent("DotNetClient/" + AssemblyVersions.GetAssemblyVersionStringForType(typeof(LdClient)))
                 .WithApplicationTags(context.ApplicationInfo)
-                .WithWrapper(wrapperName, wrapperVersion);
+                .WithWrapper(wrapperName, wrapperVersion)
+                // Per SCMP-server-connection-minutes-polling, every polling request must carry a
+                // per-instance GUID v4. We attach it to the default headers (rather than only on
+                // the poller) so that it is also present on streaming and event requests; this
+                // matches the cross-SDK contract tests and keeps the GUID stable for the lifetime
+                // of the SDK instance, since the headers are built once and never modified after
+                // construction. Guid.NewGuid() produces a v4 (random) UUID on .NET.
+                .WithHeader(InstanceIdHeader, Guid.NewGuid().ToString());
 
+            // For consistency with other SDKs, custom headers are allowed to overwrite headers
+            // such as User-Agent, Authorization, and the instance id.
             return _customHeaders.Aggregate(httpProperties, (current, kv)
                 => current.WithHeader(kv.Key, kv.Value));
         }

--- a/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/HttpConfigurationBuilder.cs
@@ -34,13 +34,10 @@ namespace LaunchDarkly.Sdk.Server.Integrations
     public sealed class HttpConfigurationBuilder : IComponentConfigurer<HttpConfiguration>, IDiagnosticDescription
     {
         /// <summary>
-        /// The HTTP header used to identify this SDK instance for the purpose of estimating
-        /// server-connection-minutes when polling. It contains a v4 UUID that is generated once
-        /// per SDK instance and remains constant for the lifetime of the client.
+        /// The HTTP header used to identify this SDK instance. Its value is a v4 UUID that is
+        /// generated once per SDK instance and remains constant for the lifetime of the client,
+        /// and is sent on polling, streaming, and event requests.
         /// </summary>
-        /// <remarks>
-        /// See: sdk-specs / SCMP-server-connection-minutes-polling.
-        /// </remarks>
         internal const string InstanceIdHeader = "X-LaunchDarkly-Instance-Id";
 
         /// <summary>
@@ -66,6 +63,11 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         internal TimeSpan _responseStartTimeout = DefaultResponseStartTimeout;
         internal string _wrapperName = null;
         internal string _wrapperVersion = null;
+
+        // Generated once when the builder is constructed so that Build() and DescribeConfiguration()
+        // -- which both call MakeHttpProperties on the same builder -- agree on the value sent in
+        // HTTP headers and reported in diagnostic events. Guid.NewGuid() produces a v4 UUID.
+        private readonly string _instanceId = Guid.NewGuid().ToString();
 
         /// <summary>
         /// Sets the network connection timeout.
@@ -267,13 +269,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
                 .WithUserAgent("DotNetClient/" + AssemblyVersions.GetAssemblyVersionStringForType(typeof(LdClient)))
                 .WithApplicationTags(context.ApplicationInfo)
                 .WithWrapper(wrapperName, wrapperVersion)
-                // Per SCMP-server-connection-minutes-polling, every polling request must carry a
-                // per-instance GUID v4. We attach it to the default headers (rather than only on
-                // the poller) so that it is also present on streaming and event requests; this
-                // matches the cross-SDK contract tests and keeps the GUID stable for the lifetime
-                // of the SDK instance, since the headers are built once and never modified after
-                // construction. Guid.NewGuid() produces a v4 (random) UUID on .NET.
-                .WithHeader(InstanceIdHeader, Guid.NewGuid().ToString());
+                .WithHeader(InstanceIdHeader, _instanceId);
 
             // For consistency with other SDKs, custom headers are allowed to overwrite headers
             // such as User-Agent, Authorization, and the instance id.

--- a/pkgs/sdk/server/src/Subsystems/LdClientContext.cs
+++ b/pkgs/sdk/server/src/Subsystems/LdClientContext.cs
@@ -1,4 +1,5 @@
-﻿using LaunchDarkly.Logging;
+﻿using System;
+using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk.Internal;
 using LaunchDarkly.Sdk.Internal.Events;
 using LaunchDarkly.Sdk.Server.Integrations;
@@ -87,6 +88,13 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
         public string SdkKey { get; }
 
         /// <summary>
+        /// A v4 UUID that uniquely identifies this SDK client instance, sent on every outbound
+        /// request in the X-LaunchDarkly-Instance-Id header (per SCMP-server-connection-minutes-polling).
+        /// Generated once at LdClientContext construction and stable for the lifetime of the client.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <summary>
         /// Defines the base service URIs used by SDK components.
         /// </summary>
         public ServiceEndpoints ServiceEndpoints { get; }
@@ -157,7 +165,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
             TaskExecutor taskExecutor,
             ApplicationInfo applicationInfo,
             WrapperInfo wrapperInfo,
-            ISelectorSource selectorSource
+            ISelectorSource selectorSource,
+            string instanceId = null
         )
         {
             SdkKey = sdkKey;
@@ -172,6 +181,11 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
             ApplicationInfo = applicationInfo;
             WrapperInfo = wrapperInfo;
             SelectorSource = selectorSource;
+            // Generate a fresh instance id when the first LdClientContext for an LDClient is
+            // constructed; downstream With*() copies thread it through unchanged so every
+            // subsystem built from this context observes the same value for the client's
+            // lifetime. Direct callers (LdClient and tests) may pass an explicit id.
+            InstanceId = instanceId ?? Guid.NewGuid().ToString();
         }
 
         internal LdClientContext WithDataSourceUpdates(IDataSourceUpdates newDataSourceUpdates) =>
@@ -187,7 +201,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithDataStoreUpdates(IDataStoreUpdates newDataStoreUpdates) =>
@@ -203,7 +218,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithDiagnosticStore(IDiagnosticStore newDiagnosticStore) =>
@@ -219,7 +235,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithHttp(HttpConfiguration newHttp) =>
@@ -235,7 +252,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithLogger(Logger newLogger) =>
@@ -251,7 +269,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithTaskExecutor(TaskExecutor newTaskExecutor) =>
@@ -267,7 +286,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 newTaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithApplicationInfo(ApplicationInfo applicationInfo) =>
@@ -283,7 +303,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 applicationInfo,
                 WrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
 
         internal LdClientContext WithWrapperInfo(WrapperInfo wrapperInfo) =>
@@ -299,7 +320,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 wrapperInfo,
-                SelectorSource
+                SelectorSource,
+                InstanceId
             );
         
         internal LdClientContext WithSelectorSource(ISelectorSource selectorSource) =>
@@ -315,7 +337,8 @@ namespace LaunchDarkly.Sdk.Server.Subsystems
                 TaskExecutor,
                 ApplicationInfo,
                 WrapperInfo,
-                selectorSource
+                selectorSource,
+                InstanceId
             );
 
         private static HttpConfiguration DefaultHttpConfiguration() =>

--- a/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
+++ b/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
@@ -191,6 +191,18 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         }
 
         [Fact]
+        public void InstanceIdHeaderIsStableAcrossBuildsOnSameBuilder()
+        {
+            // A single builder is reused by both Build() and DescribeConfiguration() against the
+            // same SDK instance, so the generated GUID must be fixed at construction rather than
+            // regenerated on each call.
+            var builder = Components.HttpConfiguration();
+            var id1 = HeadersAsMap(builder.Build(basicConfig).DefaultHeaders)["x-launchdarkly-instance-id"];
+            var id2 = HeadersAsMap(builder.Build(basicConfig).DefaultHeaders)["x-launchdarkly-instance-id"];
+            Assert.Equal(id1, id2);
+        }
+
+        [Fact]
         public void CustomHeaderCanOverrideInstanceIdHeader()
         {
             // Consistent with User-Agent / Authorization: a user-supplied custom header for the

--- a/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
+++ b/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
@@ -159,47 +159,51 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         }
 
         [Fact]
-        public void InstanceIdHeaderIsPresentAndIsUuidV4()
+        public void InstanceIdHeaderMirrorsClientContext()
         {
+            // The HTTP builder emits whatever instance id LdClientContext provides; generation
+            // is the LDClient/LdClientContext's responsibility, not the builder's.
             var config = Components.HttpConfiguration().Build(basicConfig);
             var headers = HeadersAsMap(config.DefaultHeaders);
             Assert.True(headers.ContainsKey("x-launchdarkly-instance-id"),
                 "X-LaunchDarkly-Instance-Id header must be set");
+            Assert.Equal(basicConfig.InstanceId, headers["x-launchdarkly-instance-id"]);
 
+            // The value LdClientContext generates is a v4 GUID -- verify the wire shape.
             var raw = headers["x-launchdarkly-instance-id"];
-            Assert.True(Guid.TryParse(raw, out var parsed),
+            Assert.True(Guid.TryParse(raw, out _),
                 $"instance id '{raw}' must be a parseable GUID");
-
-            // The "M" (version) nibble of a v4 UUID is 0x4. In the canonical 8-4-4-4-12 form,
-            // that is the first character of the third group.
             var groups = raw.Split('-');
             Assert.Equal(5, groups.Length);
             Assert.Equal('4', groups[2][0]);
         }
 
         [Fact]
-        public void InstanceIdHeaderIsUniquePerSdkInstance()
+        public void InstanceIdHeaderIsUniquePerClientContext()
         {
-            // Each call to Build represents a new SDK instance; each must get its own GUID.
-            var config1 = Components.HttpConfiguration().Build(basicConfig);
-            var config2 = Components.HttpConfiguration().Build(basicConfig);
-            var id1 = HeadersAsMap(config1.DefaultHeaders)["x-launchdarkly-instance-id"];
-            var id2 = HeadersAsMap(config2.DefaultHeaders)["x-launchdarkly-instance-id"];
+            // Each LdClientContext auto-generates its own instance id, so building
+            // HttpConfiguration from two distinct contexts produces distinct header values.
+            // This is the cross-SDK-instance uniqueness property the contract tests assert.
+            var context1 = new LdClientContext("sdk-key");
+            var context2 = new LdClientContext("sdk-key");
+            var id1 = HeadersAsMap(Components.HttpConfiguration().Build(context1).DefaultHeaders)["x-launchdarkly-instance-id"];
+            var id2 = HeadersAsMap(Components.HttpConfiguration().Build(context2).DefaultHeaders)["x-launchdarkly-instance-id"];
             Assert.False(string.IsNullOrEmpty(id1));
             Assert.False(string.IsNullOrEmpty(id2));
             Assert.NotEqual(id1, id2);
         }
 
         [Fact]
-        public void InstanceIdHeaderIsStableAcrossBuildsOnSameBuilder()
+        public void InstanceIdHeaderIsStableAcrossBuildsFromSameContext()
         {
-            // A single builder is reused by both Build() and DescribeConfiguration() against the
-            // same SDK instance, so the generated GUID must be fixed at construction rather than
-            // regenerated on each call.
+            // Build() and DescribeConfiguration() are both called against the same
+            // LdClientContext for one SDK instance; the value they see must agree, and must
+            // equal the context's InstanceId.
             var builder = Components.HttpConfiguration();
             var id1 = HeadersAsMap(builder.Build(basicConfig).DefaultHeaders)["x-launchdarkly-instance-id"];
             var id2 = HeadersAsMap(builder.Build(basicConfig).DefaultHeaders)["x-launchdarkly-instance-id"];
             Assert.Equal(id1, id2);
+            Assert.Equal(basicConfig.InstanceId, id1);
         }
 
         [Fact]

--- a/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
+++ b/pkgs/sdk/server/test/Integrations/HttpConfigurationBuilderTest.cs
@@ -158,6 +158,50 @@ namespace LaunchDarkly.Sdk.Server.Integrations
             Assert.Equal("my-wrapper/3.14", HeadersAsMap(config.DefaultHeaders)["x-launchdarkly-wrapper"]);
         }
 
+        [Fact]
+        public void InstanceIdHeaderIsPresentAndIsUuidV4()
+        {
+            var config = Components.HttpConfiguration().Build(basicConfig);
+            var headers = HeadersAsMap(config.DefaultHeaders);
+            Assert.True(headers.ContainsKey("x-launchdarkly-instance-id"),
+                "X-LaunchDarkly-Instance-Id header must be set");
+
+            var raw = headers["x-launchdarkly-instance-id"];
+            Assert.True(Guid.TryParse(raw, out var parsed),
+                $"instance id '{raw}' must be a parseable GUID");
+
+            // The "M" (version) nibble of a v4 UUID is 0x4. In the canonical 8-4-4-4-12 form,
+            // that is the first character of the third group.
+            var groups = raw.Split('-');
+            Assert.Equal(5, groups.Length);
+            Assert.Equal('4', groups[2][0]);
+        }
+
+        [Fact]
+        public void InstanceIdHeaderIsUniquePerSdkInstance()
+        {
+            // Each call to Build represents a new SDK instance; each must get its own GUID.
+            var config1 = Components.HttpConfiguration().Build(basicConfig);
+            var config2 = Components.HttpConfiguration().Build(basicConfig);
+            var id1 = HeadersAsMap(config1.DefaultHeaders)["x-launchdarkly-instance-id"];
+            var id2 = HeadersAsMap(config2.DefaultHeaders)["x-launchdarkly-instance-id"];
+            Assert.False(string.IsNullOrEmpty(id1));
+            Assert.False(string.IsNullOrEmpty(id2));
+            Assert.NotEqual(id1, id2);
+        }
+
+        [Fact]
+        public void CustomHeaderCanOverrideInstanceIdHeader()
+        {
+            // Consistent with User-Agent / Authorization: a user-supplied custom header for the
+            // same name takes precedence. This mirrors the behavior in other SDKs.
+            var config = Components.HttpConfiguration()
+                .CustomHeader("X-LaunchDarkly-Instance-Id", "custom-override")
+                .Build(basicConfig);
+            Assert.Equal("custom-override",
+                HeadersAsMap(config.DefaultHeaders)["x-launchdarkly-instance-id"]);
+        }
+
         private Dictionary<string, string> HeadersAsMap(IEnumerable<KeyValuePair<string, string>> headers)
         {
             return headers.ToDictionary(kv => kv.Key.ToLower(), kv => kv.Value);


### PR DESCRIPTION
## Summary

Adds the `X-LaunchDarkly-Instance-Id` header to every outbound polling, streaming, and event request. Value is a v4 UUID generated once per SDK instance (via `Guid.NewGuid()`) and stable for that instance's lifetime.

The GUID is attached via the immutable `HttpProperties` builder before the user-custom-header aggregation, matching the User-Agent / Authorization override convention.

## Test plan

- [x] \`dotnet test\` on net8.0 — Passed 1574 / Failed 0
- [x] Server SDK build (net462, netstandard2.0, net8.0) — 0 warnings, 0 errors
- [x] Contract test service jar builds clean with \`instance-id\` capability registered
- [ ] CI green across all target frameworks (net462 run requires mono, exercised by CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP request configuration by adding a new default header generated per client instance; risk is limited but could affect downstream proxies/servers that validate or log headers, and relies on correct propagation across all subsystems.
> 
> **Overview**
> Adds a per-client *instance identifier* that is generated once and propagated through `LdClientContext`, then automatically attached as `X-LaunchDarkly-Instance-Id` to all HTTP requests created via `HttpConfigurationBuilder` (while still allowing user custom headers to override it).
> 
> Updates the contract-test harness to advertise the new `instance-id` capability, and adds unit tests asserting the header is present, v4-UUID-shaped, stable within a context, unique across contexts, and overridable via `CustomHeader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a2bdf35c79a0903b1a36b1bc8faa932280bdb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->