### PR TITLE
fix: exclude documentation files from NuGet package builds

### DIFF
--- a/pkgs/dotnet-server-sdk-consul/src/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/pkgs/dotnet-server-sdk-consul/src/LaunchDarkly.ServerSdk.Consul.csproj
@@ -20,6 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RootNamespace>LaunchDarkly.Sdk.Server.Integrations</RootNamespace>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -47,30 +48,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\CONTRIBUTING.md">
+    </None>
+    <None Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\index.md">
+    </None>
+    <None Include="..\index.md">
       <Link>index.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\README.md">
+    </None>
+    <None Include="..\README.md">
       <Link>README.md</Link>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="..\SECURITY.md">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
       <Pack>false</Pack>
-    </Content>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/pkgs/dotnet-server-sdk-consul/src/LaunchDarkly.ServerSdk.Consul.csproj
+++ b/pkgs/dotnet-server-sdk-consul/src/LaunchDarkly.ServerSdk.Consul.csproj
@@ -49,21 +49,27 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\index.md">
       <Link>index.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\README.md">
       <Link>README.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 

--- a/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -44,21 +44,27 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\index.md">
       <Link>index.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\README.md">
       <Link>README.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 

--- a/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/pkgs/dotnet-server-sdk-dynamodb/src/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -20,6 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RootNamespace>LaunchDarkly.Sdk.Server.Integrations</RootNamespace>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -42,30 +43,31 @@
     <ProjectReference Include="../../sdk/server/src/LaunchDarkly.ServerSdk.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\CONTRIBUTING.md">
+    </None>
+    <None Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\index.md">
+    </None>
+    <None Include="..\index.md">
       <Link>index.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\README.md">
+    </None>
+    <None Include="..\README.md">
       <Link>README.md</Link>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="..\SECURITY.md">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
       <Pack>false</Pack>
-    </Content>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/pkgs/dotnet-server-sdk-redis/src/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/pkgs/dotnet-server-sdk-redis/src/LaunchDarkly.ServerSdk.Redis.csproj
@@ -20,6 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RootNamespace>LaunchDarkly.Sdk.Server.Integrations</RootNamespace>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -42,26 +43,27 @@
     <ProjectReference Include="../../sdk/server/src/LaunchDarkly.ServerSdk.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\CONTRIBUTING.md">
+    </None>
+    <None Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\README.md">
+    </None>
+    <None Include="..\README.md">
       <Link>README.md</Link>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="..\SECURITY.md">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
       <Pack>false</Pack>
-    </Content>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/pkgs/dotnet-server-sdk-redis/src/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/pkgs/dotnet-server-sdk-redis/src/LaunchDarkly.ServerSdk.Redis.csproj
@@ -44,18 +44,23 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\README.md">
       <Link>README.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\SECURITY.md">
       <Link>SECURITY.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 

--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -37,6 +37,7 @@
 
         <!-- fail if XML comments are missing or invalid -->
         <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <Configurations>Debug;Release;DebugLocalReferences</Configurations>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
@@ -125,26 +126,27 @@
         </Compile>
     </ItemGroup>
     <ItemGroup>
-      <Content Include="..\CHANGELOG.md">
+      <None Include="..\CHANGELOG.md">
         <Link>CHANGELOG.md</Link>
         <Pack>false</Pack>
-      </Content>
-      <Content Include="..\CONTRIBUTING.md">
+      </None>
+      <None Include="..\CONTRIBUTING.md">
         <Link>CONTRIBUTING.md</Link>
         <Pack>false</Pack>
-      </Content>
-      <Content Include="..\index.md">
+      </None>
+      <None Include="..\index.md">
         <Link>index.md</Link>
         <Pack>false</Pack>
-      </Content>
-      <Content Include="..\README.md">
+      </None>
+      <None Include="..\README.md">
         <Link>README.md</Link>
-        <Pack>false</Pack>
-      </Content>
-      <Content Include="..\toc.yml">
+        <Pack>true</Pack>
+        <PackagePath>\</PackagePath>
+      </None>
+      <None Include="..\toc.yml">
         <Link>toc.yml</Link>
         <Pack>false</Pack>
-      </Content>
+      </None>
     </ItemGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <AssemblyOriginatorKeyFile>../../../../LaunchDarkly.ClientSdk.snk</AssemblyOriginatorKeyFile>

--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -127,18 +127,23 @@
     <ItemGroup>
       <Content Include="..\CHANGELOG.md">
         <Link>CHANGELOG.md</Link>
+        <Pack>false</Pack>
       </Content>
       <Content Include="..\CONTRIBUTING.md">
         <Link>CONTRIBUTING.md</Link>
+        <Pack>false</Pack>
       </Content>
       <Content Include="..\index.md">
         <Link>index.md</Link>
+        <Pack>false</Pack>
       </Content>
       <Content Include="..\README.md">
         <Link>README.md</Link>
+        <Pack>false</Pack>
       </Content>
       <Content Include="..\toc.yml">
         <Link>toc.yml</Link>
+        <Pack>false</Pack>
       </Content>
     </ItemGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/pkgs/sdk/server-ai/src/LaunchDarkly.ServerSdk.Ai.csproj
+++ b/pkgs/sdk/server-ai/src/LaunchDarkly.ServerSdk.Ai.csproj
@@ -35,6 +35,7 @@
 
     <!-- fail if XML comments are missing or invalid -->
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -57,34 +58,35 @@
     <ProjectReference Include="../../server/src/LaunchDarkly.ServerSdk.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\CONTRIBUTING.md">
+    </None>
+    <None Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Ai.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Ai.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Ai.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\README.md">
+    </None>
+    <None Include="..\docs-src\README.md">
       <Link>docs-src\README.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\index.md">
+    </None>
+    <None Include="..\index.md">
       <Link>index.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\README.md">
+    </None>
+    <None Include="..\README.md">
       <Link>README.md</Link>
-      <Pack>false</Pack>
-    </Content>
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/pkgs/sdk/server-ai/src/LaunchDarkly.ServerSdk.Ai.csproj
+++ b/pkgs/sdk/server-ai/src/LaunchDarkly.ServerSdk.Ai.csproj
@@ -59,24 +59,31 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Ai.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Ai.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\README.md">
       <Link>docs-src\README.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\index.md">
       <Link>index.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\README.md">
       <Link>README.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -60,39 +60,51 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Json.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Json.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Integrations.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Integrations.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Interfaces.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Interfaces.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Subsystems.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Subsystems.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docs-src\README.md">
       <Link>docs-src\README.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\index.md">
       <Link>index.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\README.md">
       <Link>README.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -35,6 +35,7 @@
 
     <!-- fail if XML comments are missing or invalid -->
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -58,54 +59,55 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\CONTRIBUTING.md">
+    </None>
+    <None Include="..\CONTRIBUTING.md">
       <Link>CONTRIBUTING.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Json.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Json.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Json.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Integrations.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Integrations.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Integrations.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Interfaces.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Interfaces.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Interfaces.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Subsystems.md">
+    </None>
+    <None Include="..\docs-src\namespaces\LaunchDarkly.Sdk.Server.Subsystems.md">
       <Link>docs-src\namespaces\LaunchDarkly.Sdk.Server.Subsystems.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docs-src\README.md">
+    </None>
+    <None Include="..\docs-src\README.md">
       <Link>docs-src\README.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\index.md">
+    </None>
+    <None Include="..\index.md">
       <Link>index.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\README.md">
+    </None>
+    <None Include="..\README.md">
       <Link>README.md</Link>
-      <Pack>false</Pack>
-    </Content>
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/pkgs/telemetry/README.md
+++ b/pkgs/telemetry/README.md
@@ -1,0 +1,77 @@
+# LaunchDarkly Server-Side SDK for .NET - Telemetry
+
+[![NuGet](https://img.shields.io/nuget/v/LaunchDarkly.ServerSdk.Telemetry.svg?style=flat-square)](https://www.nuget.org/packages/LaunchDarkly.ServerSdk.Telemetry/)
+
+This library provides OpenTelemetry integration for the [LaunchDarkly Server-Side .NET SDK](https://github.com/launchdarkly/dotnet-core/tree/main/pkgs/sdk/server). It includes a `TracingHook` that automatically creates OpenTelemetry spans for feature flag evaluations using `System.Diagnostics.Activity`.
+
+For more information, see: [OpenTelemetry](https://docs.launchdarkly.com/sdk/features/opentelemetry).
+
+## Supported .NET versions
+
+This version of the library is built for the following targets:
+
+* .NET 8.0: runs on .NET 8.0 and above (including higher major versions).
+* .NET Framework 4.6.2: runs on .NET Framework 4.6.2 and above.
+* .NET Standard 2.0: runs in any project that is targeted to .NET Standard 2.x rather than to a specific runtime platform.
+
+The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
+
+## Getting started
+
+Install the NuGet package:
+
+```
+dotnet add package LaunchDarkly.ServerSdk.Telemetry
+```
+
+Then register the `TracingHook` with the LaunchDarkly SDK:
+
+```csharp
+var hook = LaunchDarkly.Sdk.Server.Telemetry.TracingHook
+    .Builder()
+    .Build();
+
+var config = Configuration.Builder("my-sdk-key")
+    .Hooks(Components.Hooks().Add(hook))
+    .Build();
+
+var client = new LdClient(config);
+```
+
+## Signing
+
+The published version of this assembly is digitally signed with Authenticode and [strong-named](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/strong-named-assemblies). Building the code locally in the default Debug configuration does not use strong-naming and does not require a key file. The public key file is in this repository at `LaunchDarkly.pk` as well as here:
+
+```
+Public Key:
+0024000004800000940000000602000000240000525341310004000001000100f121bbf427e4d7
+edc64131a9efeefd20978dc58c285aa6f548a4282fc6d871fbebeacc13160e88566f427497b625
+56bf7ff01017b0f7c9de36869cc681b236bc0df0c85927ac8a439ecb7a6a07ae4111034e03042c
+4b1569ebc6d3ed945878cca97e1592f864ba7cc81a56b8668a6d7bbe6e44c1279db088b0fdcc35
+52f746b4
+
+Public Key Token: f86add69004e6885
+```
+
+## Contributing
+ 
+We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
+
+
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
+## About LaunchDarkly
+ 
+* LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
+    * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+    * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+    * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+* Explore LaunchDarkly
+    * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
+    * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides
+    * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
+    * [blog.launchdarkly.com](https://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product updates

--- a/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
+++ b/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
@@ -34,6 +34,7 @@
 
     <!-- fail if XML comments are missing or invalid -->
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -58,18 +59,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\CHANGELOG.md">
+    <None Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\docfx.json">
+    </None>
+    <None Include="..\docfx.json">
       <Link>docfx.json</Link>
       <Pack>false</Pack>
-    </Content>
-    <Content Include="..\index.md">
+    </None>
+    <None Include="..\index.md">
       <Link>index.md</Link>
       <Pack>false</Pack>
-    </Content>
+    </None>
+    <None Include="..\README.md">
+      <Link>README.md</Link>
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
+++ b/pkgs/telemetry/src/LaunchDarkly.ServerSdk.Telemetry.csproj
@@ -60,12 +60,15 @@
   <ItemGroup>
     <Content Include="..\CHANGELOG.md">
       <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\docfx.json">
       <Link>docfx.json</Link>
+      <Pack>false</Pack>
     </Content>
     <Content Include="..\index.md">
       <Link>index.md</Link>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Closes #261

**Describe the solution you've provided**

- Changed documentation file items from `<Content>` to `<None>` in all package `.csproj` files so they are not copied to consuming project bin folders.
- Pack `README.md` into each NuGet package (with `<PackageReadmeFile>` and `<PackagePath>\</PackagePath>`) so it renders on the NuGet.org package page.
- All other doc files (CHANGELOG, docfx.json, etc.) use `<Pack>false</Pack>` to exclude them from packages.
- Created a new `README.md` for the Telemetry package (which previously had none).

**Describe alternatives you've considered**

Originally used `<Content>` with `<Pack>false</Pack>`, but switched to `<None>` per NuGet best practices to avoid files being copied to consuming projects.

**Additional context**

Reference: https://devblogs.microsoft.com/dotnet/add-a-readme-to-your-nuget-package/

Link to Devin session: https://app.devin.ai/sessions/9ab235b0b6af4361a2b4e9cec502b3f5
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MSBuild/NuGet packaging-only changes; no SDK runtime, auth, or public API behavior is modified.
> 
> **Overview**
> Across LaunchDarkly .NET SDK and integration packages, linked repo docs (`CHANGELOG`, `CONTRIBUTING`, `docfx.json`, `index.md`, etc.) move from `<Content>` to `<None>` with `<Pack>false</Pack>` so they stay in the solution without being copied into consuming apps’ output or bundled into the `.nupkg`.
> 
> **README** is wired for NuGet.org via `<PackageReadmeFile>README.md</PackageReadmeFile>` plus a packed `README.md` at the package root (`<Pack>true</Pack>`, `<PackagePath>\</PackagePath>`). Integration packages (Consul, DynamoDB, Redis) and **Telemetry** follow the same pattern; Telemetry also gains a new `pkgs/telemetry/README.md` and packs it in `LaunchDarkly.ServerSdk.Telemetry.csproj`.
> 
> Client SDK additionally stops packing `toc.yml` (explicit `<Pack>false</Pack>`). No runtime or API code changes—only packaging metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf340184e16d1a79869fc8314323859e2d38dda4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->