### PR TITLE
feat: Add template config methods to AI SDK

### DIFF
--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -33,9 +33,10 @@ internal sealed class ConfigFactory
         LdValue ldValue,
         Context context,
         LdAiCompletionConfigDefault defaultValue,
-        IReadOnlyDictionary<string, object> variables)
+        IReadOnlyDictionary<string, object> variables,
+        bool interpolate = true)
     {
-        var mergedVars = MergeVariables(variables, context);
+        var mergedVars = interpolate ? MergeVariables(variables, context) : null;
         var trackerFactory = TrackerFactoryFor(context);
 
         if (ldValue.Type != LdValueType.Object)
@@ -43,7 +44,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -53,12 +54,14 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiCompletionConfig.Mode, mode);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
-        var messages = InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key);
+        var messages = interpolate
+            ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
+            : ParseMessages(ldValue.Get("messages"));
         var tools = ParseTools(ldValue.Get("tools"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
 
@@ -79,11 +82,14 @@ internal sealed class ConfigFactory
         string key,
         LdAiCompletionConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        bool interpolate = true)
     {
         // Caller-supplied default messages can contain Mustache templates too; interpolate
         // with the same per-message fallback as server-returned configs.
-        var messages = InterpolateMessages(defaultValue.Messages, mergedVars, key);
+        var messages = interpolate
+            ? InterpolateMessages(defaultValue.Messages, mergedVars, key)
+            : (defaultValue.Messages ?? new List<LdAiConfigTypes.Message>());
         return new LdAiCompletionConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -103,9 +109,10 @@ internal sealed class ConfigFactory
         Context context,
         LdAiAgentConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> variables,
-        string graphKey = null)
+        string graphKey = null,
+        bool interpolate = true)
     {
-        var mergedVars = MergeVariables(variables, context);
+        var mergedVars = interpolate ? MergeVariables(variables, context) : null;
         var trackerFactory = TrackerFactoryFor(context, graphKey);
 
         if (ldValue.Type != LdValueType.Object)
@@ -113,7 +120,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -123,13 +130,15 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiAgentConfig.Mode, mode);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
         var tools = ParseTools(ldValue.Get("tools"));
-        var instructions = InterpolateInstructions(ParseInstructions(ldValue.Get("instructions")), mergedVars, key);
+        var instructions = interpolate
+            ? InterpolateInstructions(ParseInstructions(ldValue.Get("instructions")), mergedVars, key)
+            : ParseInstructions(ldValue.Get("instructions"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
 
         return new LdAiAgentConfig(
@@ -149,9 +158,12 @@ internal sealed class ConfigFactory
         string key,
         LdAiAgentConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        bool interpolate = true)
     {
-        var instructions = InterpolateInstructions(defaultValue.Instructions, mergedVars, key);
+        var instructions = interpolate
+            ? InterpolateInstructions(defaultValue.Instructions, mergedVars, key)
+            : defaultValue.Instructions;
         return new LdAiAgentConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -170,9 +182,10 @@ internal sealed class ConfigFactory
         LdValue ldValue,
         Context context,
         LdAiJudgeConfigDefault defaultValue,
-        IReadOnlyDictionary<string, object> variables)
+        IReadOnlyDictionary<string, object> variables,
+        bool interpolate = true)
     {
-        var mergedVars = MergeVariables(variables, context);
+        var mergedVars = interpolate ? MergeVariables(variables, context) : null;
         var trackerFactory = TrackerFactoryFor(context);
 
         if (ldValue.Type != LdValueType.Object)
@@ -180,7 +193,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -190,12 +203,14 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiJudgeConfig.Mode, mode);
-            return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory);
+            return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
-        var messages = InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key);
+        var messages = interpolate
+            ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
+            : ParseMessages(ldValue.Get("messages"));
         var evaluationMetricKey = ParseEvaluationMetricKey(ldValue);
 
         return new LdAiJudgeConfig(
@@ -214,9 +229,12 @@ internal sealed class ConfigFactory
         string key,
         LdAiJudgeConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        bool interpolate = true)
     {
-        var messages = InterpolateMessages(defaultValue.Messages, mergedVars, key);
+        var messages = interpolate
+            ? InterpolateMessages(defaultValue.Messages, mergedVars, key)
+            : (defaultValue.Messages ?? new List<LdAiConfigTypes.Message>());
         return new LdAiJudgeConfig(
             key,
             defaultValue.Enabled ?? true,

--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiClient.cs
@@ -91,6 +91,43 @@ public interface ILdAiClient
         IReadOnlyDictionary<string, object> variables = null);
 
     /// <summary>
+    /// Retrieves a LaunchDarkly AI Completion Config with Mustache placeholders left intact
+    /// (no interpolation). Useful for displaying prompt previews or storing templates for
+    /// later rendering.
+    /// </summary>
+    /// <param name="key">the AI Completion Config key</param>
+    /// <param name="context">the context</param>
+    /// <param name="defaultValue">the default config, if unable to retrieve from LaunchDarkly.
+    /// When not provided, a disabled config is used as the fallback.</param>
+    /// <returns>an AI Completion Config with raw (non-interpolated) message content</returns>
+    public LdAiCompletionConfig CompletionConfigTemplate(string key, Context context,
+        LdAiCompletionConfigDefault defaultValue = null);
+
+    /// <summary>
+    /// Retrieves a LaunchDarkly AI Agent Config with Mustache placeholders left intact
+    /// (no interpolation). Useful for auditing instruction templates or building UI previews.
+    /// </summary>
+    /// <param name="key">the AI Agent Config key</param>
+    /// <param name="context">the context</param>
+    /// <param name="defaultValue">the default config, if unable to retrieve from LaunchDarkly.
+    /// When not provided, a disabled config is used as the fallback.</param>
+    /// <returns>an AI Agent Config with raw (non-interpolated) instructions</returns>
+    public LdAiAgentConfig AgentConfigTemplate(string key, Context context,
+        LdAiAgentConfigDefault defaultValue = null);
+
+    /// <summary>
+    /// Retrieves a LaunchDarkly AI Judge Config with Mustache placeholders left intact
+    /// (no interpolation). Useful for auditing judge prompt templates.
+    /// </summary>
+    /// <param name="key">the AI Judge Config key</param>
+    /// <param name="context">the context</param>
+    /// <param name="defaultValue">the default config, if unable to retrieve from LaunchDarkly.
+    /// When not provided, a disabled config is used as the fallback.</param>
+    /// <returns>an AI Judge Config with raw (non-interpolated) message content</returns>
+    public LdAiJudgeConfig JudgeConfigTemplate(string key, Context context,
+        LdAiJudgeConfigDefault defaultValue = null);
+
+    /// <summary>
     /// Reconstructs a tracker from a resumption token. This enables cross-process scenarios
     /// such as deferred feedback, where a tracker's runId needs to be reused in a different
     /// process or at a later time.

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -58,7 +58,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
             1);
     }
 
-    private LdAiCompletionConfig EvaluateCompletion(string key, Context context,
+    private LdAiCompletionConfig BuildCompletionConfig(string key, Context context,
         LdAiCompletionConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> variables,
         bool interpolate = true)
@@ -73,7 +73,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         IReadOnlyDictionary<string, object> variables = null)
     {
         _client.Track(TrackUsageCompletionConfig, context, LdValue.Of(key), 1);
-        return EvaluateCompletion(key, context, defaultValue, variables);
+        return BuildCompletionConfig(key, context, defaultValue, variables);
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         return result;
     }
 
-    private LdAiJudgeConfig EvaluateJudge(string key, Context context,
+    private LdAiJudgeConfig BuildJudgeConfig(string key, Context context,
         LdAiJudgeConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> variables,
         bool interpolate = true)
@@ -141,7 +141,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         IReadOnlyDictionary<string, object> variables = null)
     {
         _client.Track(TrackUsageJudgeConfig, context, LdValue.Of(key), 1);
-        return EvaluateJudge(key, context, defaultValue, variables);
+        return BuildJudgeConfig(key, context, defaultValue, variables);
     }
 
     /// <inheritdoc/>
@@ -149,7 +149,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         LdAiCompletionConfigDefault defaultValue = null)
     {
         _client.Track(TrackUsageCompletionConfigTemplate, context, LdValue.Of(key), 1);
-        return EvaluateCompletion(key, context, defaultValue, variables: null, interpolate: false);
+        return BuildCompletionConfig(key, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>
@@ -165,7 +165,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         LdAiJudgeConfigDefault defaultValue = null)
     {
         _client.Track(TrackUsageJudgeConfigTemplate, context, LdValue.Of(key), 1);
-        return EvaluateJudge(key, context, defaultValue, variables: null, interpolate: false);
+        return BuildJudgeConfig(key, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -25,6 +25,9 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
     private const string TrackUsageAgentConfigs = "$ld:ai:usage:agent-configs";
     private const string TrackUsageJudgeConfig = "$ld:ai:usage:judge-config";
     private const string TrackUsageAgentGraph = "$ld:ai:usage:agent-graph";
+    private const string TrackUsageCompletionConfigTemplate = "$ld:ai:usage:completion-config-template";
+    private const string TrackUsageAgentConfigTemplate = "$ld:ai:usage:agent-config-template";
+    private const string TrackUsageJudgeConfigTemplate = "$ld:ai:usage:judge-config-template";
 
     /// <summary>
     /// Constructs a new LaunchDarkly AI client. Please note, the client library is an alpha release and is
@@ -123,6 +126,36 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         _client.Track(TrackUsageJudgeConfig, context, LdValue.Of(key), 1);
         var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
         return _factory.BuildJudgeConfig(key, ldValue, context, defaultValue, variables);
+    }
+
+    /// <inheritdoc/>
+    public LdAiCompletionConfig CompletionConfigTemplate(string key, Context context,
+        LdAiCompletionConfigDefault defaultValue = null)
+    {
+        _client.Track(TrackUsageCompletionConfigTemplate, context, LdValue.Of(key), 1);
+        defaultValue ??= LdAiCompletionConfigDefault.Disabled;
+        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
+        return _factory.BuildCompletionConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
+    }
+
+    /// <inheritdoc/>
+    public LdAiAgentConfig AgentConfigTemplate(string key, Context context,
+        LdAiAgentConfigDefault defaultValue = null)
+    {
+        _client.Track(TrackUsageAgentConfigTemplate, context, LdValue.Of(key), 1);
+        defaultValue ??= LdAiAgentConfigDefault.Disabled;
+        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
+        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
+    }
+
+    /// <inheritdoc/>
+    public LdAiJudgeConfig JudgeConfigTemplate(string key, Context context,
+        LdAiJudgeConfigDefault defaultValue = null)
+    {
+        _client.Track(TrackUsageJudgeConfigTemplate, context, LdValue.Of(key), 1);
+        defaultValue ??= LdAiJudgeConfigDefault.Disabled;
+        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
+        return _factory.BuildJudgeConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -58,15 +58,22 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
             1);
     }
 
+    private LdAiCompletionConfig EvaluateCompletion(string key, Context context,
+        LdAiCompletionConfigDefault defaultValue,
+        IReadOnlyDictionary<string, object> variables,
+        bool interpolate = true)
+    {
+        defaultValue ??= LdAiCompletionConfigDefault.Disabled;
+        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
+        return _factory.BuildCompletionConfig(key, ldValue, context, defaultValue, variables, interpolate);
+    }
+
     /// <inheritdoc/>
     public LdAiCompletionConfig CompletionConfig(string key, Context context, LdAiCompletionConfigDefault defaultValue = null,
         IReadOnlyDictionary<string, object> variables = null)
     {
         _client.Track(TrackUsageCompletionConfig, context, LdValue.Of(key), 1);
-        defaultValue ??= LdAiCompletionConfigDefault.Disabled;
-
-        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildCompletionConfig(key, ldValue, context, defaultValue, variables);
+        return EvaluateCompletion(key, context, defaultValue, variables);
     }
 
     /// <summary>
@@ -87,11 +94,12 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
     private LdAiAgentConfig BuildAgentConfig(string key, Context context,
         LdAiAgentConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> variables,
-        string graphKey = null)
+        string graphKey = null,
+        bool interpolate = true)
     {
         defaultValue ??= LdAiAgentConfigDefault.Disabled;
         var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables, graphKey);
+        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables, graphKey, interpolate);
     }
 
     /// <inheritdoc/>
@@ -117,15 +125,23 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         return result;
     }
 
+    private LdAiJudgeConfig EvaluateJudge(string key, Context context,
+        LdAiJudgeConfigDefault defaultValue,
+        IReadOnlyDictionary<string, object> variables,
+        bool interpolate = true)
+    {
+        defaultValue ??= LdAiJudgeConfigDefault.Disabled;
+        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
+        return _factory.BuildJudgeConfig(key, ldValue, context, defaultValue, variables, interpolate);
+    }
+
     /// <inheritdoc/>
     public LdAiJudgeConfig JudgeConfig(string key, Context context,
         LdAiJudgeConfigDefault defaultValue = null,
         IReadOnlyDictionary<string, object> variables = null)
     {
-        defaultValue ??= LdAiJudgeConfigDefault.Disabled;
         _client.Track(TrackUsageJudgeConfig, context, LdValue.Of(key), 1);
-        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildJudgeConfig(key, ldValue, context, defaultValue, variables);
+        return EvaluateJudge(key, context, defaultValue, variables);
     }
 
     /// <inheritdoc/>
@@ -133,9 +149,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         LdAiCompletionConfigDefault defaultValue = null)
     {
         _client.Track(TrackUsageCompletionConfigTemplate, context, LdValue.Of(key), 1);
-        defaultValue ??= LdAiCompletionConfigDefault.Disabled;
-        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildCompletionConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
+        return EvaluateCompletion(key, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>
@@ -143,9 +157,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         LdAiAgentConfigDefault defaultValue = null)
     {
         _client.Track(TrackUsageAgentConfigTemplate, context, LdValue.Of(key), 1);
-        defaultValue ??= LdAiAgentConfigDefault.Disabled;
-        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildAgentConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
+        return BuildAgentConfig(key, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>
@@ -153,9 +165,7 @@ public sealed class LdAiClient : ILdAiClient, ILdAiGraphClient
         LdAiJudgeConfigDefault defaultValue = null)
     {
         _client.Track(TrackUsageJudgeConfigTemplate, context, LdValue.Of(key), 1);
-        defaultValue ??= LdAiJudgeConfigDefault.Disabled;
-        var ldValue = _client.JsonVariation(key, context, defaultValue.ToLdValue());
-        return _factory.BuildJudgeConfig(key, ldValue, context, defaultValue, variables: null, interpolate: false);
+        return EvaluateJudge(key, context, defaultValue, variables: null, interpolate: false);
     }
 
     /// <inheritdoc/>

--- a/pkgs/sdk/server-ai/test/LdAiClientAgentJudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientAgentJudgeTest.cs
@@ -328,6 +328,214 @@ public class LdAiClientAgentJudgeTest
             m => Assert.Equal("Evaluate for metric: relevance", m.Content));
     }
 
+    // ── AgentConfigTemplate ──────────────────────────────────────────────────
+
+    [Fact]
+    public void AgentConfigTemplate_PreservesPlaceholders()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "agent"},
+              "model": {},
+              "instructions": "Hello {{name}}, specialize in {{topic}}"
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("agent-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.AgentConfigTemplate("agent-flag", Context.New("user"));
+
+        Assert.Equal("Hello {{name}}, specialize in {{topic}}", result.Instructions);
+        Assert.True(result.Enabled);
+    }
+
+    [Fact]
+    public void AgentConfigTemplate_PreservesLdCtxPlaceholder()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "agent"},
+              "model": {},
+              "instructions": "Serving context key: {{ldctx.key}}"
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("agent-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.AgentConfigTemplate("agent-flag", Context.New(ContextKind.Default, "ctx-key-123"));
+
+        Assert.Equal("Serving context key: {{ldctx.key}}", result.Instructions);
+    }
+
+    [Fact]
+    public void AgentConfigTemplate_FiresTemplateTrackingEvent()
+    {
+        var (mockClient, _, client) = MakeClient();
+        var context = Context.New(ContextKind.Default, "user");
+        mockClient.Setup(x => x.JsonVariation("my-agent", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["mode"] = LdValue.Of("agent")
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>())
+            }));
+
+        client.AgentConfigTemplate("my-agent", context);
+
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:agent-config-template",
+            context,
+            LdValue.Of("my-agent"),
+            1), Times.Once);
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:agent-config",
+            It.IsAny<Context>(), It.IsAny<LdValue>(), It.IsAny<double>()), Times.Never);
+    }
+
+    [Fact]
+    public void AgentConfigTemplate_UsesDisabledDefaultWhenNoDefaultProvided()
+    {
+        var (mockClient, _, client) = MakeClient();
+        mockClient.Setup(x => x.JsonVariation("my-agent", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Null);
+
+        var result = client.AgentConfigTemplate("my-agent", Context.New("user"));
+
+        Assert.False(result.Enabled);
+    }
+
+    [Fact]
+    public void AgentConfigTemplate_CreateTrackerIsNonNull()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "agent"},
+              "model": {}
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("agent-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.AgentConfigTemplate("agent-flag", Context.New("user"));
+
+        Assert.NotNull(result.CreateTracker());
+    }
+
+    // ── JudgeConfigTemplate ──────────────────────────────────────────────────
+
+    [Fact]
+    public void JudgeConfigTemplate_PreservesPlaceholders()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "judge"},
+              "model": {},
+              "messages": [
+                {"content": "Evaluate for metric: {{metric}}", "role": "user"},
+                {"content": "Score: {{score}}", "role": "system"}
+              ]
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("judge-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.JudgeConfigTemplate("judge-flag", Context.New("user"));
+
+        Assert.Collection(result.Messages,
+            m => Assert.Equal("Evaluate for metric: {{metric}}", m.Content),
+            m => Assert.Equal("Score: {{score}}", m.Content));
+        Assert.True(result.Enabled);
+    }
+
+    [Fact]
+    public void JudgeConfigTemplate_PreservesLdCtxPlaceholder()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "judge"},
+              "model": {},
+              "messages": [
+                {"content": "Context key: {{ldctx.key}}", "role": "system"}
+              ]
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("judge-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.JudgeConfigTemplate("judge-flag", Context.New(ContextKind.Default, "ctx-key-123"));
+
+        Assert.Collection(result.Messages,
+            m => Assert.Equal("Context key: {{ldctx.key}}", m.Content));
+    }
+
+    [Fact]
+    public void JudgeConfigTemplate_FiresTemplateTrackingEvent()
+    {
+        var (mockClient, _, client) = MakeClient();
+        var context = Context.New(ContextKind.Default, "user");
+        mockClient.Setup(x => x.JsonVariation("my-judge", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["mode"] = LdValue.Of("judge")
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>()),
+                ["messages"] = LdValue.ArrayOf()
+            }));
+
+        client.JudgeConfigTemplate("my-judge", context);
+
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:judge-config-template",
+            context,
+            LdValue.Of("my-judge"),
+            1), Times.Once);
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:judge-config",
+            It.IsAny<Context>(), It.IsAny<LdValue>(), It.IsAny<double>()), Times.Never);
+    }
+
+    [Fact]
+    public void JudgeConfigTemplate_UsesDisabledDefaultWhenNoDefaultProvided()
+    {
+        var (mockClient, _, client) = MakeClient();
+        mockClient.Setup(x => x.JsonVariation("my-judge", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Null);
+
+        var result = client.JudgeConfigTemplate("my-judge", Context.New("user"));
+
+        Assert.False(result.Enabled);
+    }
+
+    [Fact]
+    public void JudgeConfigTemplate_CreateTrackerIsNonNull()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "judge"},
+              "model": {},
+              "messages": []
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("judge-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.JudgeConfigTemplate("judge-flag", Context.New("user"));
+
+        Assert.NotNull(result.CreateTracker());
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private static void SetupAgentJson(Mock<ILaunchDarklyClient> mockClient, string key, string instructions)

--- a/pkgs/sdk/server-ai/test/LdAiClientTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientTest.cs
@@ -1296,4 +1296,122 @@ public class LdAiClientTest
         Assert.Equal("coherence", result.JudgeConfiguration.Judges[0].Key);
         Assert.Equal(0.3, result.JudgeConfiguration.Judges[0].SamplingRate);
     }
+
+    // ── CompletionConfigTemplate ──────────────────────────────────────────────
+
+    private static (Mock<ILaunchDarklyClient> MockClient, Mock<ILogger> MockLogger, LdAiClient Client) MakeClient()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        return (mockClient, mockLogger, new LdAiClient(mockClient.Object));
+    }
+
+    [Fact]
+    public void CompletionConfigTemplate_PreservesPlaceholders()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+              "model": {"name": "gpt-4"},
+              "provider": {"name": "openai"},
+              "messages": [
+                {"content": "Hello {{name}}", "role": "system"},
+                {"content": "Score: {{score}}", "role": "user"}
+              ]
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("test-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.CompletionConfigTemplate("test-flag", Context.New("user"));
+
+        Assert.Collection(result.Messages,
+            m => Assert.Equal("Hello {{name}}", m.Content),
+            m => Assert.Equal("Score: {{score}}", m.Content));
+        Assert.True(result.Enabled);
+    }
+
+    [Fact]
+    public void CompletionConfigTemplate_PreservesLdCtxPlaceholder()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+              "model": {},
+              "messages": [
+                {"content": "Key: {{ldctx.key}}", "role": "system"}
+              ]
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("test-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.CompletionConfigTemplate("test-flag", Context.New(ContextKind.Default, "ctx-key-123"));
+
+        Assert.Collection(result.Messages,
+            m => Assert.Equal("Key: {{ldctx.key}}", m.Content));
+    }
+
+    [Fact]
+    public void CompletionConfigTemplate_FiresTemplateTrackingEvent()
+    {
+        var (mockClient, _, client) = MakeClient();
+        var context = Context.New(ContextKind.Default, "user");
+        mockClient.Setup(x => x.JsonVariation("my-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["mode"] = LdValue.Of("completion")
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>()),
+                ["messages"] = LdValue.ArrayOf()
+            }));
+
+        client.CompletionConfigTemplate("my-flag", context);
+
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:completion-config-template",
+            context,
+            LdValue.Of("my-flag"),
+            1), Times.Once);
+        mockClient.Verify(x => x.Track(
+            "$ld:ai:usage:completion-config",
+            It.IsAny<Context>(), It.IsAny<LdValue>(), It.IsAny<double>()), Times.Never);
+    }
+
+    [Fact]
+    public void CompletionConfigTemplate_UsesDisabledDefaultWhenNoDefaultProvided()
+    {
+        var (mockClient, _, client) = MakeClient();
+        mockClient.Setup(x => x.JsonVariation("my-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Null);
+
+        var result = client.CompletionConfigTemplate("my-flag", Context.New("user"));
+
+        Assert.False(result.Enabled);
+    }
+
+    [Fact]
+    public void CompletionConfigTemplate_CreateTrackerIsNonNull()
+    {
+        var (mockClient, _, client) = MakeClient();
+        const string json = """
+            {
+              "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+              "model": {},
+              "messages": []
+            }
+            """;
+        mockClient.Setup(x => x.JsonVariation("test-flag", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(json));
+
+        var result = client.CompletionConfigTemplate("test-flag", Context.New("user"));
+
+        Assert.NotNull(result.CreateTracker());
+    }
 }


### PR DESCRIPTION
## Summary

Adds `CompletionConfigTemplate`, `AgentConfigTemplate`, and `JudgeConfigTemplate` to `LaunchDarkly.ServerSdk.Ai`. These methods return the same config types as their non-template counterparts but skip Mustache interpolation, preserving `{{variable}}` and `{{ldctx.key}}` placeholders verbatim. Useful for displaying prompt previews, storing templates for later rendering, or auditing prompt content without variable substitution.

### Template methods on `ILdAiClient`

```csharp
public LdAiCompletionConfig CompletionConfigTemplate(string key, Context context,
    LdAiCompletionConfigDefault defaultValue = null);

public LdAiAgentConfig AgentConfigTemplate(string key, Context context,
    LdAiAgentConfigDefault defaultValue = null);

public LdAiJudgeConfig JudgeConfigTemplate(string key, Context context,
    LdAiJudgeConfigDefault defaultValue = null);
```

Each template method fires a `-template` suffixed usage event (`$ld:ai:usage:completion-config-template`, `$ld:ai:usage:agent-config-template`, `$ld:ai:usage:judge-config-template`) and does **not** fire the standard usage event. The `variables` parameter is omitted since interpolation is skipped.

### Shared evaluator helpers in `LdAiClient`

To avoid duplicating the `defaultValue ??=` + `JsonVariation` + factory call pattern between non-template and template methods, private `BuildCompletionConfig` and `BuildJudgeConfig` helpers were introduced, matching the pre-existing `BuildAgentConfig` pattern. Both the standard and template public methods delegate through these helpers:

```csharp
// Standard path
public LdAiCompletionConfig CompletionConfig(string key, Context context, ...)
{
    _client.Track(TrackUsageCompletionConfig, context, LdValue.Of(key), 1);
    return BuildCompletionConfig(key, context, defaultValue, variables);
}

// Template path
public LdAiCompletionConfig CompletionConfigTemplate(string key, Context context, ...)
{
    _client.Track(TrackUsageCompletionConfigTemplate, context, LdValue.Of(key), 1);
    return BuildCompletionConfig(key, context, defaultValue, variables: null, interpolate: false);
}
```



### `ConfigFactory` changes

`BuildCompletionConfig`, `BuildAgentConfig`, `BuildJudgeConfig` and their `Build*FromDefault` counterparts (6 methods total) accept a new `bool interpolate = true` parameter. When `false`, `MergeVariables()` is skipped and messages/instructions are parsed but not interpolated. All existing call sites are unchanged (default `true`).

## Migration

**None required.** `ILdAiClient` gains three new members — this is additive only. Existing consumers that call the SDK through the concrete `LdAiClient` class are unaffected. Consumers that implement `ILdAiClient` in test doubles will need to add stub implementations for the three new methods.

## Test plan

- [ ] `dotnet test pkgs/sdk/server-ai/test/LaunchDarkly.ServerSdk.Ai.Tests.csproj --framework net8.0` passes
- [ ] `CompletionConfigTemplate` tests cover placeholder preservation, `ldctx` non-interpolation, template tracking event (with negative verification that the standard event is not fired), disabled default fallback, and `CreateTracker` non-null
- [ ] `AgentConfigTemplate` tests cover the same scenarios for agent configs (instructions rather than messages)
- [ ] `JudgeConfigTemplate` tests cover the same scenarios for judge configs

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API with default-on interpolation preserved for existing callers; risk is limited to consumers relying on template methods for production prompts without rendering variables themselves.
> 
> **Overview**
> Adds **template** fetch APIs on the server AI SDK so completion, agent, and judge configs can be loaded **without** Mustache interpolation—placeholders like `{{name}}` and `{{ldctx.key}}` stay in the returned messages or instructions for previews, auditing, or deferred rendering.
> 
> `ConfigFactory` now accepts an optional `interpolate` flag (default **true**) on all three build paths; when false it skips variable merging and returns parsed prompt text as-is. Existing `CompletionConfig` / `AgentConfig` / `JudgeConfig` behavior is unchanged. `LdAiClient` exposes `CompletionConfigTemplate`, `AgentConfigTemplate`, and `JudgeConfigTemplate` on `ILdAiClient`, each emitting a dedicated usage track event (`$ld:ai:usage:*-config-template`) instead of the normal config usage events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bd420324dfe0e54b464df2d26cf8678a8eed75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->