### PR TITLE
chore: Align AI config resumption token field order with spec

### DIFF
--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -118,15 +118,15 @@ public class LdAiConfigTracker : ILdAiConfigTracker
             writer.WriteStartObject();
             writer.WriteString("runId", _runId);
             writer.WriteString("configKey", _configKey);
-            if (!string.IsNullOrEmpty(_graphKey))
-            {
-                writer.WriteString("graphKey", _graphKey);
-            }
             if (!string.IsNullOrEmpty(_variationKey))
             {
                 writer.WriteString("variationKey", _variationKey);
             }
             writer.WriteNumber("version", _version);
+            if (!string.IsNullOrEmpty(_graphKey))
+            {
+                writer.WriteString("graphKey", _graphKey);
+            }
             writer.WriteEndObject();
         }
         var base64 = Convert.ToBase64String(stream.ToArray());


### PR DESCRIPTION
## Summary

#292 (already merged, not yet released) introduced `graphKey` in the AI config resumption token but placed it at the wrong position in the serialized JSON.

The spec (AITRACK Req 1.1.19.1) requires the resumption token fields to be serialized in this exact order:

1. `runId`
2. `configKey`
3. `variationKey` (omitted if absent)
4. `version`
5. `graphKey` (omitted if absent, present only for graph-node trackers)

`BuildResumptionToken()` previously emitted `runId, configKey, graphKey?, variationKey?, version`. This moves the `graphKey` write to after `version`, producing `runId, configKey, variationKey?, version, graphKey?`.

Java, Python, and js-core already follow spec order, so this restores cross-SDK byte-parity for resumption tokens. Decode is unaffected — `FromResumptionToken` is field-name based and self-round-trips regardless of wire order.

Marked `chore` rather than `fix`/`feat` because the divergent ordering landed on `main` but has not been released, so this is not a consumer-facing breaking change.

The graph tracker (`AiGraphTracker.BuildResumptionToken()`) already matches its own spec order (AIGRAPHTRACK Req 1.1.5.1: `runId, graphKey, variationKey?, version`) and is left unchanged.

## Testing

`dotnet test pkgs/sdk/server-ai/test/LaunchDarkly.ServerSdk.Ai.Tests.csproj --framework net8.0` — all 210 tests pass. The existing `ResumptionTokenHasCanonicalKeyOrder` test already asserts the corrected order.

## Context

Surfaced during review of the java-core #179 PR. See the discussion at https://github.com/launchdarkly/dotnet-core/pull/292#discussion_r3462011519.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization-order-only change in unreleased AI tracking; decode path is field-name based and existing tests assert canonical key order.
> 
> **Overview**
> Reorders how **`LdAiConfigTracker.BuildResumptionToken()`** serializes optional fields so the wire JSON matches **AITRACK Req 1.1.19.1**: `runId`, `configKey`, optional `variationKey`, `version`, then optional `graphKey` (previously `graphKey` was written before `variationKey` and `version`).
> 
> **Decoding is unchanged** — `FromResumptionToken` still binds by field name. The goal is **cross-SDK byte parity** with Java, Python, and js-core for the same tracker payload; `AiGraphTracker` token ordering is intentionally left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452563d5c8787a4fbfdda122ab9c19ec5472bb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->