### PR TITLE
feat: Add AgentGraph support to the AI SDK

### DIFF
--- a/pkgs/sdk/server-ai/src/Adapters/LoggerAdapter.cs
+++ b/pkgs/sdk/server-ai/src/Adapters/LoggerAdapter.cs
@@ -25,4 +25,7 @@ internal class LoggerAdapter : ILogger
 
     /// <inheritdoc/>
     public void Warn(string format, params object[] allParams) => _logger.Warn(format, allParams);
+
+    /// <inheritdoc/>
+    public void Debug(string format, params object[] allParams) => _logger.Debug(format, allParams);
 }

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -102,10 +102,11 @@ internal sealed class ConfigFactory
         LdValue ldValue,
         Context context,
         LdAiAgentConfigDefault defaultValue,
-        IReadOnlyDictionary<string, object> variables)
+        IReadOnlyDictionary<string, object> variables,
+        string graphKey = null)
     {
         var mergedVars = MergeVariables(variables, context);
-        var trackerFactory = TrackerFactoryFor(context);
+        var trackerFactory = TrackerFactoryFor(context, graphKey);
 
         if (ldValue.Type != LdValueType.Object)
         {
@@ -144,7 +145,7 @@ internal sealed class ConfigFactory
             trackerFactory);
     }
 
-    private LdAiAgentConfig BuildAgentFromDefault(
+    internal LdAiAgentConfig BuildAgentFromDefault(
         string key,
         LdAiAgentConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
@@ -275,7 +276,7 @@ internal sealed class ConfigFactory
         return result;
     }
 
-    private Func<LdAiConfig, ILdAiConfigTracker> TrackerFactoryFor(Context context)
+    private Func<LdAiConfig, ILdAiConfigTracker> TrackerFactoryFor(Context context, string graphKey = null)
     {
         return cfg => new LdAiConfigTracker(
             _client,
@@ -285,7 +286,8 @@ internal sealed class ConfigFactory
             cfg.Version,
             context,
             cfg.Model?.Name,
-            cfg.Provider?.Name);
+            cfg.Provider?.Name,
+            graphKey);
     }
 
     private static (bool Enabled, string VariationKey, int Version, string Mode) ParseMeta(LdValue value)

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -296,7 +296,7 @@ internal sealed class ConfigFactory
         var enabled = meta.Get("enabled").AsBool;
         var variationKey = meta.Get("variationKey").AsString ?? "";
         var versionValue = meta.Get("version");
-        var version = versionValue.IsNull ? 1 : versionValue.AsInt;
+        var version = versionValue.IsNull || versionValue.AsInt <= 0 ? 1 : versionValue.AsInt;
         // Default to the completion mode when _ldMeta.mode is missing or non-string: legacy
         // flags predate the mode tag and were always served as completion configs.
         var mode = meta.Get("mode").AsString ?? LdAiCompletionConfig.Mode;

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -296,7 +296,7 @@ internal sealed class ConfigFactory
         var enabled = meta.Get("enabled").AsBool;
         var variationKey = meta.Get("variationKey").AsString ?? "";
         var versionValue = meta.Get("version");
-        var version = versionValue.IsNull || versionValue.AsInt <= 0 ? 1 : versionValue.AsInt;
+        var version = versionValue.IsNull ? 1 : versionValue.AsInt;
         // Default to the completion mode when _ldMeta.mode is missing or non-string: legacy
         // flags predate the mode tag and were always served as completion configs.
         var mode = meta.Get("mode").AsString ?? LdAiCompletionConfig.Mode;

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -160,21 +160,6 @@ public sealed class AgentGraphDefinition
             }
         }
 
-        // If no terminals were seeded (pure cycle — no leaf nodes exist), seed all non-root nodes
-        // so every node is still visited. For a single-node graph (or self-loop), fall back to
-        // seeding root itself as the only node.
-        if (queue.Count == 0 && root != null)
-        {
-            foreach (var n in _nodes.Values)
-            {
-                if (n.Key == root.Key) continue;
-                if (visited.Add(n.Key))
-                    queue.Enqueue(n);
-            }
-            if (queue.Count == 0 && visited.Add(root.Key))
-                queue.Enqueue(root);
-        }
-
         while (queue.Count > 0)
         {
             var node = queue.Dequeue();
@@ -203,7 +188,7 @@ public sealed class AgentGraphDefinition
         }
 
         // Process root last
-        if (root != null && _nodes.Count > 1)
+        if (root != null && _nodes.Count > 1 && visited.Count > 0)
         {
             var result = fn(root, context);
             context[root.Key] = result;

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -208,7 +208,9 @@ public sealed class AgentGraphDefinition
 
         foreach (var key in allKeys)
         {
-            var config = agentConfigs[key];
+            if (!agentConfigs.TryGetValue(key, out var config))
+                continue;
+
             var outgoingEdges = flagValue.Edges != null && flagValue.Edges.TryGetValue(key, out var edges)
                 ? edges
                 : (IReadOnlyList<GraphEdge>)Array.Empty<GraphEdge>();

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Graph;
+
+/// <summary>
+/// Represents a fully-resolved agent graph returned by
+/// <see cref="LdAiClient.AgentGraph"/>. When <see cref="Enabled"/> is false, all
+/// node collections are empty and traversal is a no-op; only <see cref="GetConfig"/>
+/// and <see cref="CreateTracker"/> remain meaningful.
+/// </summary>
+public sealed class AgentGraphDefinition
+{
+    private readonly AgentGraphFlagValue _flagValue;
+    private readonly IReadOnlyDictionary<string, AgentGraphNode> _nodes;
+    private readonly Func<AiGraphTracker> _createTracker;
+
+    /// <summary>
+    /// Whether the graph passed all validation checks. False if the flag's
+    /// <c>_ldMeta.enabled</c> is false, the root is missing, any node is
+    /// unreachable from the root, or any child agent config could not be fetched.
+    /// </summary>
+    public bool Enabled { get; }
+
+    internal AgentGraphDefinition(
+        AgentGraphFlagValue flagValue,
+        IReadOnlyDictionary<string, AgentGraphNode> nodes,
+        bool enabled,
+        Func<AiGraphTracker> createTracker)
+    {
+        _flagValue = flagValue;
+        _nodes = nodes;
+        Enabled = enabled;
+        _createTracker = createTracker;
+    }
+
+    /// <summary>
+    /// Returns the root node of the graph, or null if the graph is disabled or has no root.
+    /// </summary>
+    public AgentGraphNode RootNode() =>
+        string.IsNullOrEmpty(_flagValue?.Root) ? null : GetNode(_flagValue.Root);
+
+    /// <summary>
+    /// Returns the node with the given key, or null if not found.
+    /// </summary>
+    public AgentGraphNode GetNode(string nodeKey)
+    {
+        if (nodeKey == null) return null;
+        return _nodes.TryGetValue(nodeKey, out var node) ? node : null;
+    }
+
+    /// <summary>
+    /// Returns the direct children of the given node by following its outgoing edges.
+    /// Returns an empty list if the node is not found.
+    /// </summary>
+    public IReadOnlyList<AgentGraphNode> GetChildNodes(string nodeKey)
+    {
+        var node = GetNode(nodeKey);
+        if (node == null) return Array.Empty<AgentGraphNode>();
+
+        return node.Edges
+            .Select(edge => GetNode(edge.Key))
+            .Where(n => n != null)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Returns all nodes that have an outgoing edge pointing to the given node key.
+    /// </summary>
+    public IReadOnlyList<AgentGraphNode> GetParentNodes(string nodeKey)
+    {
+        return _nodes.Values
+            .Where(node => node.Edges.Any(edge => edge.Key == nodeKey))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Returns all nodes with no outgoing edges (leaf nodes).
+    /// </summary>
+    public IReadOnlyList<AgentGraphNode> TerminalNodes() =>
+        _nodes.Values.Where(n => n.IsTerminal).ToList();
+
+    /// <summary>
+    /// Returns the raw flag value including LaunchDarkly metadata. Always non-null,
+    /// even when <see cref="Enabled"/> is false.
+    /// </summary>
+    public AgentGraphFlagValue GetConfig() => _flagValue;
+
+    /// <summary>
+    /// Creates a new graph-level tracker for this invocation.
+    /// </summary>
+    public AiGraphTracker CreateTracker() => _createTracker();
+
+    /// <summary>
+    /// Performs a breadth-first traversal of the graph starting from the root node.
+    /// For each visited node, <paramref name="fn"/> is called with the node and the
+    /// accumulated context dictionary. The return value of <paramref name="fn"/> is
+    /// stored in the context under the node's key and passed to subsequent calls.
+    /// Cycle-safe: each node is visited at most once.
+    /// </summary>
+    public void Traverse(
+        Func<AgentGraphNode, Dictionary<string, object>, object> fn,
+        Dictionary<string, object> initialContext = null)
+    {
+        var root = RootNode();
+        if (root == null) return;
+
+        var context = initialContext ?? new Dictionary<string, object>();
+
+        var visited = new HashSet<string>();
+        var queue = new Queue<AgentGraphNode>();
+        queue.Enqueue(root);
+        visited.Add(root.Key);
+
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            var result = fn(node, context);
+            context[node.Key] = result;
+
+            foreach (var child in GetChildNodes(node.Key))
+            {
+                if (visited.Add(child.Key))
+                {
+                    queue.Enqueue(child);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a reverse breadth-first traversal: starts from terminal nodes and
+    /// works upward toward the root. The root node is always processed last.
+    /// Cycle-safe: each node is visited at most once.
+    /// </summary>
+    public void ReverseTraverse(
+        Func<AgentGraphNode, Dictionary<string, object>, object> fn,
+        Dictionary<string, object> initialContext = null)
+    {
+        if (_nodes.Count == 0) return;
+
+        var context = initialContext ?? new Dictionary<string, object>();
+
+        var root = RootNode();
+        var visited = new HashSet<string>();
+        var queue = new Queue<AgentGraphNode>();
+
+        // Seed with terminal nodes (excluding root if it happens to be terminal and there are others)
+        foreach (var terminal in TerminalNodes())
+        {
+            if (root != null && terminal.Key == root.Key && _nodes.Count > 1)
+            {
+                continue;
+            }
+            if (visited.Add(terminal.Key))
+            {
+                queue.Enqueue(terminal);
+            }
+        }
+
+        // If no terminals were seeded (e.g. single-node graph that is also root), seed root directly
+        if (queue.Count == 0 && root != null && visited.Add(root.Key))
+        {
+            queue.Enqueue(root);
+        }
+
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+
+            // Defer root until the very end (unless it's the only node)
+            if (root != null && node.Key == root.Key && _nodes.Count > 1)
+            {
+                continue;
+            }
+
+            var result = fn(node, context);
+            context[node.Key] = result;
+
+            foreach (var parent in GetParentNodes(node.Key))
+            {
+                if (root != null && parent.Key == root.Key)
+                {
+                    // Don't enqueue root yet — process it last
+                    continue;
+                }
+                if (visited.Add(parent.Key))
+                {
+                    queue.Enqueue(parent);
+                }
+            }
+        }
+
+        // Process root last
+        if (root != null && _nodes.Count > 1)
+        {
+            var result = fn(root, context);
+            context[root.Key] = result;
+        }
+    }
+
+    /// <summary>
+    /// Builds the nodes dictionary from a parsed flag value and a map of pre-fetched
+    /// agent configs, associating each node with its outgoing edges from the flag value.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, AgentGraphNode> BuildNodes(
+        AgentGraphFlagValue flagValue,
+        IReadOnlyDictionary<string, LdAiAgentConfig> agentConfigs)
+    {
+        var nodes = new Dictionary<string, AgentGraphNode>();
+        var allKeys = CollectAllKeys(flagValue);
+
+        foreach (var key in allKeys)
+        {
+            if (!agentConfigs.TryGetValue(key, out var config))
+                continue;
+
+            var outgoingEdges = flagValue.Edges != null && flagValue.Edges.TryGetValue(key, out var edges)
+                ? edges
+                : (IReadOnlyList<GraphEdge>)Array.Empty<GraphEdge>();
+
+            nodes[key] = new AgentGraphNode(key, config, outgoingEdges);
+        }
+
+        return nodes;
+    }
+
+    /// <summary>
+    /// Collects all unique node keys referenced in the flag value: the root, all
+    /// edge source keys, and all edge target keys.
+    /// </summary>
+    internal static HashSet<string> CollectAllKeys(AgentGraphFlagValue flagValue)
+    {
+        var keys = new HashSet<string>();
+
+        if (!string.IsNullOrEmpty(flagValue?.Root))
+        {
+            keys.Add(flagValue.Root);
+        }
+
+        if (flagValue?.Edges != null)
+        {
+            foreach (var kv in flagValue.Edges)
+            {
+                keys.Add(kv.Key);
+                foreach (var edge in kv.Value)
+                {
+                    keys.Add(edge.Key);
+                }
+            }
+        }
+
+        return keys;
+    }
+}

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -208,9 +208,7 @@ public sealed class AgentGraphDefinition
 
         foreach (var key in allKeys)
         {
-            if (!agentConfigs.TryGetValue(key, out var config))
-                continue;
-
+            var config = agentConfigs[key];
             var outgoingEdges = flagValue.Edges != null && flagValue.Edges.TryGetValue(key, out var edges)
                 ? edges
                 : (IReadOnlyList<GraphEdge>)Array.Empty<GraphEdge>();

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -160,10 +160,19 @@ public sealed class AgentGraphDefinition
             }
         }
 
-        // If no terminals were seeded (e.g. single-node graph that is also root), seed root directly
-        if (queue.Count == 0 && root != null && visited.Add(root.Key))
+        // If no terminals were seeded (pure cycle — no leaf nodes exist), seed all non-root nodes
+        // so every node is still visited. For a single-node graph (or self-loop), fall back to
+        // seeding root itself as the only node.
+        if (queue.Count == 0 && root != null)
         {
-            queue.Enqueue(root);
+            foreach (var n in _nodes.Values)
+            {
+                if (n.Key == root.Key) continue;
+                if (visited.Add(n.Key))
+                    queue.Enqueue(n);
+            }
+            if (queue.Count == 0 && visited.Add(root.Key))
+                queue.Enqueue(root);
         }
 
         while (queue.Count > 0)

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphFlagValue.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphFlagValue.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Graph;
+
+/// <summary>
+/// Raw flag value for an agent graph configuration as returned by LaunchDarkly.
+/// Returned by <see cref="AgentGraphDefinition.GetConfig"/>.
+/// </summary>
+public sealed class AgentGraphFlagValue
+{
+    /// <summary>
+    /// The key of the root AIAgentConfig in the graph.
+    /// </summary>
+    public string Root { get; init; }
+
+    /// <summary>
+    /// Object mapping source agent config keys to arrays of outgoing target edges.
+    /// Null when no edges are defined.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<GraphEdge>> Edges { get; init; }
+
+    /// <summary>
+    /// LaunchDarkly metadata from the <c>_ldMeta</c> field on the flag value.
+    /// Null when a default/fallback value was used (flag not evaluated).
+    /// </summary>
+    public LdMeta Meta { get; init; }
+}
+
+/// <summary>
+/// LaunchDarkly metadata from the <c>_ldMeta</c> field on flag values.
+/// </summary>
+public sealed class LdMeta
+{
+    /// <summary>
+    /// The variation key, if available. Null when a default config was used.
+    /// </summary>
+    public string VariationKey { get; init; }
+
+    /// <summary>
+    /// The version of the flag variation. Defaults to 1.
+    /// </summary>
+    public int Version { get; init; } = 1;
+
+    /// <summary>
+    /// Whether the configuration is enabled in the LaunchDarkly dashboard.
+    /// Defaults to true. Note: this is distinct from
+    /// <see cref="AgentGraphDefinition.Enabled"/>, which reflects the result of ALL
+    /// validation checks (metadata enabled + root present + all nodes reachable +
+    /// all child configs fetchable).
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+}

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphNode.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphNode.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Graph;
+
+/// <summary>
+/// Represents a single node within an agent graph.
+/// Each node wraps an <see cref="LdAiAgentConfig"/> and carries the outgoing edges to
+/// its children. Use the config's tracker (via <c>Config.CreateTracker()</c>) to record
+/// node-level metrics.
+/// </summary>
+public sealed class AgentGraphNode
+{
+    /// <summary>
+    /// The agent config key for this node.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// The agent config for this node.
+    /// </summary>
+    public LdAiAgentConfig Config { get; }
+
+    /// <summary>
+    /// The outgoing edges from this node to its children.
+    /// </summary>
+    public IReadOnlyList<GraphEdge> Edges { get; }
+
+    /// <summary>
+    /// Whether this node has no outgoing edges (i.e., is a leaf node).
+    /// </summary>
+    public bool IsTerminal => Edges.Count == 0;
+
+    /// <summary>
+    /// Constructs an agent graph node.
+    /// </summary>
+    public AgentGraphNode(string key, LdAiAgentConfig config, IReadOnlyList<GraphEdge> edges)
+    {
+        Key = key;
+        Config = config;
+        Edges = edges;
+    }
+}

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -174,7 +174,7 @@ public sealed class AiGraphTracker
                 nameof(token));
         }
 
-        return new AiGraphTracker(ldClient, payload.GraphKey, payload.Version > 0 ? payload.Version.Value : 1, context,
+        return new AiGraphTracker(ldClient, payload.GraphKey, payload.Version ?? 1, context,
             payload.VariationKey, payload.RunId);
     }
 

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -263,7 +263,7 @@ public sealed class AiGraphTracker
             return;
         }
 
-        var pathArray = LdValue.ArrayFrom(System.Linq.Enumerable.Select(path, LdValue.Of));
+        var pathArray = LdValue.ArrayFrom(path.Select(LdValue.Of));
         var data = MergeTrackData("path", pathArray);
         _client.Track(GraphPath, _context, data, 1);
     }

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Graph;
+
+/// <summary>
+/// Tracking metadata included in every graph tracker event.
+/// </summary>
+public sealed record AiGraphTrackData(
+    string RunId,
+    string GraphKey,
+    string VariationKey,
+    int Version
+);
+
+/// <summary>
+/// Records metrics for a single agent graph invocation.
+/// </summary>
+/// <remarks>
+/// All events share a <c>runId</c> so LaunchDarkly can correlate them. Graph-level
+/// tracking methods (<c>TrackInvocationSuccess</c>, <c>TrackDuration</c>, etc.) are
+/// at-most-once — a second call logs a warning and is silently dropped. Edge-level
+/// methods (<c>TrackRedirect</c>, <c>TrackHandoffSuccess</c>, <c>TrackHandoffFailure</c>)
+/// are multi-fire and may be called once per edge traversal.
+/// </remarks>
+public sealed class AiGraphTracker
+{
+    private readonly ILaunchDarklyClient _client;
+    private readonly string _runId;
+    private readonly string _graphKey;
+    private readonly string _variationKey;
+    private readonly int _version;
+    private readonly Context _context;
+    private readonly LdValue _trackData;
+    private readonly ILogger _logger;
+
+    private StrongBox<bool> _trackedInvocation;
+    private StrongBox<double> _durationMs;
+    private StrongBox<Usage> _tokens;
+    private StrongBox<IReadOnlyList<string>> _path;
+
+    private readonly Lazy<string> _resumptionToken;
+
+    private const string GraphInvocationSuccess = "$ld:ai:graph:invocation_success";
+    private const string GraphInvocationFailure = "$ld:ai:graph:invocation_failure";
+    private const string GraphDuration = "$ld:ai:graph:duration:total";
+    private const string GraphTotalTokens = "$ld:ai:graph:total_tokens";
+    private const string GraphPath = "$ld:ai:graph:path";
+    private const string GraphRedirect = "$ld:ai:graph:redirect";
+    private const string GraphHandoffSuccess = "$ld:ai:graph:handoff_success";
+    private const string GraphHandoffFailure = "$ld:ai:graph:handoff_failure";
+
+    /// <summary>
+    /// Constructs a new graph tracker. If <paramref name="runId"/> is null, a new UUIDv4
+    /// is generated automatically.
+    /// </summary>
+    public AiGraphTracker(
+        ILaunchDarklyClient ldClient,
+        string graphKey,
+        int version,
+        Context context,
+        string variationKey = null,
+        string runId = null)
+    {
+        _client = ldClient ?? throw new ArgumentNullException(nameof(ldClient));
+        _graphKey = graphKey ?? throw new ArgumentNullException(nameof(graphKey));
+        _runId = runId ?? Guid.NewGuid().ToString();
+        _variationKey = variationKey ?? "";
+        _version = version;
+        _context = context;
+        _logger = _client.GetLogger();
+
+        var trackDataBuilder = new Dictionary<string, LdValue>
+        {
+            { "runId", LdValue.Of(_runId) },
+            { "graphKey", LdValue.Of(_graphKey) },
+            { "version", LdValue.Of(_version) },
+        };
+        if (!string.IsNullOrEmpty(_variationKey))
+        {
+            trackDataBuilder.Add("variationKey", LdValue.Of(_variationKey));
+        }
+        _trackData = LdValue.ObjectFrom(trackDataBuilder);
+
+        _resumptionToken = new Lazy<string>(BuildResumptionToken);
+    }
+
+    /// <summary>
+    /// The resumption token for cross-process continuation of this tracker.
+    /// </summary>
+    public string ResumptionToken => _resumptionToken.Value;
+
+    /// <summary>
+    /// A partial snapshot of the metrics tracked so far. Fields are null until the
+    /// corresponding track method fires.
+    /// </summary>
+    public AiGraphMetricSummary Summary => new AiGraphMetricSummary(
+        _trackedInvocation?.Value,
+        _durationMs?.Value,
+        _tokens?.Value,
+        _path?.Value,
+        null,
+        ResumptionToken
+    );
+
+    /// <summary>
+    /// Returns the track data included in every event fired by this tracker.
+    /// </summary>
+    public AiGraphTrackData GetTrackData() =>
+        new AiGraphTrackData(_runId, _graphKey,
+            string.IsNullOrEmpty(_variationKey) ? null : _variationKey,
+            _version);
+
+    private string BuildResumptionToken()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("runId", _runId);
+            writer.WriteString("graphKey", _graphKey);
+            if (!string.IsNullOrEmpty(_variationKey))
+            {
+                writer.WriteString("variationKey", _variationKey);
+            }
+            writer.WriteNumber("version", _version);
+            writer.WriteEndObject();
+        }
+        var base64 = Convert.ToBase64String(stream.ToArray());
+        return base64.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Reconstructs a graph tracker from a resumption token, enabling cross-process
+    /// scenarios where a tracker's run ID needs to be reused.
+    /// </summary>
+    public static AiGraphTracker FromResumptionToken(
+        string token, ILaunchDarklyClient ldClient, Context context)
+    {
+        if (token == null) throw new ArgumentNullException(nameof(token));
+        if (ldClient == null) throw new ArgumentNullException(nameof(ldClient));
+
+        var base64 = token.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+
+        GraphResumptionPayload payload;
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+            payload = JsonSerializer.Deserialize<GraphResumptionPayload>(json);
+        }
+        catch (Exception e) when (!(e is OutOfMemoryException))
+        {
+            throw new ArgumentException("Invalid graph resumption token", nameof(token), e);
+        }
+
+        if (payload == null || string.IsNullOrEmpty(payload.RunId) || string.IsNullOrEmpty(payload.GraphKey))
+        {
+            throw new ArgumentException(
+                "Graph resumption token is missing required fields (runId, graphKey)",
+                nameof(token));
+        }
+
+        return new AiGraphTracker(ldClient, payload.GraphKey, payload.Version, context,
+            payload.VariationKey, payload.RunId);
+    }
+
+    /// <summary>
+    /// Records a successful graph invocation. At-most-once; shares a slot with
+    /// <see cref="TrackInvocationFailure"/>.
+    /// </summary>
+    public void TrackInvocationSuccess()
+    {
+        if (Interlocked.CompareExchange(ref _trackedInvocation,
+                new StrongBox<bool>(true), null) != null)
+        {
+            _logger?.Warn("Skipping TrackInvocationSuccess: invocation already recorded on this graph tracker. {0}",
+                _trackData.ToJsonString());
+            return;
+        }
+        _client.Track(GraphInvocationSuccess, _context, _trackData, 1);
+    }
+
+    /// <summary>
+    /// Records a failed graph invocation. At-most-once; shares a slot with
+    /// <see cref="TrackInvocationSuccess"/>.
+    /// </summary>
+    public void TrackInvocationFailure()
+    {
+        if (Interlocked.CompareExchange(ref _trackedInvocation,
+                new StrongBox<bool>(false), null) != null)
+        {
+            _logger?.Warn("Skipping TrackInvocationFailure: invocation already recorded on this graph tracker. {0}",
+                _trackData.ToJsonString());
+            return;
+        }
+        _client.Track(GraphInvocationFailure, _context, _trackData, 1);
+    }
+
+    /// <summary>
+    /// Records the total duration of the graph invocation in milliseconds. At-most-once.
+    /// </summary>
+    public void TrackDuration(double durationMs)
+    {
+        if (Interlocked.CompareExchange(ref _durationMs,
+                new StrongBox<double>(durationMs), null) != null)
+        {
+            _logger?.Warn("Skipping TrackDuration: duration already recorded on this graph tracker. {0}",
+                _trackData.ToJsonString());
+            return;
+        }
+        _client.Track(GraphDuration, _context, _trackData, durationMs);
+    }
+
+    /// <summary>
+    /// Records the aggregate token usage across all nodes. At-most-once.
+    /// </summary>
+    public void TrackTotalTokens(Usage tokens)
+    {
+        if (Interlocked.CompareExchange(ref _tokens,
+                new StrongBox<Usage>(tokens), null) != null)
+        {
+            _logger?.Warn("Skipping TrackTotalTokens: tokens already recorded on this graph tracker. {0}",
+                _trackData.ToJsonString());
+            return;
+        }
+        if (tokens.Total is > 0)
+        {
+            _client.Track(GraphTotalTokens, _context, _trackData, tokens.Total.Value);
+        }
+    }
+
+    /// <summary>
+    /// Records the path of node keys visited during graph execution. At-most-once.
+    /// </summary>
+    public void TrackPath(IReadOnlyList<string> path)
+    {
+        if (Interlocked.CompareExchange(ref _path,
+                new StrongBox<IReadOnlyList<string>>(path), null) != null)
+        {
+            _logger?.Warn("Skipping TrackPath: path already recorded on this graph tracker. {0}",
+                _trackData.ToJsonString());
+            return;
+        }
+
+        var pathArray = LdValue.ArrayFrom(System.Linq.Enumerable.Select(path, LdValue.Of));
+        var data = MergeTrackData("path", pathArray);
+        _client.Track(GraphPath, _context, data, 1);
+    }
+
+    /// <summary>
+    /// Records that a node redirected execution to a different target than the configured edge.
+    /// Multi-fire — may be called once per redirect that occurs.
+    /// </summary>
+    public void TrackRedirect(string sourceKey, string redirectedTarget)
+    {
+        var data = MergeTrackData(new Dictionary<string, LdValue>
+        {
+            { "sourceKey", LdValue.Of(sourceKey) },
+            { "redirectedTarget", LdValue.Of(redirectedTarget) }
+        });
+        _client.Track(GraphRedirect, _context, data, 1);
+    }
+
+    /// <summary>
+    /// Records a successful handoff from one node to another.
+    /// Multi-fire — may be called once per handoff that occurs.
+    /// </summary>
+    public void TrackHandoffSuccess(string sourceKey, string targetKey)
+    {
+        var data = MergeTrackData(new Dictionary<string, LdValue>
+        {
+            { "sourceKey", LdValue.Of(sourceKey) },
+            { "targetKey", LdValue.Of(targetKey) }
+        });
+        _client.Track(GraphHandoffSuccess, _context, data, 1);
+    }
+
+    /// <summary>
+    /// Records a failed handoff from one node to another.
+    /// Multi-fire — may be called once per failed handoff that occurs.
+    /// </summary>
+    public void TrackHandoffFailure(string sourceKey, string targetKey)
+    {
+        var data = MergeTrackData(new Dictionary<string, LdValue>
+        {
+            { "sourceKey", LdValue.Of(sourceKey) },
+            { "targetKey", LdValue.Of(targetKey) }
+        });
+        _client.Track(GraphHandoffFailure, _context, data, 1);
+    }
+
+    private LdValue MergeTrackData(string key, LdValue value)
+    {
+        var builder = new Dictionary<string, LdValue>(_trackData.Dictionary);
+        builder[key] = value;
+        return LdValue.ObjectFrom(builder);
+    }
+
+    private LdValue MergeTrackData(Dictionary<string, LdValue> extra)
+    {
+        var builder = new Dictionary<string, LdValue>(_trackData.Dictionary);
+        foreach (var kv in extra)
+        {
+            builder[kv.Key] = kv.Value;
+        }
+        return LdValue.ObjectFrom(builder);
+    }
+
+    private class GraphResumptionPayload
+    {
+        [JsonPropertyName("runId")]
+        public string RunId { get; set; }
+
+        [JsonPropertyName("graphKey")]
+        public string GraphKey { get; set; }
+
+        [JsonPropertyName("variationKey")]
+        public string VariationKey { get; set; }
+
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 1;
+    }
+}

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Linq;
 using System.Threading;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 using LaunchDarkly.Sdk.Server.Ai.Tracking;

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -229,6 +229,11 @@ public sealed class AiGraphTracker
     /// </summary>
     public void TrackTotalTokens(Usage tokens)
     {
+        // Empty usage doesn't burn the slot.
+        if ((tokens.Total ?? 0) <= 0)
+        {
+            return;
+        }
         if (Interlocked.CompareExchange(ref _tokens,
                 new StrongBox<Usage>(tokens), null) != null)
         {
@@ -236,10 +241,7 @@ public sealed class AiGraphTracker
                 _trackData.ToJsonString());
             return;
         }
-        if (tokens.Total is > 0)
-        {
-            _client.Track(GraphTotalTokens, _context, _trackData, tokens.Total.Value);
-        }
+        _client.Track(GraphTotalTokens, _context, _trackData, tokens.Total.Value);
     }
 
     /// <summary>

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -173,7 +173,7 @@ public sealed class AiGraphTracker
                 nameof(token));
         }
 
-        return new AiGraphTracker(ldClient, payload.GraphKey, payload.Version, context,
+        return new AiGraphTracker(ldClient, payload.GraphKey, payload.Version > 0 ? payload.Version.Value : 1, context,
             payload.VariationKey, payload.RunId);
     }
 
@@ -338,6 +338,6 @@ public sealed class AiGraphTracker
         public string VariationKey { get; set; }
 
         [JsonPropertyName("version")]
-        public int Version { get; set; } = 1;
+        public int? Version { get; set; }
     }
 }

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -255,7 +255,7 @@ public sealed class AiGraphTracker
         if (path == null) return;
 
         if (Interlocked.CompareExchange(ref _path,
-                new StrongBox<IReadOnlyList<string>>(path), null) != null)
+                new StrongBox<IReadOnlyList<string>>(path.ToArray()), null) != null)
         {
             _logger?.Warn("Skipping TrackPath: path already recorded on this graph tracker. {0}",
                 _trackData.ToJsonString());

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -230,7 +230,7 @@ public sealed class AiGraphTracker
     public void TrackTotalTokens(Usage tokens)
     {
         // Empty usage doesn't burn the slot.
-        if ((tokens.Total ?? 0) <= 0)
+        if ((tokens.Total ?? 0) <= 0 && (tokens.Input ?? 0) <= 0 && (tokens.Output ?? 0) <= 0)
         {
             return;
         }
@@ -241,7 +241,10 @@ public sealed class AiGraphTracker
                 _trackData.ToJsonString());
             return;
         }
-        _client.Track(GraphTotalTokens, _context, _trackData, tokens.Total.Value);
+        var total = (tokens.Total ?? 0) > 0
+            ? tokens.Total.Value
+            : (tokens.Input ?? 0) + (tokens.Output ?? 0);
+        _client.Track(GraphTotalTokens, _context, _trackData, total);
     }
 
     /// <summary>

--- a/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AiGraphTracker.cs
@@ -249,6 +249,8 @@ public sealed class AiGraphTracker
     /// </summary>
     public void TrackPath(IReadOnlyList<string> path)
     {
+        if (path == null) return;
+
         if (Interlocked.CompareExchange(ref _path,
                 new StrongBox<IReadOnlyList<string>>(path), null) != null)
         {

--- a/pkgs/sdk/server-ai/src/Graph/GraphEdge.cs
+++ b/pkgs/sdk/server-ai/src/Graph/GraphEdge.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Graph;
+
+/// <summary>
+/// A directed edge in an agent graph, connecting a source node to a target node.
+/// The source is implicit — it is the node that owns this edge.
+/// </summary>
+public sealed record GraphEdge(
+    string Key,
+    IReadOnlyDictionary<string, LdValue> Handoff
+);

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk.Server.Ai.Config;
-using LaunchDarkly.Sdk.Server.Ai.Graph;
-
 namespace LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 /// <summary>
@@ -103,27 +101,4 @@ public interface ILdAiClient
     /// <param name="context">the context to use for track events</param>
     /// <returns>a tracker associated with the original runId</returns>
     public ILdAiConfigTracker CreateTracker(string resumptionToken, Context context);
-
-    /// <summary>
-    /// Retrieves and validates an agent graph identified by <paramref name="graphKey"/>.
-    /// Fires a usage tracking event, evaluates the graph flag, fetches all agent configs
-    /// referenced in the graph, and performs connectivity validation. Returns an
-    /// <see cref="AgentGraphDefinition"/> whose <c>Enabled</c> property indicates whether
-    /// all validation steps passed.
-    /// </summary>
-    /// <param name="graphKey">the LaunchDarkly flag key for the agent graph</param>
-    /// <param name="context">the context</param>
-    /// <param name="variables">optional variables interpolated into each node's agent instructions</param>
-    /// <returns>an agent graph definition</returns>
-    public AgentGraphDefinition AgentGraph(string graphKey, Context context,
-        IReadOnlyDictionary<string, object> variables = null);
-
-    /// <summary>
-    /// Reconstructs a graph tracker from a resumption token. This enables cross-process
-    /// continuation of graph-level metrics.
-    /// </summary>
-    /// <param name="resumptionToken">the token obtained from <see cref="AiGraphTracker.ResumptionToken"/></param>
-    /// <param name="context">the context to use for track events</param>
-    /// <returns>a graph tracker associated with the original run</returns>
-    public AiGraphTracker CreateGraphTracker(string resumptionToken, Context context);
 }

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
 
 namespace LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
@@ -102,4 +103,27 @@ public interface ILdAiClient
     /// <param name="context">the context to use for track events</param>
     /// <returns>a tracker associated with the original runId</returns>
     public ILdAiConfigTracker CreateTracker(string resumptionToken, Context context);
+
+    /// <summary>
+    /// Retrieves and validates an agent graph identified by <paramref name="graphKey"/>.
+    /// Fires a usage tracking event, evaluates the graph flag, fetches all agent configs
+    /// referenced in the graph, and performs connectivity validation. Returns an
+    /// <see cref="AgentGraphDefinition"/> whose <c>Enabled</c> property indicates whether
+    /// all validation steps passed.
+    /// </summary>
+    /// <param name="graphKey">the LaunchDarkly flag key for the agent graph</param>
+    /// <param name="context">the context</param>
+    /// <param name="variables">optional variables interpolated into each node's agent instructions</param>
+    /// <returns>an agent graph definition</returns>
+    public AgentGraphDefinition AgentGraph(string graphKey, Context context,
+        IReadOnlyDictionary<string, object> variables = null);
+
+    /// <summary>
+    /// Reconstructs a graph tracker from a resumption token. This enables cross-process
+    /// continuation of graph-level metrics.
+    /// </summary>
+    /// <param name="resumptionToken">the token obtained from <see cref="AiGraphTracker.ResumptionToken"/></param>
+    /// <param name="context">the context to use for track events</param>
+    /// <returns>a graph tracker associated with the original run</returns>
+    public AiGraphTracker CreateGraphTracker(string resumptionToken, Context context);
 }

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+
 namespace LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 /// <summary>

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiGraphClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiGraphClient.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Interfaces;
+
+/// <summary>
+/// Extension interface for agent graph operations. Implemented alongside
+/// <see cref="ILdAiClient"/> by <see cref="LdAiClient"/>.
+/// </summary>
+public interface ILdAiGraphClient
+{
+    /// <summary>
+    /// Retrieves and validates an agent graph identified by <paramref name="graphKey"/>.
+    /// Fires a usage tracking event, evaluates the graph flag, fetches all agent configs
+    /// referenced in the graph, and performs connectivity validation. Returns an
+    /// <see cref="AgentGraphDefinition"/> whose <c>Enabled</c> property indicates whether
+    /// all validation steps passed.
+    /// </summary>
+    /// <param name="graphKey">the LaunchDarkly flag key for the agent graph</param>
+    /// <param name="context">the context</param>
+    /// <param name="variables">optional variables interpolated into each node's agent instructions</param>
+    /// <returns>an agent graph definition</returns>
+    AgentGraphDefinition AgentGraph(string graphKey, Context context,
+        IReadOnlyDictionary<string, object> variables = null);
+
+    /// <summary>
+    /// Reconstructs a graph tracker from a resumption token. This enables cross-process
+    /// continuation of graph-level metrics.
+    /// </summary>
+    /// <param name="resumptionToken">the token obtained from <see cref="AiGraphTracker.ResumptionToken"/></param>
+    /// <param name="context">the context to use for track events</param>
+    /// <returns>a graph tracker associated with the original run</returns>
+    AiGraphTracker CreateGraphTracker(string resumptionToken, Context context);
+}

--- a/pkgs/sdk/server-ai/src/Interfaces/ILogger.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILogger.cs
@@ -18,4 +18,11 @@ public interface ILogger
     /// <param name="format">format string</param>
     /// <param name="allParams">parameters</param>
     void Warn(string format, params object[] allParams);
+
+    /// <summary>
+    /// Log a debug message.
+    /// </summary>
+    /// <param name="format">format string</param>
+    /// <param name="allParams">parameters</param>
+    void Debug(string format, params object[] allParams);
 }

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -13,7 +13,7 @@ namespace LaunchDarkly.Sdk.Server.Ai;
 /// The LaunchDarkly AI client. The client is capable of retrieving AI Configs from LaunchDarkly,
 /// and generating events specific to usage of the AI Config when interacting with model providers.
 /// </summary>
-public sealed class LdAiClient : ILdAiClient
+public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
 {
     private readonly ILaunchDarklyClient _client;
     private readonly ConfigFactory _factory;

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -155,13 +155,13 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
 
         if (parsed.Meta?.Enabled == false)
         {
-            _client.GetLogger()?.Warn($"agentGraph: graph \"{graphKey}\" is disabled.");
+            _client.GetLogger()?.Debug($"agentGraph: graph \"{graphKey}\" is disabled.");
             return disabled;
         }
 
         if (string.IsNullOrEmpty(parsed.Root))
         {
-            _client.GetLogger()?.Warn($"agentGraph: graph \"{graphKey}\" is not fetchable or has no root node.");
+            _client.GetLogger()?.Debug($"agentGraph: graph \"{graphKey}\" is not fetchable or has no root node.");
             return disabled;
         }
 
@@ -170,7 +170,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         var unreachable = allKeys.FirstOrDefault(k => !reachableKeys.Contains(k));
         if (unreachable != null)
         {
-            _client.GetLogger()?.Warn(
+            _client.GetLogger()?.Debug(
                 $"agentGraph: graph \"{graphKey}\" has unconnected node \"{unreachable}\" that is not reachable from the root.");
             return disabled;
         }
@@ -181,7 +181,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
             var config = BuildAgentConfig(key, context, null, variables, graphKey);
             if (!config.Enabled)
             {
-                _client.GetLogger()?.Warn(
+                _client.GetLogger()?.Debug(
                     $"agentGraph: agent config \"{key}\" in graph \"{graphKey}\" is not enabled or could not be fetched.");
                 return disabled;
             }

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
@@ -225,7 +226,8 @@ public sealed class LdAiClient : ILdAiClient
                     var handoffVal = edgeVal.Get("handoff");
                     if (handoffVal.Type == LdValueType.Object)
                     {
-                        handoff = handoffVal.Dictionary.ToDictionary(h => h.Key, h => h.Value);
+                        handoff = new ReadOnlyDictionary<string, LdValue>(
+                            handoffVal.Dictionary.ToDictionary(h => h.Key, h => h.Value));
                     }
 
                     edgeList.Add(new GraphEdge(targetKey, handoff));

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -232,9 +232,9 @@ public sealed class LdAiClient : ILdAiClient
 
                     edgeList.Add(new GraphEdge(targetKey, handoff));
                 }
-                edgesDict[kv.Key] = edgeList;
+                edgesDict[kv.Key] = edgeList.AsReadOnly();
             }
-            edges = edgesDict;
+            edges = new ReadOnlyDictionary<string, IReadOnlyList<GraphEdge>>(edgesDict);
         }
 
         LdMeta meta = null;

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -10,8 +10,9 @@ using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 namespace LaunchDarkly.Sdk.Server.Ai;
 
 /// <summary>
-/// The LaunchDarkly AI client. The client is capable of retrieving AI Configs from LaunchDarkly,
-/// and generating events specific to usage of the AI Config when interacting with model providers.
+/// The LaunchDarkly AI client. The client is capable of retrieving AI Configs and agent graphs
+/// from LaunchDarkly, and generating events specific to usage of those configs when interacting
+/// with model providers.
 /// </summary>
 public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
 {

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -247,7 +247,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
             meta = new LdMeta
             {
                 VariationKey = metaValue.Get("variationKey").AsString,
-                Version = versionVal.IsNull ? 1 : versionVal.AsInt,
+                Version = versionVal.IsNull || versionVal.AsInt <= 0 ? 1 : versionVal.AsInt,
                 Enabled = enabledVal.IsNull || enabledVal.AsBool
             };
         }

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai;
@@ -21,6 +22,7 @@ public sealed class LdAiClient : ILdAiClient
     private const string TrackUsageAgentConfig = "$ld:ai:usage:agent-config";
     private const string TrackUsageAgentConfigs = "$ld:ai:usage:agent-configs";
     private const string TrackUsageJudgeConfig = "$ld:ai:usage:judge-config";
+    private const string TrackUsageAgentGraph = "$ld:ai:usage:agent-graph";
 
     /// <summary>
     /// Constructs a new LaunchDarkly AI client. Please note, the client library is an alpha release and is
@@ -79,11 +81,12 @@ public sealed class LdAiClient : ILdAiClient
 
     private LdAiAgentConfig BuildAgentConfig(string key, Context context,
         LdAiAgentConfigDefault defaultValue,
-        IReadOnlyDictionary<string, object> variables)
+        IReadOnlyDictionary<string, object> variables,
+        string graphKey = null)
     {
         defaultValue ??= LdAiAgentConfigDefault.Disabled;
         var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables);
+        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables, graphKey);
     }
 
     /// <inheritdoc/>
@@ -124,5 +127,152 @@ public sealed class LdAiClient : ILdAiClient
     public ILdAiConfigTracker CreateTracker(string resumptionToken, Context context)
     {
         return LdAiConfigTracker.FromResumptionToken(resumptionToken, _client, context);
+    }
+
+    /// <inheritdoc/>
+    public AgentGraphDefinition AgentGraph(string graphKey, Context context,
+        IReadOnlyDictionary<string, object> variables = null)
+    {
+        _client.Track(TrackUsageAgentGraph, context, LdValue.Of(graphKey), 1);
+
+        var defaultFlagValue = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+        {
+            { "root", LdValue.Of("") }
+        });
+        var flagValue = _client.JsonVariation(graphKey, context, defaultFlagValue);
+        var parsed = ParseAgentGraphFlagValue(flagValue);
+
+        var variationKey = parsed.Meta?.VariationKey;
+        var version = parsed.Meta?.Version ?? 1;
+        AiGraphTracker TrackerFactory() => new AiGraphTracker(_client, graphKey, version, context, variationKey);
+
+        var disabled = new AgentGraphDefinition(parsed,
+            new Dictionary<string, AgentGraphNode>(),
+            enabled: false,
+            createTracker: TrackerFactory);
+
+        if (parsed.Meta?.Enabled == false)
+        {
+            _client.GetLogger()?.Warn($"agentGraph: graph \"{graphKey}\" is disabled.");
+            return disabled;
+        }
+
+        if (string.IsNullOrEmpty(parsed.Root))
+        {
+            _client.GetLogger()?.Warn($"agentGraph: graph \"{graphKey}\" is not fetchable or has no root node.");
+            return disabled;
+        }
+
+        var allKeys = AgentGraphDefinition.CollectAllKeys(parsed);
+        var reachableKeys = CollectReachableKeys(parsed);
+        var unreachable = allKeys.FirstOrDefault(k => !reachableKeys.Contains(k));
+        if (unreachable != null)
+        {
+            _client.GetLogger()?.Warn(
+                $"agentGraph: graph \"{graphKey}\" has unconnected node \"{unreachable}\" that is not reachable from the root.");
+            return disabled;
+        }
+
+        var agentConfigs = new Dictionary<string, LdAiAgentConfig>();
+        foreach (var key in allKeys)
+        {
+            var config = BuildAgentConfig(key, context, null, variables, graphKey);
+            if (!config.Enabled)
+            {
+                _client.GetLogger()?.Warn(
+                    $"agentGraph: agent config \"{key}\" in graph \"{graphKey}\" is not enabled or could not be fetched.");
+                return disabled;
+            }
+            agentConfigs[key] = config;
+        }
+
+        var nodes = AgentGraphDefinition.BuildNodes(parsed, agentConfigs);
+        return new AgentGraphDefinition(parsed, nodes, enabled: true, createTracker: TrackerFactory);
+    }
+
+    /// <inheritdoc/>
+    public AiGraphTracker CreateGraphTracker(string resumptionToken, Context context)
+    {
+        return AiGraphTracker.FromResumptionToken(resumptionToken, _client, context);
+    }
+
+    private static AgentGraphFlagValue ParseAgentGraphFlagValue(LdValue flagValue)
+    {
+        if (flagValue.Type != LdValueType.Object)
+        {
+            return new AgentGraphFlagValue { Root = "" };
+        }
+
+        var root = flagValue.Get("root").AsString ?? "";
+
+        IReadOnlyDictionary<string, IReadOnlyList<GraphEdge>> edges = null;
+        var edgesValue = flagValue.Get("edges");
+        if (edgesValue.Type == LdValueType.Object)
+        {
+            var edgesDict = new Dictionary<string, IReadOnlyList<GraphEdge>>();
+            foreach (var kv in edgesValue.Dictionary)
+            {
+                if (kv.Value.Type != LdValueType.Array) continue;
+                var edgeList = new List<GraphEdge>();
+                for (var i = 0; i < kv.Value.Count; i++)
+                {
+                    var edgeVal = kv.Value.Get(i);
+                    if (edgeVal.Type != LdValueType.Object) continue;
+                    var targetKey = edgeVal.Get("key").AsString;
+                    if (string.IsNullOrEmpty(targetKey)) continue;
+
+                    IReadOnlyDictionary<string, LdValue> handoff = null;
+                    var handoffVal = edgeVal.Get("handoff");
+                    if (handoffVal.Type == LdValueType.Object)
+                    {
+                        handoff = handoffVal.Dictionary.ToDictionary(h => h.Key, h => h.Value);
+                    }
+
+                    edgeList.Add(new GraphEdge(targetKey, handoff));
+                }
+                edgesDict[kv.Key] = edgeList;
+            }
+            edges = edgesDict;
+        }
+
+        LdMeta meta = null;
+        var metaValue = flagValue.Get("_ldMeta");
+        if (metaValue.Type == LdValueType.Object)
+        {
+            var versionVal = metaValue.Get("version");
+            var enabledVal = metaValue.Get("enabled");
+            meta = new LdMeta
+            {
+                VariationKey = metaValue.Get("variationKey").AsString,
+                Version = versionVal.IsNull ? 1 : versionVal.AsInt,
+                Enabled = enabledVal.IsNull || enabledVal.AsBool
+            };
+        }
+
+        return new AgentGraphFlagValue { Root = root, Edges = edges, Meta = meta };
+    }
+
+    private static HashSet<string> CollectReachableKeys(AgentGraphFlagValue flagValue)
+    {
+        var visited = new HashSet<string> { flagValue.Root };
+        var queue = new Queue<string>();
+        queue.Enqueue(flagValue.Root);
+
+        while (queue.Count > 0)
+        {
+            var key = queue.Dequeue();
+            if (flagValue.Edges != null && flagValue.Edges.TryGetValue(key, out var edges))
+            {
+                foreach (var edge in edges)
+                {
+                    if (visited.Add(edge.Key))
+                    {
+                        queue.Enqueue(edge.Key);
+                    }
+                }
+            }
+        }
+
+        return visited;
     }
 }

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -247,7 +247,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
             meta = new LdMeta
             {
                 VariationKey = metaValue.Get("variationKey").AsString,
-                Version = versionVal.IsNull || versionVal.AsInt <= 0 ? 1 : versionVal.AsInt,
+                Version = versionVal.IsNull ? 1 : versionVal.AsInt,
                 Enabled = enabledVal.IsNull || enabledVal.AsBool
             };
         }

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -29,6 +29,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     private readonly ILaunchDarklyClient _client;
     private readonly string _runId;
     private readonly string _configKey;
+    private readonly string _graphKey;
     private readonly string _variationKey;
     private readonly int _version;
     private readonly Context _context;
@@ -68,11 +69,13 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     /// funnel through this single constructor.
     /// </summary>
     internal LdAiConfigTracker(ILaunchDarklyClient client, string runId, string configKey,
-        string variationKey, int version, Context context, string modelName, string providerName)
+        string variationKey, int version, Context context, string modelName, string providerName,
+        string graphKey = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _configKey = configKey ?? throw new ArgumentNullException(nameof(configKey));
         _runId = runId ?? "";
+        _graphKey = graphKey ?? "";
         _variationKey = variationKey ?? "";
         _version = version;
         _context = context;
@@ -88,6 +91,10 @@ public class LdAiConfigTracker : ILdAiConfigTracker
             { "modelName", LdValue.Of(_modelName) },
             { "providerName", LdValue.Of(_providerName) },
         };
+        if (!string.IsNullOrEmpty(_graphKey))
+        {
+            trackDataBuilder.Add("graphKey", LdValue.Of(_graphKey));
+        }
         if (!string.IsNullOrEmpty(_variationKey))
         {
             trackDataBuilder.Add("variationKey", LdValue.Of(_variationKey));
@@ -103,14 +110,18 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     private string BuildResumptionToken()
     {
         // Utf8JsonWriter gives stable key ordering and avoids the runtime cost of
-        // anonymous-type reflection. The wire format omits empty variationKey so that
-        // resumption tokens round-trip exactly for configs that never carried one.
+        // anonymous-type reflection. The wire format omits empty optional fields so that
+        // resumption tokens round-trip exactly for configs that never carried them.
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
         {
             writer.WriteStartObject();
             writer.WriteString("runId", _runId);
             writer.WriteString("configKey", _configKey);
+            if (!string.IsNullOrEmpty(_graphKey))
+            {
+                writer.WriteString("graphKey", _graphKey);
+            }
             if (!string.IsNullOrEmpty(_variationKey))
             {
                 writer.WriteString("variationKey", _variationKey);
@@ -414,7 +425,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         }
 
         return new LdAiConfigTracker(client, payload.RunId, payload.ConfigKey,
-            payload.VariationKey, payload.Version, context, "", "");
+            payload.VariationKey, payload.Version, context, "", "", payload.GraphKey);
     }
 
     private class ResumptionPayload
@@ -424,6 +435,9 @@ public class LdAiConfigTracker : ILdAiConfigTracker
 
         [JsonPropertyName("configKey")]
         public string ConfigKey { get; set; }
+
+        [JsonPropertyName("graphKey")]
+        public string GraphKey { get; set; }
 
         [JsonPropertyName("variationKey")]
         public string VariationKey { get; set; }

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -425,7 +425,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         }
 
         return new LdAiConfigTracker(client, payload.RunId, payload.ConfigKey,
-            payload.VariationKey, payload.Version, context, "", "", payload.GraphKey);
+            payload.VariationKey, payload.Version > 0 ? payload.Version.Value : 1, context, "", "", payload.GraphKey);
     }
 
     private class ResumptionPayload
@@ -443,6 +443,6 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         public string VariationKey { get; set; }
 
         [JsonPropertyName("version")]
-        public int Version { get; set; } = 1;
+        public int? Version { get; set; }
     }
 }

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -425,7 +425,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         }
 
         return new LdAiConfigTracker(client, payload.RunId, payload.ConfigKey,
-            payload.VariationKey, payload.Version > 0 ? payload.Version.Value : 1, context, "", "", payload.GraphKey);
+            payload.VariationKey, payload.Version ?? 1, context, "", "", payload.GraphKey);
     }
 
     private class ResumptionPayload

--- a/pkgs/sdk/server-ai/src/Polyfills/IsExternalInit.cs
+++ b/pkgs/sdk/server-ai/src/Polyfills/IsExternalInit.cs
@@ -1,0 +1,13 @@
+// Required for C# 9+ init-only properties when targeting net462 or netstandard2.0.
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    using System.ComponentModel;
+
+    // Polyfill for the IsExternalInit marker class, which the C# compiler requires
+    // for 'init' accessors and positional record properties but which is only defined
+    // in .NET 5+ runtimes.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
+}
+#endif

--- a/pkgs/sdk/server-ai/src/Tracking/AiGraphMetricSummary.cs
+++ b/pkgs/sdk/server-ai/src/Tracking/AiGraphMetricSummary.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Tracking;
+
+/// <summary>
+/// A summary of the metrics tracked by an <c>AiGraphTracker</c> during a graph invocation.
+/// </summary>
+/// <param name="Success">whether the overall graph invocation succeeded</param>
+/// <param name="DurationMs">the total duration in milliseconds</param>
+/// <param name="Tokens">the aggregate token usage across the graph</param>
+/// <param name="Path">the sequence of node keys visited during execution</param>
+/// <param name="NodeMetrics">per-node metric summaries keyed by agent config key</param>
+/// <param name="ResumptionToken">the resumption token for cross-process continuation</param>
+public record struct AiGraphMetricSummary(
+    bool? Success,
+    double? DurationMs,
+    Usage? Tokens,
+    IReadOnlyList<string> Path,
+    IReadOnlyDictionary<string, MetricSummary> NodeMetrics,
+    string ResumptionToken
+);

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -227,7 +227,7 @@ public class AgentGraphDefinitionTest
         Assert.Equal("my-graph-key", tracker.GetTrackData().GraphKey);
     }
 
-    // Test 35: Cycle-safe — ReverseTraverse on pure cycle visits every node, root last
+    // Test 35: Cycle-safe — pure cycle has no terminal nodes, so reverse traversal is a no-op
     [Fact]
     public void ReverseTraverseIsCycleSafe()
     {

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -227,7 +227,47 @@ public class AgentGraphDefinitionTest
         Assert.Equal("my-graph-key", tracker.GetTrackData().GraphKey);
     }
 
-    // Test 35: Cycle-safe — graph with cycles doesn't infinite loop
+    // Test 35: Cycle-safe — ReverseTraverse on pure cycle visits every node, root last
+    [Fact]
+    public void ReverseTraverseIsCycleSafe()
+    {
+        // a → b → c → a (pure cycle, no terminal nodes)
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = "a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null) },
+                ["b"] = new[] { new GraphEdge("c", null) },
+                ["c"] = new[] { new GraphEdge("a", null) }
+            },
+            Meta = new LdMeta { Enabled = true }
+        };
+        var configs = new Dictionary<string, LdAiAgentConfig>
+        {
+            ["a"] = MakeAgentConfig("a"),
+            ["b"] = MakeAgentConfig("b"),
+            ["c"] = MakeAgentConfig("c")
+        };
+
+        var graph = BuildEnabled(flagValue, configs);
+
+        var visited = new List<string>();
+        graph.ReverseTraverse((node, ctx) =>
+        {
+            visited.Add(node.Key);
+            return null;
+        });
+
+        // All three nodes visited exactly once, root last
+        Assert.Equal(3, visited.Count);
+        Assert.Contains("a", visited);
+        Assert.Contains("b", visited);
+        Assert.Contains("c", visited);
+        Assert.Equal("a", visited[visited.Count - 1]);
+    }
+
+    // Test 36: Cycle-safe — graph with cycles doesn't infinite loop
     [Fact]
     public void TraverseIsCycleSafe()
     {

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -259,12 +259,8 @@ public class AgentGraphDefinitionTest
             return null;
         });
 
-        // All three nodes visited exactly once, root last
-        Assert.Equal(3, visited.Count);
-        Assert.Contains("a", visited);
-        Assert.Contains("b", visited);
-        Assert.Contains("c", visited);
-        Assert.Equal("a", visited[visited.Count - 1]);
+        // Pure cycle has no terminal nodes — reverse traversal is a no-op per spec AIGRAPH 1.4
+        Assert.Empty(visited);
     }
 
     // Test 36: Cycle-safe — graph with cycles doesn't infinite loop

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+/// <summary>
+/// Tests for AgentGraphDefinition (spec tests 26–35).
+/// </summary>
+public class AgentGraphDefinitionTest
+{
+    private static LdAiAgentConfig MakeAgentConfig(string key, bool enabled = true)
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        return new LdAiAgentConfig(
+            key: key,
+            enabled: enabled,
+            variationKey: "v1",
+            version: 1,
+            instructions: null,
+            tools: new Dictionary<string, LdAiConfigTypes.Tool>(),
+            model: null,
+            provider: null,
+            judgeConfiguration: null,
+            trackerFactory: _ => new LdAiConfigTracker(mockClient.Object, Guid.NewGuid().ToString(),
+                key, "v1", 1, Context.New("u"), "", ""));
+    }
+
+    private static AgentGraphFlagValue ThreeNodeFlagValue()
+    {
+        return new AgentGraphFlagValue
+        {
+            Root = "agent-a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["agent-a"] = new[] { new GraphEdge("agent-b", null) },
+                ["agent-b"] = new[] { new GraphEdge("agent-c", null) }
+            },
+            Meta = new LdMeta { VariationKey = "v1", Version = 1, Enabled = true }
+        };
+    }
+
+    private static IReadOnlyDictionary<string, LdAiAgentConfig> ThreeNodeConfigs()
+    {
+        return new Dictionary<string, LdAiAgentConfig>
+        {
+            ["agent-a"] = MakeAgentConfig("agent-a"),
+            ["agent-b"] = MakeAgentConfig("agent-b"),
+            ["agent-c"] = MakeAgentConfig("agent-c")
+        };
+    }
+
+    private static AgentGraphDefinition BuildEnabled(AgentGraphFlagValue flagValue,
+        IReadOnlyDictionary<string, LdAiAgentConfig> configs)
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, configs);
+        return new AgentGraphDefinition(flagValue, nodes, enabled: true,
+            createTracker: () => new AiGraphTracker(mockClient.Object, "g", 1, Context.New("u")));
+    }
+
+    // Test 26: BuildNodes populates each node with structured GraphEdge[] from flag value edges map
+    [Fact]
+    public void BuildNodesPopulatesEdgesFromFlagValue()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var configs = ThreeNodeConfigs();
+
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, configs);
+
+        Assert.Equal(3, nodes.Count);
+        Assert.True(nodes.ContainsKey("agent-a"));
+        Assert.True(nodes.ContainsKey("agent-b"));
+        Assert.True(nodes.ContainsKey("agent-c"));
+
+        Assert.Single(nodes["agent-a"].Edges);
+        Assert.Equal("agent-b", nodes["agent-a"].Edges[0].Key);
+
+        Assert.Single(nodes["agent-b"].Edges);
+        Assert.Equal("agent-c", nodes["agent-b"].Edges[0].Key);
+
+        Assert.Empty(nodes["agent-c"].Edges);
+    }
+
+    // Test 27: GetChildNodes maps through node's Edges (edge.Key → node lookup)
+    [Fact]
+    public void GetChildNodesMapsEdgesToNodes()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var childrenOfA = graph.GetChildNodes("agent-a");
+        Assert.Single(childrenOfA);
+        Assert.Equal("agent-b", childrenOfA[0].Key);
+
+        var childrenOfB = graph.GetChildNodes("agent-b");
+        Assert.Single(childrenOfB);
+        Assert.Equal("agent-c", childrenOfB[0].Key);
+
+        var childrenOfC = graph.GetChildNodes("agent-c");
+        Assert.Empty(childrenOfC);
+    }
+
+    // Test 28: GetParentNodes finds all nodes whose edges reference the given key
+    [Fact]
+    public void GetParentNodesFindsByEdgeTarget()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var parentsOfA = graph.GetParentNodes("agent-a");
+        Assert.Empty(parentsOfA);
+
+        var parentsOfB = graph.GetParentNodes("agent-b");
+        Assert.Single(parentsOfB);
+        Assert.Equal("agent-a", parentsOfB[0].Key);
+
+        var parentsOfC = graph.GetParentNodes("agent-c");
+        Assert.Single(parentsOfC);
+        Assert.Equal("agent-b", parentsOfC[0].Key);
+    }
+
+    // Test 29: TerminalNodes returns nodes with no outgoing edges
+    [Fact]
+    public void TerminalNodesReturnsLeafNodes()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var terminals = graph.TerminalNodes();
+        Assert.Single(terminals);
+        Assert.Equal("agent-c", terminals[0].Key);
+    }
+
+    // Test 30: RootNode returns node matching GetConfig().Root
+    [Fact]
+    public void RootNodeReturnsNodeMatchingRoot()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var root = graph.RootNode();
+        Assert.NotNull(root);
+        Assert.Equal("agent-a", root.Key);
+        Assert.Equal(graph.GetConfig().Root, root.Key);
+    }
+
+    // Test 31: GetConfig returns AgentGraphFlagValue with Meta nested (variationKey, version, enabled)
+    [Fact]
+    public void GetConfigReturnsFlagValueWithMeta()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var graph = BuildEnabled(flagValue, ThreeNodeConfigs());
+
+        var config = graph.GetConfig();
+        Assert.Equal("agent-a", config.Root);
+        Assert.NotNull(config.Meta);
+        Assert.Equal("v1", config.Meta.VariationKey);
+        Assert.Equal(1, config.Meta.Version);
+        Assert.True(config.Meta.Enabled);
+    }
+
+    // Test 31b: GetConfig is still available when graph is disabled
+    [Fact]
+    public void GetConfigAvailableOnDisabledGraph()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        var disabled = new AgentGraphDefinition(flagValue, new Dictionary<string, AgentGraphNode>(),
+            enabled: false, createTracker: () => new AiGraphTracker(mockClient.Object, "g", 1, Context.New("u")));
+
+        Assert.False(disabled.Enabled);
+        Assert.Same(flagValue, disabled.GetConfig());
+    }
+
+    // Test 32: Traverse visits nodes BFS from root
+    [Fact]
+    public void TraverseVisitsNodesInBfsOrder()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var visited = new List<string>();
+        graph.Traverse((node, ctx) =>
+        {
+            visited.Add(node.Key);
+            return null;
+        });
+
+        Assert.Equal(new[] { "agent-a", "agent-b", "agent-c" }, visited);
+    }
+
+    // Test 33: ReverseTraverse visits from terminals upward, root always last
+    [Fact]
+    public void ReverseTraverseVisitsRootLast()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var visited = new List<string>();
+        graph.ReverseTraverse((node, ctx) =>
+        {
+            visited.Add(node.Key);
+            return null;
+        });
+
+        Assert.Equal(3, visited.Count);
+        Assert.Equal("agent-c", visited[0]);
+        Assert.Equal("agent-a", visited[visited.Count - 1]);
+    }
+
+    // Test 34: CreateTracker returns AiGraphTracker with correct graphKey
+    [Fact]
+    public void CreateTrackerReturnsGraphTrackerWithGraphKey()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        var context = Context.New("user");
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, ThreeNodeConfigs());
+        var graph = new AgentGraphDefinition(flagValue, nodes, enabled: true,
+            createTracker: () => new AiGraphTracker(mockClient.Object, "my-graph-key", 1, context));
+
+        var tracker = graph.CreateTracker();
+        Assert.Equal("my-graph-key", tracker.GetTrackData().GraphKey);
+    }
+
+    // Test 35: Cycle-safe — graph with cycles doesn't infinite loop
+    [Fact]
+    public void TraverseIsCycleSafe()
+    {
+        // a → b → c → a (cycle)
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = "a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null) },
+                ["b"] = new[] { new GraphEdge("c", null) },
+                ["c"] = new[] { new GraphEdge("a", null) }
+            },
+            Meta = new LdMeta { Enabled = true }
+        };
+        var configs = new Dictionary<string, LdAiAgentConfig>
+        {
+            ["a"] = MakeAgentConfig("a"),
+            ["b"] = MakeAgentConfig("b"),
+            ["c"] = MakeAgentConfig("c")
+        };
+
+        var graph = BuildEnabled(flagValue, configs);
+
+        var visited = new List<string>();
+        graph.Traverse((node, ctx) =>
+        {
+            visited.Add(node.Key);
+            return null;
+        });
+
+        // Each node visited exactly once despite cycle
+        Assert.Equal(3, visited.Count);
+        Assert.Contains("a", visited);
+        Assert.Contains("b", visited);
+        Assert.Contains("c", visited);
+    }
+
+    [Fact]
+    public void GetNodeReturnsNullForUnknownKey()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+        Assert.Null(graph.GetNode("nonexistent"));
+    }
+
+    [Fact]
+    public void GetChildNodesReturnsEmptyForUnknownNode()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+        Assert.Empty(graph.GetChildNodes("nonexistent"));
+    }
+
+    [Fact]
+    public void CollectAllKeysIncludesRootEdgeSourcesAndTargets()
+    {
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = "a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) }
+            }
+        };
+
+        var keys = AgentGraphDefinition.CollectAllKeys(flagValue);
+        Assert.Contains("a", keys);
+        Assert.Contains("b", keys);
+        Assert.Contains("c", keys);
+        Assert.Equal(3, keys.Count);
+    }
+
+    [Fact]
+    public void BuildNodesSkipsKeysMissingFromConfigs()
+    {
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = "a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null) }
+            }
+        };
+        // Only provide config for "a", not "b"
+        var configs = new Dictionary<string, LdAiAgentConfig>
+        {
+            ["a"] = MakeAgentConfig("a")
+        };
+
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, configs);
+        Assert.Single(nodes);
+        Assert.True(nodes.ContainsKey("a"));
+        Assert.False(nodes.ContainsKey("b"));
+    }
+
+    [Fact]
+    public void TraversePassesContextBetweenNodes()
+    {
+        var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
+
+        var ctx = new Dictionary<string, object>();
+        graph.Traverse((node, context) =>
+        {
+            context[$"{node.Key}-visited"] = true;
+            return node.Key.ToUpper();
+        }, ctx);
+
+        Assert.Equal("AGENT-A", ctx["agent-a"]);
+        Assert.Equal("AGENT-B", ctx["agent-b"]);
+        Assert.Equal("AGENT-C", ctx["agent-c"]);
+    }
+
+    [Fact]
+    public void IsTerminalTrueForNodeWithNoEdges()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, ThreeNodeConfigs());
+
+        Assert.False(nodes["agent-a"].IsTerminal);
+        Assert.False(nodes["agent-b"].IsTerminal);
+        Assert.True(nodes["agent-c"].IsTerminal);
+    }
+
+    [Fact]
+    public void GraphEdgeHandoffDataPreserved()
+    {
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = "a",
+            Edges = new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[]
+                {
+                    new GraphEdge("b", new Dictionary<string, LdValue> { ["tool"] = LdValue.Of("search") })
+                }
+            }
+        };
+        var configs = new Dictionary<string, LdAiAgentConfig>
+        {
+            ["a"] = MakeAgentConfig("a"),
+            ["b"] = MakeAgentConfig("b")
+        };
+
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, configs);
+        var edge = nodes["a"].Edges[0];
+        Assert.Equal("b", edge.Key);
+        Assert.NotNull(edge.Handoff);
+        Assert.Equal("search", edge.Handoff["tool"].AsString);
+    }
+
+    [Fact]
+    public void GraphEdgeWithNoHandoffHasNullHandoff()
+    {
+        var flagValue = ThreeNodeFlagValue();
+        var nodes = AgentGraphDefinition.BuildNodes(flagValue, ThreeNodeConfigs());
+        Assert.Null(nodes["agent-a"].Edges[0].Handoff);
+    }
+}

--- a/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
@@ -374,6 +374,66 @@ public class AiGraphTrackerTest
         Assert.True(Guid.TryParse(td.RunId, out _));
     }
 
+    // At-most-once — second TrackPath logs warning and drops
+    [Fact]
+    public void TrackPathAtMostOnce()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackPath(new[] { "a", "b" });
+        tracker.TrackPath(new[] { "a", "b" });
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:path",
+            context,
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Once);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    // At-most-once — second TrackTotalTokens logs warning and drops
+    [Fact]
+    public void TrackTotalTokensAtMostOnce()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(100, 60, 40));
+        tracker.TrackTotalTokens(new Usage(100, 60, 40));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            context,
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Once);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    // Empty Usage does not consume the TrackTotalTokens slot
+    [Fact]
+    public void TrackTotalTokensEmptyUsageDoesNotConsumeSlot()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(0, 0, 0));
+        tracker.TrackTotalTokens(new Usage(100, 60, 40));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            100.0), Times.Once);
+    }
+
     // TrackTotalTokens derives total from Input+Output when Total is null
     [Fact]
     public void TrackTotalTokensDerivesSumWhenTotalIsNull()

--- a/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
@@ -373,4 +373,55 @@ public class AiGraphTrackerTest
         // Should be a valid GUID format
         Assert.True(Guid.TryParse(td.RunId, out _));
     }
+
+    // TrackTotalTokens derives total from Input+Output when Total is null
+    [Fact]
+    public void TrackTotalTokensDerivesSumWhenTotalIsNull()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(null, 60, 40));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            100.0), Times.Once);
+    }
+
+    // TrackTotalTokens does not fire when Total is null and Input/Output are both absent
+    [Fact]
+    public void TrackTotalTokensDropsWhenAllFieldsEmpty()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(null, null, null));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            It.IsAny<Context>(),
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Never);
+    }
+
+    // TrackTotalTokens fires when only Output is provided (Total and Input null)
+    [Fact]
+    public void TrackTotalTokensUsesOutputAloneWhenInputIsNull()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(null, null, 75));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            75.0), Times.Once);
+    }
 }

--- a/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/AiGraphTrackerTest.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+/// <summary>
+/// Tests for AiGraphTracker (spec tests 14–25).
+/// </summary>
+public class AiGraphTrackerTest
+{
+    private static Mock<ILaunchDarklyClient> MockClient()
+    {
+        var mock = new Mock<ILaunchDarklyClient>();
+        mock.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        return mock;
+    }
+
+    private static AiGraphTracker MakeTracker(ILaunchDarklyClient client, Context context,
+        string graphKey = "my-graph", string variationKey = "v1", int version = 2, string runId = null)
+    {
+        return new AiGraphTracker(client, graphKey, version, context, variationKey, runId);
+    }
+
+    // Test 14: TrackInvocationSuccess fires correct event with track data
+    [Fact]
+    public void TrackInvocationSuccessFiresCorrectEvent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackInvocationSuccess();
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:invocation_success",
+            context,
+            It.Is<LdValue>(v =>
+                v.Get("graphKey").AsString == "my-graph" &&
+                v.Get("version").AsInt == 2 &&
+                v.Get("variationKey").AsString == "v1" &&
+                v.Get("runId").Type == LdValueType.String),
+            1.0), Times.Once);
+    }
+
+    // Test 15: TrackInvocationFailure fires correct event
+    [Fact]
+    public void TrackInvocationFailureFiresCorrectEvent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackInvocationFailure();
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:invocation_failure",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            1.0), Times.Once);
+    }
+
+    // Test 16: TrackDuration fires correct event with duration as metric value
+    [Fact]
+    public void TrackDurationFiresCorrectEvent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackDuration(250.5);
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:duration:total",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            250.5), Times.Once);
+    }
+
+    // Test 17: TrackTotalTokens fires correct event
+    [Fact]
+    public void TrackTotalTokensFiresCorrectEvent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackTotalTokens(new Usage(100, 60, 40));
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:total_tokens",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            100.0), Times.Once);
+    }
+
+    // Test 18: TrackPath fires correct event with path array in data
+    [Fact]
+    public void TrackPathFiresCorrectEventWithPathInData()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackPath(new[] { "agent-a", "agent-b", "agent-c" });
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:path",
+            context,
+            It.Is<LdValue>(v =>
+                v.Get("graphKey").AsString == "my-graph" &&
+                v.Get("path").Type == LdValueType.Array &&
+                v.Get("path").Count == 3 &&
+                v.Get("path").Get(0).AsString == "agent-a" &&
+                v.Get("path").Get(1).AsString == "agent-b" &&
+                v.Get("path").Get(2).AsString == "agent-c"),
+            1.0), Times.Once);
+    }
+
+    // Test 19: At-most-once — second TrackDuration logs warning and drops
+    [Fact]
+    public void TrackDurationAtMostOnce()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackDuration(100.0);
+        tracker.TrackDuration(200.0);
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:duration:total",
+            context,
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Once);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    // Test 20: Success/failure share slot: TrackInvocationSuccess then TrackInvocationFailure → second dropped
+    [Fact]
+    public void InvocationSuccessAndFailureShareSlot()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackInvocationSuccess();
+        tracker.TrackInvocationFailure();
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:invocation_success",
+            context,
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Once);
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:invocation_failure",
+            context,
+            It.IsAny<LdValue>(),
+            It.IsAny<double>()), Times.Never);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    // Test 21: Edge methods (redirect, handoff success/failure) are multi-fire
+    [Fact]
+    public void EdgeMethodsAreMultiFire()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackRedirect("a", "b");
+        tracker.TrackRedirect("a", "c");
+        tracker.TrackHandoffSuccess("a", "b");
+        tracker.TrackHandoffSuccess("b", "c");
+        tracker.TrackHandoffFailure("a", "x");
+        tracker.TrackHandoffFailure("b", "y");
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:redirect", context, It.IsAny<LdValue>(), It.IsAny<double>()), Times.Exactly(2));
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:handoff_success", context, It.IsAny<LdValue>(), It.IsAny<double>()), Times.Exactly(2));
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:handoff_failure", context, It.IsAny<LdValue>(), It.IsAny<double>()), Times.Exactly(2));
+    }
+
+    // Test 22: Summary reflects tracked values incrementally
+    [Fact]
+    public void SummaryReflectsTrackedValues()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        Assert.Null(tracker.Summary.Success);
+        Assert.Null(tracker.Summary.DurationMs);
+
+        tracker.TrackInvocationSuccess();
+        Assert.Equal(true, tracker.Summary.Success);
+
+        tracker.TrackDuration(100.0);
+        Assert.Equal(100.0, tracker.Summary.DurationMs);
+
+        tracker.TrackTotalTokens(new Usage(50, 30, 20));
+        Assert.Equal(50, tracker.Summary.Tokens?.Total);
+
+        tracker.TrackPath(new[] { "a", "b" });
+        Assert.Equal(new[] { "a", "b" }, tracker.Summary.Path);
+    }
+
+    // Test 23: GetTrackData returns correct RunId, GraphKey, VariationKey, Version
+    [Fact]
+    public void GetTrackDataReturnsCorrectFields()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var runId = Guid.NewGuid().ToString();
+        var tracker = new AiGraphTracker(mockClient.Object, "graph-key", 3, context, "vkey", runId);
+
+        var td = tracker.GetTrackData();
+        Assert.Equal(runId, td.RunId);
+        Assert.Equal("graph-key", td.GraphKey);
+        Assert.Equal("vkey", td.VariationKey);
+        Assert.Equal(3, td.Version);
+    }
+
+    // Test 23b: VariationKey is null in GetTrackData when not provided
+    [Fact]
+    public void GetTrackDataVariationKeyNullWhenAbsent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = new AiGraphTracker(mockClient.Object, "graph-key", 1, context);
+
+        var td = tracker.GetTrackData();
+        Assert.Null(td.VariationKey);
+    }
+
+    // Test 24: ResumptionToken round-trips correctly
+    [Fact]
+    public void ResumptionTokenRoundTrips()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var runId = Guid.NewGuid().ToString();
+        var tracker = new AiGraphTracker(mockClient.Object, "graph-key", 5, context, "var-key", runId);
+
+        var token = tracker.ResumptionToken;
+        Assert.NotEmpty(token);
+
+        var base64 = token.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(runId, doc.RootElement.GetProperty("runId").GetString());
+        Assert.Equal("graph-key", doc.RootElement.GetProperty("graphKey").GetString());
+        Assert.Equal("var-key", doc.RootElement.GetProperty("variationKey").GetString());
+        Assert.Equal(5, doc.RootElement.GetProperty("version").GetInt32());
+    }
+
+    // Test 24b: ResumptionToken omits variationKey when absent
+    [Fact]
+    public void ResumptionTokenOmitsVariationKeyWhenAbsent()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = new AiGraphTracker(mockClient.Object, "graph-key", 1, context);
+
+        var token = tracker.ResumptionToken;
+        var base64 = token.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+        var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("variationKey", out _));
+    }
+
+    // Test 25: FromResumptionToken reconstructs tracker with same runId
+    [Fact]
+    public void FromResumptionTokenReconstructsTracker()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var runId = Guid.NewGuid().ToString();
+        var original = new AiGraphTracker(mockClient.Object, "graph-key", 2, context, "vkey", runId);
+
+        var token = original.ResumptionToken;
+        var reconstructed = AiGraphTracker.FromResumptionToken(token, mockClient.Object, context);
+
+        var td = reconstructed.GetTrackData();
+        Assert.Equal(runId, td.RunId);
+        Assert.Equal("graph-key", td.GraphKey);
+        Assert.Equal("vkey", td.VariationKey);
+        Assert.Equal(2, td.Version);
+    }
+
+    [Fact]
+    public void FromResumptionTokenThrowsOnNullToken()
+    {
+        var mockClient = MockClient();
+        Assert.Throws<ArgumentNullException>(() =>
+            AiGraphTracker.FromResumptionToken(null, mockClient.Object, Context.New("u")));
+    }
+
+    [Fact]
+    public void FromResumptionTokenThrowsOnMalformedToken()
+    {
+        var mockClient = MockClient();
+        Assert.Throws<ArgumentException>(() =>
+            AiGraphTracker.FromResumptionToken("not-valid-base64!!!", mockClient.Object, Context.New("u")));
+    }
+
+    [Fact]
+    public void EdgeMethodsIncludeSourceAndTargetKeys()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context);
+
+        tracker.TrackRedirect("src-node", "redir-node");
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:redirect",
+            context,
+            It.Is<LdValue>(v =>
+                v.Get("sourceKey").AsString == "src-node" &&
+                v.Get("redirectedTarget").AsString == "redir-node"),
+            1.0), Times.Once);
+
+        tracker.TrackHandoffSuccess("src-node", "tgt-node");
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:handoff_success",
+            context,
+            It.Is<LdValue>(v =>
+                v.Get("sourceKey").AsString == "src-node" &&
+                v.Get("targetKey").AsString == "tgt-node"),
+            1.0), Times.Once);
+
+        tracker.TrackHandoffFailure("src-node", "bad-node");
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:graph:handoff_failure",
+            context,
+            It.Is<LdValue>(v =>
+                v.Get("sourceKey").AsString == "src-node" &&
+                v.Get("targetKey").AsString == "bad-node"),
+            1.0), Times.Once);
+    }
+
+    [Fact]
+    public void RunIdIsAutoGeneratedWhenNotProvided()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = new AiGraphTracker(mockClient.Object, "graph-key", 1, context);
+
+        var td = tracker.GetTrackData();
+        Assert.NotEmpty(td.RunId);
+        // Should be a valid GUID format
+        Assert.True(Guid.TryParse(td.RunId, out _));
+    }
+}

--- a/pkgs/sdk/server-ai/test/LdAiAgentGraphConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiAgentGraphConfigTest.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+/// <summary>
+/// Tests graphKey threading through LdAiConfigTracker (spec tests 1–3).
+/// </summary>
+public class LdAiAgentGraphConfigTest
+{
+    private static Mock<ILaunchDarklyClient> MockClient()
+    {
+        var mock = new Mock<ILaunchDarklyClient>();
+        mock.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        return mock;
+    }
+
+    private static LdAiConfigTracker MakeTracker(ILaunchDarklyClient client, Context context,
+        string graphKey = null)
+    {
+        return new LdAiConfigTracker(client, Guid.NewGuid().ToString(), "config-key",
+            "v1", 1, context, "model", "provider", graphKey);
+    }
+
+    // Test 1: Tracker created with graphKey → events include graphKey in data
+    [Fact]
+    public void TrackDataIncludesGraphKeyWhenSet()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context, "my-graph");
+
+        tracker.TrackSuccess();
+
+        mockClient.Verify(c => c.Track(
+            It.IsAny<string>(),
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            It.IsAny<double>()), Times.Once);
+    }
+
+    // Test 2: Tracker created without graphKey → events omit graphKey
+    [Fact]
+    public void TrackDataOmitsGraphKeyWhenNotSet()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context, graphKey: null);
+
+        tracker.TrackSuccess();
+
+        mockClient.Verify(c => c.Track(
+            It.IsAny<string>(),
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").IsNull),
+            It.IsAny<double>()), Times.Once);
+    }
+
+    // Test 3a: ResumptionToken includes graphKey when set; round-trips via FromResumptionToken
+    [Fact]
+    public void ResumptionTokenIncludesGraphKeyWhenSet()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        const string graphKey = "my-graph";
+        var tracker = MakeTracker(mockClient.Object, context, graphKey);
+
+        var token = tracker.ResumptionToken;
+        Assert.NotEmpty(token);
+
+        // Decode and verify graphKey is present
+        var base64 = token.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(graphKey, doc.RootElement.GetProperty("graphKey").GetString());
+    }
+
+    // Test 3b: ResumptionToken omits graphKey when not set
+    [Fact]
+    public void ResumptionTokenOmitsGraphKeyWhenNotSet()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        var tracker = MakeTracker(mockClient.Object, context, graphKey: null);
+
+        var token = tracker.ResumptionToken;
+
+        var base64 = token.Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+        var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("graphKey", out _));
+    }
+
+    // Test 3c: FromResumptionToken reconstructs tracker with same graphKey
+    [Fact]
+    public void FromResumptionTokenRoundTripsGraphKey()
+    {
+        var mockClient = MockClient();
+        var context = Context.New("user");
+        const string graphKey = "round-trip-graph";
+        var original = MakeTracker(mockClient.Object, context, graphKey);
+
+        var token = original.ResumptionToken;
+        var reconstructed = LdAiConfigTracker.FromResumptionToken(token, mockClient.Object, context);
+
+        // The reconstructed tracker should include graphKey in track data
+        reconstructed.TrackSuccess();
+        mockClient.Verify(c => c.Track(
+            It.IsAny<string>(),
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == graphKey),
+            It.IsAny<double>()), Times.Once);
+    }
+}

--- a/pkgs/sdk/server-ai/test/LdAiClientAgentGraphTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientAgentGraphTest.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using LaunchDarkly.Sdk.Server.Ai.Graph;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+/// <summary>
+/// Tests for LdAiClient.AgentGraph() and CreateGraphTracker() (spec tests 36–44).
+/// </summary>
+public class LdAiClientAgentGraphTest
+{
+    private static (LdAiClient client, Mock<ILaunchDarklyClient> mockClient) MakeClient()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(new Mock<ILogger>().Object);
+        return (new LdAiClient(mockClient.Object), mockClient);
+    }
+
+    /// <summary>
+    /// Returns an LdValue representing a valid agent config flag variation for the given key.
+    /// Mode must be "agent" to pass ConfigFactory's mode check.
+    /// </summary>
+    private static LdValue AgentConfigValue(string variationKey = "v1", bool enabled = true)
+    {
+        return LdValue.ObjectFrom(new Dictionary<string, LdValue>
+        {
+            ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["enabled"] = LdValue.Of(enabled),
+                ["variationKey"] = LdValue.Of(variationKey),
+                ["version"] = LdValue.Of(1),
+                ["mode"] = LdValue.Of("agent")
+            }),
+            ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["name"] = LdValue.Of("gpt-4")
+            }),
+            ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["name"] = LdValue.Of("openai")
+            }),
+            ["instructions"] = LdValue.Of("You are helpful.")
+        });
+    }
+
+    /// <summary>
+    /// Returns an LdValue for a two-node graph flag: root=agent-a, edge a→b.
+    /// </summary>
+    private static LdValue TwoNodeGraphValue(string variationKey = "gv1", bool metaEnabled = true)
+    {
+        return LdValue.ObjectFrom(new Dictionary<string, LdValue>
+        {
+            ["root"] = LdValue.Of("agent-a"),
+            ["edges"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["agent-a"] = LdValue.ArrayOf(
+                    LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                    {
+                        ["key"] = LdValue.Of("agent-b")
+                    }))
+            }),
+            ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["enabled"] = LdValue.Of(metaEnabled),
+                ["variationKey"] = LdValue.Of(variationKey),
+                ["version"] = LdValue.Of(2)
+            })
+        });
+    }
+
+    private static void SetupAgentConfigReturns(Mock<ILaunchDarklyClient> mockClient,
+        params string[] nodeKeys)
+    {
+        foreach (var key in nodeKeys)
+        {
+            var capturedKey = key;
+            mockClient.Setup(c => c.JsonVariation(capturedKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+                .Returns(AgentConfigValue());
+        }
+    }
+
+    // Test 36: Valid graph → returns enabled definition with structured nodes/edges
+    [Fact]
+    public void ValidGraphReturnsEnabledDefinition()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue());
+        SetupAgentConfigReturns(mockClient, "agent-a", "agent-b");
+
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.True(result.Enabled);
+        Assert.NotNull(result.RootNode());
+        Assert.Equal("agent-a", result.RootNode().Key);
+        Assert.NotNull(result.GetNode("agent-b"));
+    }
+
+    // Test 37: _ldMeta.enabled === false → AgentGraphDefinition.Enabled = false + warning
+    [Fact]
+    public void MetaDisabledReturnsFalseEnabledWithWarning()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue(metaEnabled: false));
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.False(result.Enabled);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    // Test 38: _ldMeta absent → defaults to enabled (no false check fires)
+    [Fact]
+    public void MissingMetaDefaultsToEnabled()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        // Graph flag with no _ldMeta
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["root"] = LdValue.Of("agent-a"),
+                ["edges"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["agent-a"] = LdValue.ArrayOf(
+                        LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                        {
+                            ["key"] = LdValue.Of("agent-b")
+                        }))
+                })
+            }));
+        SetupAgentConfigReturns(mockClient, "agent-a", "agent-b");
+
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.True(result.Enabled);
+    }
+
+    // Test 39: Missing root → disabled + warning
+    [Fact]
+    public void MissingRootReturnsDisabledWithWarning()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns((string _, Context _, LdValue dv) => dv); // returns default {"root": ""}
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.False(result.Enabled);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    // Test 40: Unconnected node → disabled + warning
+    [Fact]
+    public void UnconnectedNodeReturnsDisabledWithWarning()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+
+        // a → b, but c is listed as edge source from nowhere (disconnected island)
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["root"] = LdValue.Of("agent-a"),
+                ["edges"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["agent-a"] = LdValue.ArrayOf(
+                        LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                        {
+                            ["key"] = LdValue.Of("agent-b")
+                        })),
+                    // agent-c is an edge source not reachable from root
+                    ["agent-c"] = LdValue.ArrayOf(
+                        LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                        {
+                            ["key"] = LdValue.Of("agent-d")
+                        }))
+                }),
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["version"] = LdValue.Of(1)
+                })
+            }));
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.False(result.Enabled);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    // Test 41: Child config disabled → disabled + warning
+    [Fact]
+    public void DisabledChildConfigReturnsDisabledWithWarning()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        mockClient.Setup(c => c.GetLogger()).Returns(mockLogger.Object);
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue());
+        mockClient.Setup(c => c.JsonVariation("agent-a", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(AgentConfigValue(enabled: true));
+        mockClient.Setup(c => c.JsonVariation("agent-b", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(AgentConfigValue(enabled: false));
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.False(result.Enabled);
+        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+    }
+
+    // Test 42: Per-node trackers include graphKey (via BuildAgentConfig threading)
+    [Fact]
+    public void PerNodeTrackersIncludeGraphKey()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue());
+        SetupAgentConfigReturns(mockClient, "agent-a", "agent-b");
+
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.True(result.Enabled);
+
+        // Verify that per-node tracker emits graphKey in track data
+        var nodeTracker = result.GetNode("agent-a").Config.CreateTracker();
+        nodeTracker.TrackSuccess();
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:generation:success",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            It.IsAny<double>()), Times.Once);
+    }
+
+    // Test 43: Disabled definition still has GetConfig() returning the raw flag value
+    [Fact]
+    public void DisabledGraphDefinitionStillExposesGetConfig()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue(variationKey: "var-123", metaEnabled: false));
+
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.False(result.Enabled);
+        var config = result.GetConfig();
+        Assert.NotNull(config);
+        Assert.Equal("agent-a", config.Root);
+        Assert.NotNull(config.Meta);
+        Assert.Equal("var-123", config.Meta.VariationKey);
+    }
+
+    // Test 44: CreateGraphTracker delegates to AiGraphTracker.FromResumptionToken; returned tracker has correct graphKey/runId
+    [Fact]
+    public void CreateGraphTrackerDelegatesToFromResumptionToken()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        var runId = Guid.NewGuid().ToString();
+        var original = new AiGraphTracker(mockClient.Object, "test-graph", 3, context, "vkey", runId);
+        var token = original.ResumptionToken;
+
+        var reconstructed = client.CreateGraphTracker(token, context);
+
+        Assert.Equal(runId, reconstructed.GetTrackData().RunId);
+        Assert.Equal("test-graph", reconstructed.GetTrackData().GraphKey);
+        Assert.Equal("vkey", reconstructed.GetTrackData().VariationKey);
+        Assert.Equal(3, reconstructed.GetTrackData().Version);
+    }
+
+    // Test: AgentGraph fires $ld:ai:usage:agent-graph tracking event
+    [Fact]
+    public void AgentGraphFiresUsageTrackingEvent()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(TwoNodeGraphValue());
+        SetupAgentConfigReturns(mockClient, "agent-a", "agent-b");
+
+        client.AgentGraph("my-graph", context);
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:usage:agent-graph",
+            context,
+            LdValue.Of("my-graph"),
+            1), Times.Once);
+    }
+
+    // Test: Edges with handoff data are parsed correctly
+    [Fact]
+    public void EdgeHandoffDataParsedCorrectly()
+    {
+        var (client, mockClient) = MakeClient();
+        var context = Context.New("user");
+
+        mockClient.Setup(c => c.JsonVariation("my-graph", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["root"] = LdValue.Of("agent-a"),
+                ["edges"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["agent-a"] = LdValue.ArrayOf(
+                        LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                        {
+                            ["key"] = LdValue.Of("agent-b"),
+                            ["handoff"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                            {
+                                ["tool"] = LdValue.Of("search")
+                            })
+                        }))
+                }),
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["version"] = LdValue.Of(1)
+                })
+            }));
+        SetupAgentConfigReturns(mockClient, "agent-a", "agent-b");
+
+        var result = client.AgentGraph("my-graph", context);
+
+        Assert.True(result.Enabled);
+        var edgesFromA = result.GetNode("agent-a").Edges;
+        Assert.Single(edgesFromA);
+        Assert.Equal("agent-b", edgesFromA[0].Key);
+        Assert.NotNull(edgesFromA[0].Handoff);
+        Assert.Equal("search", edgesFromA[0].Handoff["tool"].AsString);
+    }
+}

--- a/pkgs/sdk/server-ai/test/LdAiClientAgentGraphTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientAgentGraphTest.cs
@@ -101,9 +101,9 @@ public class LdAiClientAgentGraphTest
         Assert.NotNull(result.GetNode("agent-b"));
     }
 
-    // Test 37: _ldMeta.enabled === false → AgentGraphDefinition.Enabled = false + warning
+    // Test 37: _ldMeta.enabled === false → AgentGraphDefinition.Enabled = false + debug log
     [Fact]
-    public void MetaDisabledReturnsFalseEnabledWithWarning()
+    public void MetaDisabledReturnsFalseEnabledWithDebugLog()
     {
         var mockLogger = new Mock<ILogger>();
         var mockClient = new Mock<ILaunchDarklyClient>();
@@ -117,7 +117,7 @@ public class LdAiClientAgentGraphTest
         var result = client.AgentGraph("my-graph", context);
 
         Assert.False(result.Enabled);
-        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+        mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
     }
 
     // Test 38: _ldMeta absent → defaults to enabled (no false check fires)
@@ -148,9 +148,9 @@ public class LdAiClientAgentGraphTest
         Assert.True(result.Enabled);
     }
 
-    // Test 39: Missing root → disabled + warning
+    // Test 39: Missing root → disabled + debug log
     [Fact]
-    public void MissingRootReturnsDisabledWithWarning()
+    public void MissingRootReturnsDisabledWithDebugLog()
     {
         var mockLogger = new Mock<ILogger>();
         var mockClient = new Mock<ILaunchDarklyClient>();
@@ -164,12 +164,12 @@ public class LdAiClientAgentGraphTest
         var result = client.AgentGraph("my-graph", context);
 
         Assert.False(result.Enabled);
-        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+        mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
     }
 
-    // Test 40: Unconnected node → disabled + warning
+    // Test 40: Unconnected node → disabled + debug log
     [Fact]
-    public void UnconnectedNodeReturnsDisabledWithWarning()
+    public void UnconnectedNodeReturnsDisabledWithDebugLog()
     {
         var mockLogger = new Mock<ILogger>();
         var mockClient = new Mock<ILaunchDarklyClient>();
@@ -206,12 +206,12 @@ public class LdAiClientAgentGraphTest
         var result = client.AgentGraph("my-graph", context);
 
         Assert.False(result.Enabled);
-        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+        mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
     }
 
-    // Test 41: Child config disabled → disabled + warning
+    // Test 41: Child config disabled → disabled + debug log
     [Fact]
-    public void DisabledChildConfigReturnsDisabledWithWarning()
+    public void DisabledChildConfigReturnsDisabledWithDebugLog()
     {
         var mockLogger = new Mock<ILogger>();
         var mockClient = new Mock<ILaunchDarklyClient>();
@@ -229,7 +229,7 @@ public class LdAiClientAgentGraphTest
         var result = client.AgentGraph("my-graph", context);
 
         Assert.False(result.Enabled);
-        mockLogger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
+        mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.IsAny<object[]>()), Times.AtLeastOnce);
     }
 
     // Test 42: Per-node trackers include graphKey (via BuildAgentConfig threading)


### PR DESCRIPTION
## Summary

Adds first-class support for **agent graphs** to `LaunchDarkly.ServerSdk.Ai`. An agent graph is a LaunchDarkly-managed directed graph whose nodes are existing `LdAiAgentConfig`s and whose edges describe handoffs between agents. The SDK fetches the graph flag, resolves every referenced agent config, validates connectivity, and hands the caller a typed object they can traverse and instrument — without exposing the underlying flag shape.

### `AgentGraph` and `CreateGraphTracker` on `ILdAiGraphClient`

```csharp
// New interface — does not modify ILdAiClient
public interface ILdAiGraphClient
{
    AgentGraphDefinition AgentGraph(
        string graphKey,
        Context context,
        IReadOnlyDictionary<string, object> variables = null);

    AiGraphTracker CreateGraphTracker(string resumptionToken, Context context);
}
```

`LdAiClient` now implements both `ILdAiClient` and the new `ILdAiGraphClient`. The existing `ILdAiClient` interface is **unchanged** — no members added, removed, or modified. Graph functionality lives entirely on the separate `ILdAiGraphClient` interface, making this a purely additive change.

`AgentGraph` fires a `$ld:ai:usage:agent-graph` usage event, evaluates the graph flag, fetches every child `LdAiAgentConfig`, runs connectivity validation, and returns an `AgentGraphDefinition`. The returned definition's `Enabled` property reflects the result of **all** validation checks combined: `_ldMeta.enabled`, root present, every node reachable from the root, and every child agent config fetchable and enabled. When any check fails, the SDK logs a warning and returns a disabled definition whose traversal/inspection methods are safe no-ops; only `GetConfig()` (raw flag value + `_ldMeta`) and `CreateTracker()` remain meaningful.

`CreateGraphTracker` reconstructs an `AiGraphTracker` from a base64url resumption token, enabling cross-process continuation (e.g. emitting graph-level events from a worker that didn't run the original evaluation).

### `AgentGraphDefinition`

```csharp
public AgentGraphNode RootNode();
public AgentGraphNode GetNode(string nodeKey);
public IReadOnlyList<AgentGraphNode> GetChildNodes(string nodeKey);
public IReadOnlyList<AgentGraphNode> GetParentNodes(string nodeKey);
public IReadOnlyList<AgentGraphNode> TerminalNodes();
public AgentGraphFlagValue GetConfig();
public AiGraphTracker CreateTracker();

public void Traverse(
    Func<AgentGraphNode, Dictionary<string, object>, object> fn,
    Dictionary<string, object> initialContext = null);

public void ReverseTraverse(
    Func<AgentGraphNode, Dictionary<string, object>, object> fn,
    Dictionary<string, object> initialContext = null);
```

`Traverse` does a breadth-first walk from the root; `ReverseTraverse` walks from terminals back toward the root (the root is always processed last unless it is the only node). Both are cycle-safe — each node is visited at most once. The callback receives the current node and an accumulator dictionary; whatever the callback returns is stored in the accumulator under that node's key and is visible to subsequent visits.

### Node and edge types

- **`AgentGraphNode`** — wraps an `LdAiAgentConfig` plus its outgoing `GraphEdge`s and exposes `IsTerminal` (true when there are no outgoing edges). Per-node metrics are recorded via the wrapped config's existing `CreateTracker()`.
- **`GraphEdge`** — `record` carrying the target `Key` and an optional `Handoff` dictionary (`IReadOnlyDictionary<string, LdValue>`). Handoff maps are wrapped in `ReadOnlyDictionary` to enforce immutability; edge lists are frozen via `AsReadOnly()`.
- **`AgentGraphFlagValue` / `LdMeta`** — the parsed raw flag value, including `_ldMeta`. Always non-null on the returned definition, even when the graph is disabled.

### `AiGraphTracker`

```csharp
public void TrackInvocationSuccess();       // at-most-once (shares slot with TrackInvocationFailure)
public void TrackInvocationFailure();       // at-most-once
public void TrackDuration(double durationMs); // at-most-once
public void TrackTotalTokens(Usage tokens); // at-most-once (skips slot claim when usage is empty)
public void TrackPath(IReadOnlyList<string> path); // at-most-once

public void TrackRedirect(string sourceKey, string redirectedTarget); // multi-fire
public void TrackHandoffSuccess(string sourceKey, string targetKey);  // multi-fire
public void TrackHandoffFailure(string sourceKey, string targetKey);  // multi-fire

public string ResumptionToken { get; }
public AiGraphMetricSummary Summary { get; }
public AiGraphTrackData GetTrackData();
public static AiGraphTracker FromResumptionToken(string token, ILaunchDarklyClient client, Context context);
```

Graph-scoped tracker emitting `$ld:ai:graph:*` events. At-most-once methods use `Interlocked.CompareExchange` so the contract holds under racing callers — a second call logs a warning and is silently dropped. `TrackTotalTokens` short-circuits before claiming the slot when usage is empty, consistent with `LdAiConfigTracker.TrackTokens`. Multi-fire methods may be called once per edge traversal. Every event carries the standard `runId` + `graphKey` + `version` track data (plus `variationKey` when non-empty). `ResumptionToken` is a base64url-encoded JSON payload of those fields; `FromResumptionToken` validates and round-trips it, throwing `ArgumentException` on malformed or missing-required-fields input.

### `graphKey` propagation through `LdAiConfigTracker`

When a per-node tracker is created via `AgentGraph` (rather than via the standalone `AgentConfig` path), the parent graph's key is threaded through to `LdAiConfigTracker` so every per-node event includes `graphKey` in its track data and resumption token. The wire format omits empty optional fields, so existing non-graph trackers continue to round-trip exactly.

### Other touched files

- `ConfigFactory.BuildAgentConfig` and `TrackerFactoryFor` accept an optional `graphKey` parameter (default `null`). The default-path helper `BuildAgentFromDefault` is now `internal` (was `private`) so the graph code path can reuse it. All existing call sites are unchanged.
- `Polyfills/IsExternalInit.cs` enables `init` accessors and positional records on the `net462`/`netstandard2.0` targets used by the new graph types.

## Migration

**None required.** `ILdAiClient` is unchanged — no new members were added. Graph functionality is on the new `ILdAiGraphClient` interface, which `LdAiClient` implements alongside `ILdAiClient`. Existing consumers, including hand-rolled test doubles that implement `ILdAiClient`, will continue to compile and work without modification. The wire format is backward-compatible (the new `graphKey` field on config resumption tokens is omitted when empty).

## Test plan

- [ ] `dotnet build` succeeds across `netstandard2.0`, `net462`, `net6.0`, `net8.0`
- [ ] `dotnet test pkgs/sdk/server-ai/test/LaunchDarkly.ServerSdk.Ai.Tests.csproj --framework net8.0` passes
- [ ] `AgentGraphDefinitionTest` covers node lookup, parent/child/terminal queries, BFS and reverse-BFS traversal, cycle safety, and disabled-graph no-op behavior
- [ ] `AiGraphTrackerTest` covers track-data shape, at-most-once vs. multi-fire semantics, `TrackTotalTokens` empty-usage short-circuit, `ResumptionToken` round-trip, `FromResumptionToken` error handling, and the `Summary` snapshot
- [ ] `LdAiAgentGraphConfigTest` covers `graphKey` propagation into per-node track data and resumption tokens
- [ ] `LdAiClientAgentGraphTest` covers end-to-end `AgentGraph` retrieval and every validation path: disabled `_ldMeta`, missing root, unreachable node, and unfetchable/disabled child agent config — plus the `$ld:ai:usage:agent-graph` usage event
- [ ] Reviewer confirms graph event names, at-most-once semantics, and resumption-token wire format match the cross-SDK contract

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive public API and shared telemetry/resumption-token contracts must stay aligned with other AI SDKs; optional ILogger.Debug is a compile-time break only for custom ILogger implementations outside the package.
> 
> **Overview**
> Adds **agent graph** support to the server AI SDK: `LdAiClient` now also implements **`ILdAiGraphClient`** with `AgentGraph` and `CreateGraphTracker`, while **`ILdAiClient` stays unchanged**.
> 
> `AgentGraph` evaluates a graph flag, parses `root` / `edges` / `_ldMeta`, validates connectivity and that every referenced agent config is enabled, then returns an **`AgentGraphDefinition`** (or a disabled shell with empty nodes when validation fails). The definition exposes node lookup, BFS **`Traverse`** / terminal-up **`ReverseTraverse`**, and **`CreateTracker`** for graph-scoped metrics.
> 
> New types include **`AgentGraphNode`**, **`GraphEdge`** (optional handoff payload), **`AgentGraphFlagValue`**, **`AiGraphTracker`** (`$ld:ai:graph:*` events, at-most-once vs multi-fire handoff/redirect), and **`AiGraphMetricSummary`**. Graph node fetches thread an optional **`graphKey`** into **`LdAiConfigTracker`** track data and resumption tokens when absent from standalone `AgentConfig` calls.
> 
> Supporting tweaks: **`ILogger.Debug`** (+ adapter), optional **`graphKey`** on **`ConfigFactory.BuildAgentConfig`**, and an **`IsExternalInit`** polyfill for older TFMs. Broad xUnit coverage for definition, tracker, client validation paths, and `graphKey` propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64294c263a42c6c270daf3b4197fb3119141fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->