### PR TITLE
fix: Check disabled state before AI Config mode mismatch

### DIFF
--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -48,6 +48,24 @@ internal sealed class ConfigFactory
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
 
+        // A disabled variation is served as {"_ldMeta": {"enabled": false}} with no mode field,
+        // so check the disabled state before comparing mode. Otherwise the missing mode defaults
+        // to "completion" and trips the mode-mismatch path for agent and judge callers.
+        if (!enabled)
+        {
+            return new LdAiCompletionConfig(
+                key,
+                enabled: false,
+                variationKey,
+                version,
+                messages: new List<LdAiConfigTypes.Message>(),
+                tools: ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty,
+                judgeConfiguration: null,
+                model: null,
+                provider: null,
+                trackerFactory);
+        }
+
         if (mode != LdAiCompletionConfig.Mode)
         {
             _logger.Warn(
@@ -117,6 +135,24 @@ internal sealed class ConfigFactory
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
 
+        // A disabled variation is served as {"_ldMeta": {"enabled": false}} with no mode field,
+        // so check the disabled state before comparing mode. Otherwise the missing mode defaults
+        // to "completion" and trips the mode-mismatch path for agent and judge callers.
+        if (!enabled)
+        {
+            return new LdAiAgentConfig(
+                key,
+                enabled: false,
+                variationKey,
+                version,
+                instructions: null,
+                tools: ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty,
+                model: null,
+                provider: null,
+                judgeConfiguration: null,
+                trackerFactory);
+        }
+
         if (mode != LdAiAgentConfig.Mode)
         {
             _logger.Warn(
@@ -183,6 +219,23 @@ internal sealed class ConfigFactory
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
+
+        // A disabled variation is served as {"_ldMeta": {"enabled": false}} with no mode field,
+        // so check the disabled state before comparing mode. Otherwise the missing mode defaults
+        // to "completion" and trips the mode-mismatch path for agent and judge callers.
+        if (!enabled)
+        {
+            return new LdAiJudgeConfig(
+                key,
+                enabled: false,
+                variationKey,
+                version,
+                messages: new List<LdAiConfigTypes.Message>(),
+                evaluationMetricKey: null,
+                model: null,
+                provider: null,
+                trackerFactory);
+        }
 
         if (mode != LdAiJudgeConfig.Mode)
         {

--- a/pkgs/sdk/server-ai/test/LdAiClientAgentJudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientAgentJudgeTest.cs
@@ -86,6 +86,33 @@ public class LdAiClientAgentJudgeTest
     }
 
     [Fact]
+    public void AgentConfig_DisabledVariation_ReturnsDisabledAgentWithoutModeMismatchWarning()
+    {
+        var (mockClient, mockLogger, client) = MakeClient();
+
+        // A disabled variation is served with no mode field, so its mode defaults to "completion".
+        const string json = """
+                            {
+                              "_ldMeta": {"variationKey": "v1", "enabled": false}
+                            }
+                            """;
+
+        mockClient.Setup(x => x.JsonVariation("agent-key", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var defaultConfig = LdAiAgentConfigDefault.New().SetInstructions("fallback").Build();
+        var result = client.AgentConfig("agent-key", Context.New("user"), defaultConfig);
+
+        Assert.IsType<LdAiAgentConfig>(result);
+        Assert.False(result.Enabled);
+
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("AI Config mode mismatch")),
+            It.IsAny<object[]>()
+        ), Times.Never);
+    }
+
+    [Fact]
     public void AgentConfig_InstructionsInterpolated()
     {
         var (mockClient, _, client) = MakeClient();
@@ -274,6 +301,36 @@ public class LdAiClientAgentJudgeTest
         var result = client.JudgeConfig("judge-key", Context.New("user"), defaultConfig);
 
         Assert.Equal("$ld:ai:judge:fallback", result.EvaluationMetricKey);
+    }
+
+    [Fact]
+    public void JudgeConfig_DisabledVariation_ReturnsDisabledJudgeWithoutModeMismatchWarning()
+    {
+        var (mockClient, mockLogger, client) = MakeClient();
+
+        // A disabled variation is served with no mode field, so its mode defaults to "completion".
+        const string json = """
+                            {
+                              "_ldMeta": {"variationKey": "v1", "enabled": false}
+                            }
+                            """;
+
+        mockClient.Setup(x => x.JsonVariation("judge-key", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var defaultConfig = LdAiJudgeConfigDefault.New()
+            .SetEvaluationMetricKey("$ld:ai:judge:fallback")
+            .Build();
+
+        var result = client.JudgeConfig("judge-key", Context.New("user"), defaultConfig);
+
+        Assert.IsType<LdAiJudgeConfig>(result);
+        Assert.False(result.Enabled);
+
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("AI Config mode mismatch")),
+            It.IsAny<object[]>()
+        ), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Bug

A disabled AI Config variation is served as `{"_ldMeta": {"enabled": false}}` with **no `mode` field**. In `ConfigFactory`, each of the three builders (`BuildCompletionConfig`, `BuildAgentConfig`, `BuildJudgeConfig`) ran the mode-mismatch check *before* looking at the `enabled` flag. Because `ParseMeta` defaults a missing mode to `"completion"`, an agent or judge caller whose served variation was the disabled/off variation saw a spurious warning:

```
AI Config mode mismatch for sample-agent: expected agent, got completion. Returning caller's default.
```

The config wasn't a mode mismatch at all — it was simply disabled.

## Fix

In all three builders, the disabled check now runs **before** the mode comparison. When the served variation is disabled (`enabled == false`):

- No mode comparison runs and no "mode mismatch" warning is emitted.
- The builder returns a disabled config of the **requested** type (`LdAiCompletionConfig` / `LdAiAgentConfig` / `LdAiJudgeConfig`) with `enabled: false`, carrying through the served `variationKey` and `version`.

A minimal disabled config of the requested type is built rather than parsing the served body, since a disabled variation carries no model/messages/instructions. Null model/provider is safe — the base `LdAiConfig` constructor already coalesces them to empty defaults, matching how the SDK treats disabled configs elsewhere.

The genuine mode-mismatch behavior for **enabled** configs whose mode truly differs is unchanged: it still warns and returns the caller's default. No public API changes.

## Tests

Added two regression tests in `LdAiClientAgentJudgeTest`: calling the agent and judge builders with a served `{"_ldMeta": {"enabled": false}}` (no mode) returns a disabled config of the requested type and emits no mode-mismatch warning. Existing mismatch tests (enabled config, wrong mode) continue to assert the warn-and-default path.

## Related

Companion changes are going up on branch `jb/disabled-config-mode-check` in:
- `sdk-specs` (spec change)
- `js-core` (companion SDK fix)