### PR TITLE
feat: enable per-context summary events

### DIFF
--- a/pkgs/sdk/client/contract-tests/TestService.cs
+++ b/pkgs/sdk/client/contract-tests/TestService.cs
@@ -41,7 +41,8 @@ namespace TestService
             "auto-env-attributes",
             "inline-context-all",
             "anonymous-redaction",
-            "client-prereq-events"
+            "client-prereq-events",
+            "client-per-context-summaries"
         };
 
         public readonly Handler Handler;

--- a/pkgs/sdk/client/src/Integrations/EventProcessorBuilder.cs
+++ b/pkgs/sdk/client/src/Integrations/EventProcessorBuilder.cs
@@ -228,7 +228,10 @@ namespace LaunchDarkly.Sdk.Client.Integrations
                 DiagnosticRecordingInterval = _diagnosticRecordingInterval,
                 DiagnosticUri = baseUri.AddPath(StandardEndpoints.DiagnosticEventsPostRequestPath),
                 PrivateAttributes = _privateAttributes.ToImmutableHashSet(),
-                RetryInterval = TimeSpan.FromSeconds(1)
+                RetryInterval = TimeSpan.FromSeconds(1),
+                // Client-side SDKs emit a summary event per context, with the context attached,
+                // since only one context is active at a time and context cardinality is low.
+                PerContextSummaries = true
             };
         }
     }

--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -51,7 +51,7 @@
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"/>
         <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0"/>
         <PackageReference Include="LaunchDarkly.EventSource" Version="5.2.1"/>
-        <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.6.1" />
+        <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.7.0" />
         <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0"/>
         <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.100" />
         <Compile Include="**\*.cs" Exclude="PlatformSpecific\*.cs;bin\**\*.cs;obj\**\*.cs"/>


### PR DESCRIPTION
## Overview

Enables **per-context summary events** in the .NET client-side SDK, now that the supporting InternalSdk change has been released.

- `EventProcessorBuilder.cs`: sets `PerContextSummaries = true` on the events configuration.
- `TestService.cs` (contract tests): advertises the `client-per-context-summaries` capability so the harness runs the per-context summary variants.
- `LaunchDarkly.ClientSdk.csproj`: bumps `LaunchDarkly.InternalSdk` 3.6.1 → **3.7.0** (the published version that adds per-context summary support — `EventsConfiguration.PerContextSummaries`). This is the dependency bump the original commit deferred until the InternalSdk release.

## Validation (against the published 3.7.0 package, not a local build)

- Builds clean against `LaunchDarkly.InternalSdk` 3.7.0 restored from NuGet.
- Contract tests (sdk-test-harness **v2** / 2.37.0) pass fully:
  - `events` suite: 353 ran, **0 failures** — including the per-context summary variants `basic counter behavior for per context summaries` and `context kinds for per context summaries` (gated on the `client-per-context-summaries` capability).
  - Full suite: **922 total, 14 skipped, 908 ran, 0 failures**.

Relates to SDK-2450. Depends on dotnet-sdk-internal SDK-2449 (released as InternalSdk 3.7.0).

Left as a draft for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics event shape and delivery semantics for all client-side SDK users; dependency bump ties behavior to InternalSdk 3.7.0 event processing.
> 
> **Overview**
> Turns on **per-context analytics summary events** for the .NET client-side SDK by setting `PerContextSummaries = true` in `EventProcessorBuilder`’s `EventsConfiguration`, so summaries are emitted per active context (with context attached) instead of the prior aggregation behavior.
> 
> Contract test harness capability **`client-per-context-summaries`** is advertised so v2 harness runs the per-context summary scenarios. **`LaunchDarkly.InternalSdk`** is bumped **3.6.1 → 3.7.0**, which supplies `EventsConfiguration.PerContextSummaries`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd03b85e5e7e03b4de9ec1c2ba3c51f16b3e6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->