### PR TITLE
chore: remove development warning in server-ai README

### DIFF
--- a/pkgs/sdk/server-ai/README.md
+++ b/pkgs/sdk/server-ai/README.md
@@ -4,8 +4,6 @@
 > This AI SDK is in pre-release and not subject to backwards compatibility guarantees. The API may change based on feedback.
 >
 > Pin to a specific minor version and review the [changelog] before upgrading.
->
-> Active feature development is ongoing in the [Python][python-ai-sdk] and [Node.js][node-ai-sdk] AI SDKs, so this SDK will receive new features at a slower pace. Refer to those for the latest capabilities.
 
 [changelog]: https://github.com/launchdarkly/dotnet-core/blob/main/pkgs/sdk/server-ai/CHANGELOG.md
 [python-ai-sdk]: https://github.com/launchdarkly/python-server-sdk-ai/tree/main/packages/sdk/server-ai


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the **server-ai** README by removing the caution callout line that said active AI SDK work happens mainly in the **Python** and **Node.js** SDKs and that the .NET package will get new capabilities more slowly.
> 
> The existing **pre-release** warning (no backwards-compatibility guarantee, pin minor versions, check the changelog) is unchanged. Link reference definitions for the Python and Node AI SDKs remain at the top of the file even though nothing in the README links to them anymore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5564c176e8d9d697d4c8abe00488a7f57d8299d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->