### PR TITLE
chore: declare per-context summary events support in client SDK metadata

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -88,6 +88,11 @@
       "languages": [
         "C#"
       ],
+      "features": {
+        "perContextSummaryEvents": {
+          "introduced": "5.9"
+        }
+      },
       "releases": {
         "tag-prefix": "LaunchDarkly.ClientSdk-"
       },


### PR DESCRIPTION
## Overview

Follow-up to #288 (which enables per-context summary events in the .NET client SDK). This records that support in `.sdk_metadata.json` so sdk-meta's feature data reflects it.

- Adds a `features` object to the **dotnet-client-sdk** entry with `perContextSummaryEvents` (the canonical feature key from sdk-meta's `feature_info.json` — "Per-Context Summary Events"), `introduced: "5.9"`.
- The client entry had no `features` section previously; this adds it with this one feature.

## Notes

- `introduced: "5.9"` is the **anticipated** next client release (current is 5.8.0; #288 is a `feat`, so release-please will cut 5.9.0). If the release lands at a different version, update this value. The metadata becomes accurate once 5.9 ships.
- Root-level metadata change only — not under a release-please package path, so it doesn't trigger an SDK version bump.

Relates to SDK-2450. Should land after #288 (the feature it documents).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Root-level SDK metadata only; no application, auth, or release logic changes.
> 
> **Overview**
> Documents **per-context summary events** for the **.NET Client SDK** in `.sdk_metadata.json` by adding a new `features` block on `dotnet-client-sdk` with `perContextSummaryEvents` and `introduced: "5.9"`, aligning sdk-meta with the client implementation from the related feature work.
> 
> This is metadata-only (no runtime or package code changes) and does not drive a release-please version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dba46f579f5d6695cf9be49bd37f58628e293c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->