### PR TITLE
fix: gracefully handle MAUI unavailability in non-MAUI Windows apps

### DIFF
--- a/pkgs/sdk/client/src/PlatformSpecific/AppInfo.maui.cs
+++ b/pkgs/sdk/client/src/PlatformSpecific/AppInfo.maui.cs
@@ -5,10 +5,20 @@ namespace LaunchDarkly.Sdk.Client.PlatformSpecific
 {
     internal static partial class AppInfo
     {
-        internal static ApplicationInfo? GetAppInfo() => new ApplicationInfo(
-            Microsoft.Maui.ApplicationModel.AppInfo.Current.PackageName,
-            Microsoft.Maui.ApplicationModel.AppInfo.Current.Name,
-            Microsoft.Maui.ApplicationModel.AppInfo.Current.BuildString,
-            Microsoft.Maui.ApplicationModel.AppInfo.Current.VersionString);
+        internal static ApplicationInfo? GetAppInfo()
+        {
+            try
+            {
+                return new ApplicationInfo(
+                    Microsoft.Maui.ApplicationModel.AppInfo.Current.PackageName,
+                    Microsoft.Maui.ApplicationModel.AppInfo.Current.Name,
+                    Microsoft.Maui.ApplicationModel.AppInfo.Current.BuildString,
+                    Microsoft.Maui.ApplicationModel.AppInfo.Current.VersionString);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 }

--- a/pkgs/sdk/client/src/PlatformSpecific/Connectivity.maui.cs
+++ b/pkgs/sdk/client/src/PlatformSpecific/Connectivity.maui.cs
@@ -7,20 +7,34 @@ namespace LaunchDarkly.Sdk.Client.PlatformSpecific
 {
     internal static partial class PlatformConnectivity
     {
+        private static readonly bool _mauiAvailable;
+
         static PlatformConnectivity()
         {
-            Connectivity.Current.ConnectivityChanged += (sender, args) => ConnectivityChanged?.Invoke(sender, EventArgs.Empty);
+            try
+            {
+                Connectivity.Current.ConnectivityChanged += (sender, args) => ConnectivityChanged?.Invoke(sender, EventArgs.Empty);
+                _mauiAvailable = true;
+            }
+            catch
+            {
+                _mauiAvailable = false;
+            }
         }
 
         /// <summary>
         /// Gets the current state of network access.
         /// </summary>
-        public static LdNetworkAccess LdNetworkAccess => Convert(Connectivity.Current.NetworkAccess);
+        public static LdNetworkAccess LdNetworkAccess =>
+            _mauiAvailable ? Convert(Connectivity.Current.NetworkAccess) : LdNetworkAccess.Internet;
 
         /// <summary>
         /// Gets the active connectivity types for the device.
         /// </summary>
-        public static IEnumerable<LdConnectionProfile> LdConnectionProfiles => Connectivity.Current.ConnectionProfiles.Distinct().Select(Convert);
+        public static IEnumerable<LdConnectionProfile> LdConnectionProfiles =>
+            _mauiAvailable
+                ? Connectivity.Current.ConnectionProfiles.Distinct().Select(Convert)
+                : Enumerable.Empty<LdConnectionProfile>();
 
         /// <summary>
         /// Occurs when network access or profile has changed.  This is just a signal and the

--- a/pkgs/sdk/client/src/PlatformSpecific/DeviceInfo.maui.cs
+++ b/pkgs/sdk/client/src/PlatformSpecific/DeviceInfo.maui.cs
@@ -5,18 +5,36 @@ namespace LaunchDarkly.Sdk.Client.PlatformSpecific
 {
     internal static partial class DeviceInfo
     {
-        internal static OsInfo? GetOsInfo() =>
-            new OsInfo(
-                PlatformToFamilyString(Devices.DeviceInfo.Current.Platform),
-                Devices.DeviceInfo.Current.Platform.ToString(),
-                Devices.DeviceInfo.Current.VersionString
-            );
+        internal static OsInfo? GetOsInfo()
+        {
+            try
+            {
+                return new OsInfo(
+                    PlatformToFamilyString(Devices.DeviceInfo.Current.Platform),
+                    Devices.DeviceInfo.Current.Platform.ToString(),
+                    Devices.DeviceInfo.Current.VersionString
+                );
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
-        internal static LaunchDarkly.Sdk.EnvReporting.LayerModels.DeviceInfo? GetDeviceInfo() =>
-            new EnvReporting.LayerModels.DeviceInfo(
-                Devices.DeviceInfo.Current.Manufacturer,
-                Devices.DeviceInfo.Current.Model
-            );
+        internal static LaunchDarkly.Sdk.EnvReporting.LayerModels.DeviceInfo? GetDeviceInfo()
+        {
+            try
+            {
+                return new EnvReporting.LayerModels.DeviceInfo(
+                    Devices.DeviceInfo.Current.Manufacturer,
+                    Devices.DeviceInfo.Current.Model
+                );
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
         private static string PlatformToFamilyString(Devices.DevicePlatform platform) {
             if (platform == Devices.DevicePlatform.Android)


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality.
Not worth the squeeze.

- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
TODO

**Describe the solution you've provided**

PlatformConnectivity, AppInfo, and DeviceInfo all call MAUI APIs that require platform initialization. In WPF/WinForms apps targeting net8.0-windows, MAUI is never initialized, causing a TypeInitializationException during LdClient.Init(). Guard the static constructor with a _mauiAvailable flag and fall back to safe defaults (assume connected, return null for app/device info) when MAUI is not available at runtime.

**Describe alternatives you've considered**

A multilayer approach with default platform impls and a public API for overrides from another package.  This could be a future improvement.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive fallbacks around optional MAUI metadata and connectivity; behavior matches existing netstandard stubs when MAUI is absent, with no auth or data-path changes.
> 
> **Overview**
> Prevents **`LdClient.Init()`** crashes on **net8.0-windows** desktop apps (WPF/WinForms) where MAUI is referenced but never initialized.
> 
> **`PlatformConnectivity`** now sets **`_mauiAvailable`** in a guarded static constructor; when MAUI fails, it assumes **Internet** connectivity, returns **no connection profiles**, and skips subscribing to MAUI connectivity events (aligned with the existing netstandard stub behavior).
> 
> **`AppInfo`** and **`DeviceInfo`** MAUI helpers wrap MAUI API calls in **try/catch** and return **`null`** for app/OS/device metadata when MAUI is unavailable, instead of throwing during init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e2f9b35b7f5d9311ec614c579ea51f8c727af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->