### PR TITLE
feat!: Add AI online evaluations (Judge, Evaluator, IRunner)

### DIFF
--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -130,7 +130,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate, graphKey);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -140,7 +140,7 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiAgentConfig.Mode, mode);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate, graphKey);
         }
 
         var model = ParseModel(ldValue.Get("model"));
@@ -150,7 +150,7 @@ internal sealed class ConfigFactory
             ? InterpolateInstructions(ParseInstructions(ldValue.Get("instructions")), mergedVars, key)
             : ParseInstructions(ldValue.Get("instructions"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
-        var evaluator = BuildEvaluator(judgeConfiguration, context, variables);
+        var evaluator = BuildEvaluator(judgeConfiguration, context, variables, graphKey);
 
         return new LdAiAgentConfig(
             key,
@@ -173,12 +173,13 @@ internal sealed class ConfigFactory
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
         Context context,
         IReadOnlyDictionary<string, object> variables = null,
-        bool interpolate = true)
+        bool interpolate = true,
+        string graphKey = null)
     {
         var instructions = interpolate
             ? InterpolateInstructions(defaultValue.Instructions, mergedVars, key)
             : defaultValue.Instructions;
-        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context, variables);
+        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context, variables, graphKey);
         return new LdAiAgentConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -199,10 +200,11 @@ internal sealed class ConfigFactory
         Context context,
         LdAiJudgeConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> variables,
-        bool interpolate = true)
+        bool interpolate = true,
+        string graphKey = null)
     {
         var mergedVars = interpolate ? MergeVariables(variables, context) : null;
-        var trackerFactory = TrackerFactoryFor(context);
+        var trackerFactory = TrackerFactoryFor(context, graphKey);
 
         if (ldValue.Type != LdValueType.Object)
         {
@@ -264,7 +266,7 @@ internal sealed class ConfigFactory
     }
 
     private Evaluator BuildEvaluator(LdAiConfigTypes.JudgeConfiguration judgeConfiguration, Context context,
-        IReadOnlyDictionary<string, object> variables = null)
+        IReadOnlyDictionary<string, object> variables = null, string graphKey = null)
     {
         if (_runnerFactory == null || judgeConfiguration == null || judgeConfiguration.Judges.Count == 0)
         {
@@ -278,7 +280,7 @@ internal sealed class ConfigFactory
             {
                 var defaultValue = LdAiJudgeConfigDefault.Disabled;
                 var ldValue = _client.JsonVariation(judgeEntry.Key, context, defaultValue.ToLdValue());
-                var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, variables);
+                var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, variables, graphKey: graphKey);
 
                 if (!judgeConfig.Enabled)
                 {
@@ -460,9 +462,13 @@ internal sealed class ConfigFactory
         {
             var j = judgesArray.Get(i);
             if (j.Type != LdValueType.Object) continue;
+            var samplingRateValue = j.Get("samplingRate");
+            double? samplingRate = samplingRateValue.Type == LdValueType.Number
+                ? samplingRateValue.AsDouble
+                : (double?)null;
             entries.Add(new LdAiConfigTypes.JudgeConfiguration.Judge(
                 j.Get("key").AsString ?? "",
-                j.Get("samplingRate").AsDouble));
+                samplingRate));
         }
         return new LdAiConfigTypes.JudgeConfiguration(entries);
     }

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -48,7 +48,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -58,7 +58,7 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiCompletionConfig.Mode, mode);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
@@ -89,6 +89,7 @@ internal sealed class ConfigFactory
         LdAiCompletionConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        Context context,
         bool interpolate = true)
     {
         // Caller-supplied default messages can contain Mustache templates too; interpolate
@@ -96,6 +97,7 @@ internal sealed class ConfigFactory
         var messages = interpolate
             ? InterpolateMessages(defaultValue.Messages, mergedVars, key)
             : (defaultValue.Messages ?? new List<LdAiConfigTypes.Message>());
+        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context);
         return new LdAiCompletionConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -107,7 +109,7 @@ internal sealed class ConfigFactory
             defaultValue.Model,
             defaultValue.Provider,
             trackerFactory,
-            evaluator: null);
+            evaluator);
     }
 
     public LdAiAgentConfig BuildAgentConfig(
@@ -127,7 +129,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -137,7 +139,7 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiAgentConfig.Mode, mode);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
@@ -168,11 +170,13 @@ internal sealed class ConfigFactory
         LdAiAgentConfigDefault defaultValue,
         IReadOnlyDictionary<string, object> mergedVars,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        Context context,
         bool interpolate = true)
     {
         var instructions = interpolate
             ? InterpolateInstructions(defaultValue.Instructions, mergedVars, key)
             : defaultValue.Instructions;
+        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context);
         return new LdAiAgentConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -184,7 +188,7 @@ internal sealed class ConfigFactory
             defaultValue.Provider,
             defaultValue.JudgeConfiguration,
             trackerFactory,
-            evaluator: null);
+            evaluator);
     }
 
     public LdAiJudgeConfig BuildJudgeConfig(
@@ -275,7 +279,7 @@ internal sealed class ConfigFactory
 
                 if (!judgeConfig.Enabled)
                 {
-                    _logger?.Warn("Judge '{0}' is disabled; skipping.", judgeEntry.Key);
+                    _logger?.Debug("Judge '{0}' is disabled; skipping.", judgeEntry.Key);
                     continue;
                 }
 
@@ -294,7 +298,9 @@ internal sealed class ConfigFactory
             }
         }
 
-        return new Evaluator(judges, judgeConfiguration, _logger);
+        var filteredConfig = new LdAiConfigTypes.JudgeConfiguration(
+            judgeConfiguration.Judges.Where(j => judges.ContainsKey(j.Key)).ToList());
+        return new Evaluator(judges, filteredConfig, _logger);
     }
 
     private string InterpolateInstructions(

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 using Mustache;
 
@@ -21,11 +22,14 @@ internal sealed class ConfigFactory
 
     private readonly ILaunchDarklyClient _client;
     private readonly ILogger _logger;
+    private readonly Func<LdAiJudgeConfig, IRunner> _runnerFactory;
 
-    public ConfigFactory(ILaunchDarklyClient client, ILogger logger)
+    public ConfigFactory(ILaunchDarklyClient client, ILogger logger,
+        Func<LdAiJudgeConfig, IRunner> runnerFactory = null)
     {
         _client = client;
         _logger = logger;
+        _runnerFactory = runnerFactory;
     }
 
     public LdAiCompletionConfig BuildCompletionConfig(
@@ -61,6 +65,7 @@ internal sealed class ConfigFactory
         var messages = InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key);
         var tools = ParseTools(ldValue.Get("tools"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
+        var evaluator = BuildEvaluator(judgeConfiguration, context);
 
         return new LdAiCompletionConfig(
             key,
@@ -72,7 +77,8 @@ internal sealed class ConfigFactory
             judgeConfiguration,
             model,
             provider,
-            trackerFactory);
+            trackerFactory,
+            evaluator);
     }
 
     private LdAiCompletionConfig BuildCompletionFromDefault(
@@ -94,7 +100,8 @@ internal sealed class ConfigFactory
             defaultValue.JudgeConfiguration,
             defaultValue.Model,
             defaultValue.Provider,
-            trackerFactory);
+            trackerFactory,
+            evaluator: null);
     }
 
     public LdAiAgentConfig BuildAgentConfig(
@@ -130,6 +137,7 @@ internal sealed class ConfigFactory
         var tools = ParseTools(ldValue.Get("tools"));
         var instructions = InterpolateInstructions(ParseInstructions(ldValue.Get("instructions")), mergedVars, key);
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
+        var evaluator = BuildEvaluator(judgeConfiguration, context);
 
         return new LdAiAgentConfig(
             key,
@@ -141,7 +149,8 @@ internal sealed class ConfigFactory
             model,
             provider,
             judgeConfiguration,
-            trackerFactory);
+            trackerFactory,
+            evaluator);
     }
 
     private LdAiAgentConfig BuildAgentFromDefault(
@@ -226,6 +235,26 @@ internal sealed class ConfigFactory
             defaultValue.Model,
             defaultValue.Provider,
             trackerFactory);
+    }
+
+    private Evaluator BuildEvaluator(LdAiConfigTypes.JudgeConfiguration judgeConfiguration, Context context)
+    {
+        if (_runnerFactory == null || judgeConfiguration == null || judgeConfiguration.Judges.Count == 0)
+        {
+            return Evaluator.Noop();
+        }
+
+        var judges = new Dictionary<string, Judge>();
+        foreach (var judgeEntry in judgeConfiguration.Judges)
+        {
+            var defaultValue = LdAiJudgeConfigDefault.Disabled;
+            var ldValue = _client.JsonVariation(judgeEntry.Key, context, defaultValue.ToLdValue());
+            var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, null);
+            var runner = _runnerFactory(judgeConfig);
+            judges[judgeEntry.Key] = new Judge(judgeConfig, runner, _logger);
+        }
+
+        return new Evaluator(judges, judgeConfiguration, _logger);
     }
 
     private string InterpolateInstructions(

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -183,7 +183,8 @@ internal sealed class ConfigFactory
             defaultValue.Model,
             defaultValue.Provider,
             defaultValue.JudgeConfiguration,
-            trackerFactory);
+            trackerFactory,
+            evaluator: null);
     }
 
     public LdAiJudgeConfig BuildJudgeConfig(
@@ -266,11 +267,31 @@ internal sealed class ConfigFactory
         var judges = new Dictionary<string, Judge>();
         foreach (var judgeEntry in judgeConfiguration.Judges)
         {
-            var defaultValue = LdAiJudgeConfigDefault.Disabled;
-            var ldValue = _client.JsonVariation(judgeEntry.Key, context, defaultValue.ToLdValue());
-            var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, null);
-            var runner = _runnerFactory(judgeConfig);
-            judges[judgeEntry.Key] = new Judge(judgeConfig, runner, _logger);
+            try
+            {
+                var defaultValue = LdAiJudgeConfigDefault.Disabled;
+                var ldValue = _client.JsonVariation(judgeEntry.Key, context, defaultValue.ToLdValue());
+                var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, null);
+
+                if (!judgeConfig.Enabled)
+                {
+                    _logger?.Warn("Judge '{0}' is disabled; skipping.", judgeEntry.Key);
+                    continue;
+                }
+
+                var runner = _runnerFactory(judgeConfig);
+                if (runner == null)
+                {
+                    _logger?.Warn("Runner factory returned null for judge '{0}'; skipping.", judgeEntry.Key);
+                    continue;
+                }
+
+                judges[judgeEntry.Key] = new Judge(judgeConfig, runner, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger?.Warn("Failed to initialize judge '{0}': {1}", judgeEntry.Key, ex.Message);
+            }
         }
 
         return new Evaluator(judges, judgeConfiguration, _logger);

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -48,7 +48,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -58,7 +58,7 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiCompletionConfig.Mode, mode);
-            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
+            return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
@@ -68,7 +68,7 @@ internal sealed class ConfigFactory
             : ParseMessages(ldValue.Get("messages"));
         var tools = ParseTools(ldValue.Get("tools"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
-        var evaluator = BuildEvaluator(judgeConfiguration, context);
+        var evaluator = BuildEvaluator(judgeConfiguration, context, variables);
 
         return new LdAiCompletionConfig(
             key,
@@ -90,6 +90,7 @@ internal sealed class ConfigFactory
         IReadOnlyDictionary<string, object> mergedVars,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
         Context context,
+        IReadOnlyDictionary<string, object> variables = null,
         bool interpolate = true)
     {
         // Caller-supplied default messages can contain Mustache templates too; interpolate
@@ -97,7 +98,7 @@ internal sealed class ConfigFactory
         var messages = interpolate
             ? InterpolateMessages(defaultValue.Messages, mergedVars, key)
             : (defaultValue.Messages ?? new List<LdAiConfigTypes.Message>());
-        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context);
+        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context, variables);
         return new LdAiCompletionConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -129,7 +130,7 @@ internal sealed class ConfigFactory
             _logger.Error(
                 "AI Config '{0}': variation result is not an object (got {1}); using caller's default.",
                 key, ldValue.Type);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
         }
 
         var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
@@ -139,7 +140,7 @@ internal sealed class ConfigFactory
             _logger.Warn(
                 "AI Config mode mismatch for {0}: expected {1}, got {2}. Returning caller's default.",
                 key, LdAiAgentConfig.Mode, mode);
-            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, interpolate);
+            return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, context, variables, interpolate);
         }
 
         var model = ParseModel(ldValue.Get("model"));
@@ -149,7 +150,7 @@ internal sealed class ConfigFactory
             ? InterpolateInstructions(ParseInstructions(ldValue.Get("instructions")), mergedVars, key)
             : ParseInstructions(ldValue.Get("instructions"));
         var judgeConfiguration = ParseJudgeConfiguration(ldValue.Get("judgeConfiguration"));
-        var evaluator = BuildEvaluator(judgeConfiguration, context);
+        var evaluator = BuildEvaluator(judgeConfiguration, context, variables);
 
         return new LdAiAgentConfig(
             key,
@@ -171,12 +172,13 @@ internal sealed class ConfigFactory
         IReadOnlyDictionary<string, object> mergedVars,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
         Context context,
+        IReadOnlyDictionary<string, object> variables = null,
         bool interpolate = true)
     {
         var instructions = interpolate
             ? InterpolateInstructions(defaultValue.Instructions, mergedVars, key)
             : defaultValue.Instructions;
-        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context);
+        var evaluator = BuildEvaluator(defaultValue.JudgeConfiguration, context, variables);
         return new LdAiAgentConfig(
             key,
             defaultValue.Enabled ?? true,
@@ -261,7 +263,8 @@ internal sealed class ConfigFactory
             trackerFactory);
     }
 
-    private Evaluator BuildEvaluator(LdAiConfigTypes.JudgeConfiguration judgeConfiguration, Context context)
+    private Evaluator BuildEvaluator(LdAiConfigTypes.JudgeConfiguration judgeConfiguration, Context context,
+        IReadOnlyDictionary<string, object> variables = null)
     {
         if (_runnerFactory == null || judgeConfiguration == null || judgeConfiguration.Judges.Count == 0)
         {
@@ -275,7 +278,7 @@ internal sealed class ConfigFactory
             {
                 var defaultValue = LdAiJudgeConfigDefault.Disabled;
                 var ldValue = _client.JsonVariation(judgeEntry.Key, context, defaultValue.ToLdValue());
-                var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, null);
+                var judgeConfig = BuildJudgeConfig(judgeEntry.Key, ldValue, context, defaultValue, variables);
 
                 if (!judgeConfig.Enabled)
                 {

--- a/pkgs/sdk/server-ai/src/Config/LdAiAgentConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiAgentConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai.Config;
@@ -46,8 +47,9 @@ public sealed class LdAiAgentConfig : LdAiConfig
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
         LdAiConfigTypes.JudgeConfiguration judgeConfiguration,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        Evaluator evaluator = null)
+        : base(key, enabled, variationKey, version, model, provider, trackerFactory, evaluator)
     {
         Instructions = instructions;
         Tools = tools?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty;

--- a/pkgs/sdk/server-ai/src/Config/LdAiAgentConfigDefault.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiAgentConfigDefault.cs
@@ -192,11 +192,15 @@ public sealed class LdAiAgentConfigDefault : LdAiConfigDefault
             root["judgeConfiguration"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
                 { "judges", LdValue.ArrayFrom(JudgeConfiguration.Judges.Select(j =>
-                    LdValue.ObjectFrom(new Dictionary<string, LdValue>
                     {
-                        { "key", LdValue.Of(j.Key) },
-                        { "samplingRate", LdValue.Of(j.SamplingRate) }
-                    })))
+                        var judgeFields = new Dictionary<string, LdValue>
+                        {
+                            { "key", LdValue.Of(j.Key) }
+                        };
+                        if (j.SamplingRate.HasValue)
+                            judgeFields["samplingRate"] = LdValue.Of(j.SamplingRate.Value);
+                        return LdValue.ObjectFrom(judgeFields);
+                    }))
                 }
             });
         }

--- a/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfig.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai.Config;
@@ -42,8 +43,9 @@ public sealed class LdAiCompletionConfig : LdAiConfig
         IEnumerable<LdAiConfigTypes.Message> messages, IReadOnlyDictionary<string, LdAiConfigTypes.Tool> tools,
         LdAiConfigTypes.JudgeConfiguration judgeConfiguration,
         LdAiConfigTypes.ModelConfig model, LdAiConfigTypes.ProviderConfig provider,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        Evaluator evaluator = null)
+        : base(key, enabled, variationKey, version, model, provider, trackerFactory, evaluator)
     {
         Messages = messages?.ToList() ?? new List<LdAiConfigTypes.Message>();
         Tools = tools ?? ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty;

--- a/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfigDefault.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfigDefault.cs
@@ -198,11 +198,15 @@ public sealed class LdAiCompletionConfigDefault : LdAiConfigDefault
             root["judgeConfiguration"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
             {
                 { "judges", LdValue.ArrayFrom(JudgeConfiguration.Judges.Select(j =>
-                    LdValue.ObjectFrom(new Dictionary<string, LdValue>
                     {
-                        { "key", LdValue.Of(j.Key) },
-                        { "samplingRate", LdValue.Of(j.SamplingRate) }
-                    })))
+                        var judgeFields = new Dictionary<string, LdValue>
+                        {
+                            { "key", LdValue.Of(j.Key) }
+                        };
+                        if (j.SamplingRate.HasValue)
+                            judgeFields["samplingRate"] = LdValue.Of(j.SamplingRate.Value);
+                        return LdValue.ObjectFrom(judgeFields);
+                    }))
                 }
             });
         }

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai.Config;
@@ -41,6 +42,12 @@ public abstract class LdAiConfig
     internal int Version { get; }
 
     /// <summary>
+    /// The evaluator attached to this config. Always non-null; use <see cref="Evaluator.Noop"/>
+    /// when no real evaluation is configured.
+    /// </summary>
+    public Evaluator Evaluator { get; }
+
+    /// <summary>
     /// Factory that produces a tracker for the config. The factory is mode-agnostic — it
     /// operates only on the shared fields (<see cref="Key"/>, <see cref="Model"/>,
     /// <see cref="Provider"/>, <see cref="VariationKey"/>, <see cref="Version"/>), so the
@@ -66,7 +73,8 @@ public abstract class LdAiConfig
         int version,
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
-        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
+        Func<LdAiConfig, ILdAiConfigTracker> trackerFactory,
+        Evaluator evaluator = null)
     {
         Key = key;
         Enabled = enabled;
@@ -75,5 +83,6 @@ public abstract class LdAiConfig
         Model = model ?? new LdAiConfigTypes.ModelConfig("", new Dictionary<string, LdValue>(), new Dictionary<string, LdValue>());
         Provider = provider ?? new LdAiConfigTypes.ProviderConfig("");
         _trackerFactory = trackerFactory ?? throw new ArgumentNullException(nameof(trackerFactory));
+        Evaluator = evaluator ?? Evals.Evaluator.Noop();
     }
 }

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
@@ -161,10 +161,11 @@ public static class LdAiConfigTypes
 
             /// <summary>
             /// The fraction of requests that this judge evaluates, in the range [0, 1].
+            /// When null, the judge evaluates 100% of requests.
             /// </summary>
-            public double SamplingRate { get; }
+            public double? SamplingRate { get; }
 
-            internal Judge(string key, double samplingRate)
+            internal Judge(string key, double? samplingRate)
             {
                 Key = key;
                 SamplingRate = samplingRate;

--- a/pkgs/sdk/server-ai/src/Config/LdAiJudgeConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiJudgeConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai.Config;
@@ -41,7 +42,7 @@ public sealed class LdAiJudgeConfig : LdAiConfig
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        : base(key, enabled, variationKey, version, model, provider, trackerFactory, Evaluator.Noop())
     {
         Messages = messages?.ToList() ?? new List<LdAiConfigTypes.Message>();
         EvaluationMetricKey = evaluationMetricKey;

--- a/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Evals;
+
+/// <summary>
+/// Runs one or more <see cref="Judge"/> instances against a single input/output pair and
+/// collects their results.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The evaluator does NOT call <c>TrackJudgeResult</c> — that is the responsibility of the
+/// managed type (Plan D). Use <see cref="Noop"/> when evaluation is not required.
+/// </para>
+/// </remarks>
+public sealed class Evaluator
+{
+    private static readonly Evaluator _noop = new Evaluator();
+
+    private readonly IReadOnlyDictionary<string, Judge> _judges;
+    private readonly LdAiConfigTypes.JudgeConfiguration _judgeConfiguration;
+    private readonly ILogger _logger;
+    private readonly bool _isNoop;
+
+    private Evaluator()
+    {
+        _isNoop = true;
+        _judges = new Dictionary<string, Judge>();
+        _judgeConfiguration = null;
+        _logger = null;
+    }
+
+    /// <summary>
+    /// Constructs an <see cref="Evaluator"/>.
+    /// </summary>
+    /// <param name="judges">a dictionary mapping judge keys to their <see cref="Judge"/> instances</param>
+    /// <param name="judgeConfiguration">the judge configuration describing which judges to run and at
+    /// what sampling rate</param>
+    /// <param name="logger">optional logger for missing-judge warnings</param>
+    public Evaluator(
+        IReadOnlyDictionary<string, Judge> judges,
+        LdAiConfigTypes.JudgeConfiguration judgeConfiguration,
+        ILogger logger = null)
+    {
+        _judges = judges ?? new Dictionary<string, Judge>();
+        _judgeConfiguration = judgeConfiguration;
+        _logger = logger;
+        _isNoop = false;
+    }
+
+    /// <summary>
+    /// Returns an <see cref="Evaluator"/> that performs no evaluation. <see cref="EvaluateAsync"/>
+    /// on the returned instance resolves immediately to an empty list without invoking any judges
+    /// or emitting any warnings.
+    /// </summary>
+    public static Evaluator Noop() => _noop;
+
+    /// <summary>
+    /// Runs all configured judges against the given input/output pair.
+    /// </summary>
+    /// <param name="input">the original input (e.g. user prompt)</param>
+    /// <param name="output">the model response to evaluate</param>
+    /// <returns>a list of <see cref="JudgeResult"/> values, one per judge that was found and
+    /// executed; judges that are missing from the <c>judges</c> dictionary are skipped and
+    /// produce no entry</returns>
+    public async Task<IReadOnlyList<JudgeResult>> EvaluateAsync(string input, string output)
+    {
+        if (_isNoop || _judgeConfiguration == null || _judgeConfiguration.Judges.Count == 0)
+        {
+            return new List<JudgeResult>();
+        }
+
+        var results = new List<JudgeResult>(_judgeConfiguration.Judges.Count);
+        foreach (var judgeEntry in _judgeConfiguration.Judges)
+        {
+            if (!_judges.TryGetValue(judgeEntry.Key, out var judge))
+            {
+                _logger?.Warn("Evaluator: judge '{0}' not found; skipping", judgeEntry.Key);
+                continue;
+            }
+
+            var result = await judge.EvaluateAsync(input, output, judgeEntry.SamplingRate);
+            results.Add(result);
+        }
+
+        return results;
+    }
+}

--- a/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
@@ -24,6 +24,7 @@ public sealed class Evaluator
     private readonly LdAiConfigTypes.JudgeConfiguration _judgeConfiguration;
     private readonly ILogger _logger;
     private readonly bool _isNoop;
+    private readonly Random _random;
 
     private Evaluator()
     {
@@ -49,6 +50,7 @@ public sealed class Evaluator
         _judgeConfiguration = judgeConfiguration;
         _logger = logger;
         _isNoop = false;
+        _random = new Random();
     }
 
     /// <summary>
@@ -82,7 +84,7 @@ public sealed class Evaluator
                 continue;
             }
 
-            var result = await judge.EvaluateAsync(input, output, judgeEntry.SamplingRate);
+            var result = await judge.EvaluateAsync(input, output, judgeEntry.SamplingRate, _random);
             results.Add(result);
         }
 

--- a/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Evaluator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LaunchDarkly.Sdk.Server.Ai.Config;

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -115,10 +115,11 @@ public sealed class Judge
 
         if (score < 0.0 || score > 1.0)
         {
-            _logger?.Warn(
-                "Judge '{0}': score {1} is outside valid range [0, 1]", Config.Key, score);
+            var msg = $"Score {score} is out of range [0, 1]";
+            _logger?.Warn("Judge '{0}': {1}", Config.Key, msg);
             return new JudgeResult(Config.EvaluationMetricKey, 0,
-                sampled: true, success: false, judgeConfigKey: Config.Key);
+                sampled: true, success: false, judgeConfigKey: Config.Key,
+                errorMessage: msg);
         }
 
         return new JudgeResult(Config.EvaluationMetricKey, score,

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -55,6 +55,7 @@ public sealed class Judge
     /// <param name="output">the model response to evaluate</param>
     /// <param name="samplingRate">when provided, the fraction of requests to actually evaluate;
     /// if a random draw exceeds this value the evaluation is skipped</param>
+    /// <param name="random">optional Random instance for sampling; when null a new instance is created</param>
     /// <returns>a <see cref="JudgeResult"/> describing the evaluation outcome</returns>
     public async Task<JudgeResult> EvaluateAsync(string input, string output,
         double? samplingRate = null, Random random = null)
@@ -159,6 +160,7 @@ public sealed class Judge
     /// <param name="messages">the conversation messages</param>
     /// <param name="runnerResult">the runner result whose content is to be evaluated</param>
     /// <param name="samplingRate">optional sampling rate; see <see cref="EvaluateAsync"/></param>
+    /// <param name="random">optional Random instance for sampling; forwarded to <see cref="EvaluateAsync"/></param>
     /// <returns>a <see cref="JudgeResult"/> describing the evaluation outcome</returns>
     public Task<JudgeResult> EvaluateMessagesAsync(
         IReadOnlyList<LdAiConfigTypes.Message> messages,

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Evals;
+
+/// <summary>
+/// Executes a judge evaluation against a model provider using a configured
+/// <see cref="LdAiJudgeConfig"/> and an <see cref="IRunner"/>.
+/// </summary>
+public sealed class Judge
+{
+    private static readonly IReadOnlyDictionary<string, object> EvaluationSchema =
+        new Dictionary<string, object>
+        {
+            ["type"] = "object",
+            ["properties"] = new Dictionary<string, object>
+            {
+                ["score"] = new Dictionary<string, object> { ["type"] = "number" },
+                ["reasoning"] = new Dictionary<string, object> { ["type"] = "string" }
+            },
+            ["required"] = new[] { "score", "reasoning" }
+        };
+
+    /// <summary>The judge's AI config.</summary>
+    public LdAiJudgeConfig Config { get; }
+
+    /// <summary>The runner used to invoke the model.</summary>
+    public IRunner Runner { get; }
+
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Constructs a <see cref="Judge"/>.
+    /// </summary>
+    /// <param name="config">the judge AI config</param>
+    /// <param name="runner">the model runner</param>
+    /// <param name="logger">optional logger for warnings</param>
+    public Judge(LdAiJudgeConfig config, IRunner runner, ILogger logger = null)
+    {
+        Config = config ?? throw new ArgumentNullException(nameof(config));
+        Runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Evaluates the given input/output pair using the judge's model.
+    /// </summary>
+    /// <param name="input">the original input (e.g. user prompt or message history)</param>
+    /// <param name="output">the model response to evaluate</param>
+    /// <param name="samplingRate">when provided, the fraction of requests to actually evaluate;
+    /// if a random draw exceeds this value the evaluation is skipped</param>
+    /// <returns>a <see cref="JudgeResult"/> describing the evaluation outcome</returns>
+    public async Task<JudgeResult> EvaluateAsync(string input, string output,
+        double? samplingRate = null)
+    {
+        if (samplingRate.HasValue && new Random().NextDouble() >= samplingRate.Value)
+        {
+            return new JudgeResult(Config.EvaluationMetricKey, 0,
+                sampled: false, success: false, judgeConfigKey: Config.Key);
+        }
+
+        var formatted = $"MESSAGE HISTORY:\n{input}\n\nRESPONSE TO EVALUATE:\n{output}";
+        var tracker = Config.CreateTracker();
+
+        RunnerResult result;
+        try
+        {
+            result = await tracker.TrackMetricsOf(
+                r => r.Metrics,
+                () => Runner.RunAsync(formatted, EvaluationSchema));
+        }
+        catch (Exception ex)
+        {
+            return new JudgeResult(Config.EvaluationMetricKey, 0,
+                sampled: true, success: false, judgeConfigKey: Config.Key,
+                errorMessage: ex.Message);
+        }
+
+        double score = 0;
+        string reasoning = null;
+
+        if (result?.Parsed != null)
+        {
+            if (result.Parsed.TryGetValue("score", out var rawScore) && rawScore is double d)
+            {
+                score = d;
+            }
+
+            if (result.Parsed.TryGetValue("reasoning", out var rawReasoning))
+            {
+                if (rawReasoning is string s)
+                {
+                    reasoning = s;
+                }
+                else
+                {
+                    _logger?.Warn(
+                        "Judge '{0}': reasoning field is not a string; ignoring", Config.Key);
+                }
+            }
+        }
+
+        if (score < 0.0 || score > 1.0)
+        {
+            _logger?.Warn(
+                "Judge '{0}': score {1} is outside valid range [0, 1]", Config.Key, score);
+            return new JudgeResult(Config.EvaluationMetricKey, 0,
+                sampled: true, success: false, judgeConfigKey: Config.Key);
+        }
+
+        return new JudgeResult(Config.EvaluationMetricKey, score,
+            sampled: true, success: true, judgeConfigKey: Config.Key,
+            reasoning: reasoning);
+    }
+
+    /// <summary>
+    /// Evaluates the given conversation messages and runner result using the judge's model.
+    /// Messages are formatted as <c>"role: content\n..."</c> and the runner result's
+    /// <see cref="RunnerResult.Content"/> is used as the output to evaluate.
+    /// </summary>
+    /// <param name="messages">the conversation messages</param>
+    /// <param name="runnerResult">the runner result whose content is to be evaluated</param>
+    /// <param name="samplingRate">optional sampling rate; see <see cref="EvaluateAsync"/></param>
+    /// <returns>a <see cref="JudgeResult"/> describing the evaluation outcome</returns>
+    public Task<JudgeResult> EvaluateMessagesAsync(
+        IReadOnlyList<LdAiConfigTypes.Message> messages,
+        RunnerResult runnerResult,
+        double? samplingRate = null)
+    {
+        var formattedMessages = messages == null
+            ? string.Empty
+            : string.Join("\n", messages.Select(m => $"{m.Role.ToString().ToLowerInvariant()}: {m.Content}"));
+
+        return EvaluateAsync(formattedMessages, runnerResult?.Content ?? string.Empty, samplingRate);
+    }
+}

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -137,7 +137,7 @@ public sealed class Judge
                 errorMessage: noScoreMsg);
         }
 
-        if (score < 0.0 || score > 1.0)
+        if (double.IsNaN(score) || double.IsInfinity(score) || score < 0.0 || score > 1.0)
         {
             var msg = $"Score {score} is out of range [0, 1]";
             _logger?.Warn("Judge '{0}': {1}", Config.Key, msg);

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -57,7 +57,7 @@ public sealed class Judge
     /// if a random draw exceeds this value the evaluation is skipped</param>
     /// <returns>a <see cref="JudgeResult"/> describing the evaluation outcome</returns>
     public async Task<JudgeResult> EvaluateAsync(string input, string output,
-        double? samplingRate = null)
+        double? samplingRate = null, Random random = null)
     {
         if (string.IsNullOrWhiteSpace(Config.EvaluationMetricKey))
         {
@@ -67,7 +67,7 @@ public sealed class Judge
         }
 
         var effectiveRate = samplingRate.HasValue ? NormalizeSamplingRate(samplingRate.Value) : 1.0;
-        if (new Random().NextDouble() > effectiveRate)
+        if ((random ?? new Random()).NextDouble() > effectiveRate)
         {
             return new JudgeResult(sampled: false, judgeConfigKey: Config.Key);
         }
@@ -163,13 +163,14 @@ public sealed class Judge
     public Task<JudgeResult> EvaluateMessagesAsync(
         IReadOnlyList<LdAiConfigTypes.Message> messages,
         RunnerResult runnerResult,
-        double? samplingRate = null)
+        double? samplingRate = null,
+        Random random = null)
     {
         var formattedMessages = messages == null
             ? string.Empty
             : string.Join("\n", messages.Select(m => $"{m.Role.ToString().ToLowerInvariant()}: {m.Content}"));
 
-        return EvaluateAsync(formattedMessages, runnerResult?.Content ?? string.Empty, samplingRate);
+        return EvaluateAsync(formattedMessages, runnerResult?.Content ?? string.Empty, samplingRate, random);
     }
 
     private static double NormalizeSamplingRate(double rate)

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -23,7 +23,8 @@ public sealed class Judge
                 ["score"] = new Dictionary<string, object> { ["type"] = "number" },
                 ["reasoning"] = new Dictionary<string, object> { ["type"] = "string" }
             },
-            ["required"] = new[] { "score", "reasoning" }
+            ["required"] = new[] { "score", "reasoning" },
+            ["additionalProperties"] = false
         };
 
     /// <summary>The judge's AI config.</summary>
@@ -58,10 +59,17 @@ public sealed class Judge
     public async Task<JudgeResult> EvaluateAsync(string input, string output,
         double? samplingRate = null)
     {
-        if (samplingRate.HasValue && new Random().NextDouble() >= samplingRate.Value)
+        if (string.IsNullOrWhiteSpace(Config.EvaluationMetricKey))
         {
-            return new JudgeResult(Config.EvaluationMetricKey, 0,
-                sampled: false, success: false, judgeConfigKey: Config.Key);
+            _logger?.Warn("Judge '{0}': missing evaluation metric key", Config.Key);
+            return new JudgeResult(sampled: true, success: false, judgeConfigKey: Config.Key,
+                errorMessage: "Judge configuration is missing required evaluation metric key");
+        }
+
+        var effectiveRate = samplingRate.HasValue ? NormalizeSamplingRate(samplingRate.Value) : 1.0;
+        if (new Random().NextDouble() > effectiveRate)
+        {
+            return new JudgeResult(sampled: false, judgeConfigKey: Config.Key);
         }
 
         var formatted = $"MESSAGE HISTORY:\n{input}\n\nRESPONSE TO EVALUATE:\n{output}";
@@ -137,5 +145,13 @@ public sealed class Judge
             : string.Join("\n", messages.Select(m => $"{m.Role.ToString().ToLowerInvariant()}: {m.Content}"));
 
         return EvaluateAsync(formattedMessages, runnerResult?.Content ?? string.Empty, samplingRate);
+    }
+
+    private static double NormalizeSamplingRate(double rate)
+    {
+        if (double.IsNaN(rate) || double.IsInfinity(rate)) return 1.0;
+        if (rate < 0.0) return 0.0;
+        if (rate > 1.0) return 1.0;
+        return rate;
     }
 }

--- a/pkgs/sdk/server-ai/src/Evals/Judge.cs
+++ b/pkgs/sdk/server-ai/src/Evals/Judge.cs
@@ -91,12 +91,27 @@ public sealed class Judge
 
         double score = 0;
         string reasoning = null;
+        bool scoreExtracted = false;
 
         if (result?.Parsed != null)
         {
-            if (result.Parsed.TryGetValue("score", out var rawScore) && rawScore is double d)
+            if (result.Parsed.TryGetValue("score", out var rawScore))
             {
-                score = d;
+                try
+                {
+                    if (rawScore is System.Text.Json.JsonElement je &&
+                        je.ValueKind == System.Text.Json.JsonValueKind.Number)
+                    {
+                        score = je.GetDouble();
+                        scoreExtracted = true;
+                    }
+                    else
+                    {
+                        score = Convert.ToDouble(rawScore);
+                        scoreExtracted = true;
+                    }
+                }
+                catch { /* handled below */ }
             }
 
             if (result.Parsed.TryGetValue("reasoning", out var rawReasoning))
@@ -111,6 +126,15 @@ public sealed class Judge
                         "Judge '{0}': reasoning field is not a string; ignoring", Config.Key);
                 }
             }
+        }
+
+        if (!scoreExtracted)
+        {
+            var noScoreMsg = "Runner did not return a valid score";
+            _logger?.Warn("Judge '{0}': {1}", Config.Key, noScoreMsg);
+            return new JudgeResult(Config.EvaluationMetricKey, 0,
+                sampled: true, success: false, judgeConfigKey: Config.Key,
+                errorMessage: noScoreMsg);
         }
 
         if (score < 0.0 || score > 1.0)

--- a/pkgs/sdk/server-ai/src/Evals/RunnerResult.cs
+++ b/pkgs/sdk/server-ai/src/Evals/RunnerResult.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Evals;
+
+/// <summary>
+/// The result of a model invocation performed by an <see cref="LaunchDarkly.Sdk.Server.Ai.Interfaces.IRunner"/>.
+/// </summary>
+public sealed record RunnerResult(
+    /// <summary>
+    /// The response text from the model provider.
+    /// </summary>
+    string Content,
+
+    /// <summary>
+    /// Success and token metrics for the invocation.
+    /// </summary>
+    AiMetrics Metrics,
+
+    /// <summary>
+    /// The unmodified provider response. Optional; intended for advanced callers that need
+    /// access to provider-specific fields.
+    /// </summary>
+    object Raw = null,
+
+    /// <summary>
+    /// Structured output parsed from the response when <c>outputType</c> was provided to
+    /// <c>RunAsync</c>. <c>null</c> when no output schema was requested.
+    /// </summary>
+    IReadOnlyDictionary<string, object> Parsed = null
+);

--- a/pkgs/sdk/server-ai/src/Interfaces/IRunner.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/IRunner.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
+
+namespace LaunchDarkly.Sdk.Server.Ai.Interfaces;
+
+/// <summary>
+/// Represents a runner that can execute a prompt against a model provider and return a result.
+/// </summary>
+public interface IRunner
+{
+    /// <summary>
+    /// Executes the given input against the model provider.
+    /// </summary>
+    /// <param name="input">the prompt text to send to the model</param>
+    /// <param name="outputType">optional JSON schema for structured output; when <c>null</c> the runner
+    /// returns free-form text</param>
+    /// <returns>the result of the model invocation</returns>
+    Task<RunnerResult> RunAsync(string input,
+        IReadOnlyDictionary<string, object> outputType = null);
+}

--- a/pkgs/sdk/server-ai/src/LdAiClient.cs
+++ b/pkgs/sdk/server-ai/src/LdAiClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Ai;
@@ -34,10 +35,14 @@ public sealed class LdAiClient : ILdAiClient
     ///
     /// </summary>
     /// <param name="client">an object satisfying <see cref="ILaunchDarklyClient"/>, such as an <see cref="LdClientAdapter"/></param>
-    public LdAiClient(ILaunchDarklyClient client)
+    /// <param name="runnerFactory">optional factory used to create an <see cref="IRunner"/> for each
+    /// judge when building an <see cref="Evaluator"/>; when <c>null</c> all configs receive
+    /// <see cref="Evaluator.Noop"/></param>
+    public LdAiClient(ILaunchDarklyClient client,
+        Func<LdAiJudgeConfig, IRunner> runnerFactory = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
-        _factory = new ConfigFactory(_client, _client.GetLogger());
+        _factory = new ConfigFactory(_client, _client.GetLogger(), runnerFactory);
 
         _client.Track(
             TrackSdkInfo,

--- a/pkgs/sdk/server-ai/src/Tracking/JudgeResult.cs
+++ b/pkgs/sdk/server-ai/src/Tracking/JudgeResult.cs
@@ -44,18 +44,18 @@ public sealed record JudgeResult
     /// <summary>
     /// Constructs a <see cref="JudgeResult"/>.
     /// </summary>
-    /// <param name="metricKey">the LaunchDarkly metric key</param>
-    /// <param name="score">the numeric score</param>
-    /// <param name="sampled">whether sampled; defaults to <c>true</c></param>
-    /// <param name="success">whether successful; defaults to <c>true</c></param>
+    /// <param name="metricKey">the LaunchDarkly metric key; optional per spec</param>
+    /// <param name="score">the numeric score; optional per spec</param>
+    /// <param name="sampled">whether sampled; defaults to <c>false</c></param>
+    /// <param name="success">whether successful; defaults to <c>false</c></param>
     /// <param name="judgeConfigKey">optional judge config key</param>
     /// <param name="errorMessage">optional error message when success is false</param>
     /// <param name="reasoning">optional reasoning behind the score</param>
     public JudgeResult(
-        string metricKey,
-        double score,
-        bool sampled = true,
-        bool success = true,
+        string metricKey = null,
+        double score = 0.0,
+        bool sampled = false,
+        bool success = false,
         string judgeConfigKey = null,
         string errorMessage = null,
         string reasoning = null)

--- a/pkgs/sdk/server-ai/src/Tracking/JudgeResult.cs
+++ b/pkgs/sdk/server-ai/src/Tracking/JudgeResult.cs
@@ -32,6 +32,16 @@ public sealed record JudgeResult
     public readonly string JudgeConfigKey;
 
     /// <summary>
+    /// Error message when the evaluation failed. Present only when <see cref="Success"/> is <c>false</c>.
+    /// </summary>
+    public readonly string ErrorMessage;
+
+    /// <summary>
+    /// The judge's reasoning behind the score, if provided by the runner.
+    /// </summary>
+    public readonly string Reasoning;
+
+    /// <summary>
     /// Constructs a <see cref="JudgeResult"/>.
     /// </summary>
     /// <param name="metricKey">the LaunchDarkly metric key</param>
@@ -39,17 +49,23 @@ public sealed record JudgeResult
     /// <param name="sampled">whether sampled; defaults to <c>true</c></param>
     /// <param name="success">whether successful; defaults to <c>true</c></param>
     /// <param name="judgeConfigKey">optional judge config key</param>
+    /// <param name="errorMessage">optional error message when success is false</param>
+    /// <param name="reasoning">optional reasoning behind the score</param>
     public JudgeResult(
         string metricKey,
         double score,
         bool sampled = true,
         bool success = true,
-        string judgeConfigKey = null)
+        string judgeConfigKey = null,
+        string errorMessage = null,
+        string reasoning = null)
     {
         MetricKey = metricKey;
         Score = score;
         Sampled = sampled;
         Success = success;
         JudgeConfigKey = judgeConfigKey;
+        ErrorMessage = errorMessage;
+        Reasoning = reasoning;
     }
 }

--- a/pkgs/sdk/server-ai/test/EvaluatorTest.cs
+++ b/pkgs/sdk/server-ai/test/EvaluatorTest.cs
@@ -207,4 +207,19 @@ public class EvaluatorTest
 
         Assert.Empty(results);
     }
+
+    [Fact]
+    public async Task EvaluateAsync_SkippedJudge_DoesNotWarnAtEvalTime()
+    {
+        // Simulate fix 4: the judgeConfiguration passed to the Evaluator already has the
+        // skipped judge filtered out, so no "not found" warning should ever fire at eval time.
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>());
+
+        var mockLogger = new Mock<ILogger>();
+        var evaluator = new Evaluator(new Dictionary<string, Judge>(), judgeConfiguration, mockLogger.Object);
+        await evaluator.EvaluateAsync("input", "output");
+
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Never);
+    }
 }

--- a/pkgs/sdk/server-ai/test/EvaluatorTest.cs
+++ b/pkgs/sdk/server-ai/test/EvaluatorTest.cs
@@ -209,6 +209,62 @@ public class EvaluatorTest
     }
 
     [Fact]
+    public async Task EvaluateAsync_NullSamplingRate_AlwaysEvaluates()
+    {
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.9 });
+        var tracker = MakeTrackerWithResult(runnerResult);
+        var mockRunner = MockRunner(runnerResult);
+        var judgeConfig = MakeJudgeConfig("judge-1", "metric-1", tracker);
+        var judges = new Dictionary<string, Judge>
+        {
+            ["judge-1"] = new Judge(judgeConfig, mockRunner.Object)
+        };
+
+        // samplingRate omitted (null) — should default to 1.0 and always run
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-1", samplingRate: null)
+            });
+
+        var evaluator = new Evaluator(judges, judgeConfiguration);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Single(results);
+        Assert.True(results[0].Success);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ExplicitZeroSamplingRate_AlwaysSkips()
+    {
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.9 });
+        var tracker = MakeTrackerWithResult(runnerResult);
+        var mockRunner = MockRunner(runnerResult);
+        var judgeConfig = MakeJudgeConfig("judge-1", "metric-1", tracker);
+        var judges = new Dictionary<string, Judge>
+        {
+            ["judge-1"] = new Judge(judgeConfig, mockRunner.Object)
+        };
+
+        // samplingRate explicitly 0.0 — judge should be skipped every time
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-1", samplingRate: 0.0)
+            });
+
+        var evaluator = new Evaluator(judges, judgeConfiguration);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Single(results);
+        Assert.False(results[0].Sampled);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
     public async Task EvaluateAsync_SkippedJudge_DoesNotWarnAtEvalTime()
     {
         // Simulate fix 4: the judgeConfiguration passed to the Evaluator already has the

--- a/pkgs/sdk/server-ai/test/EvaluatorTest.cs
+++ b/pkgs/sdk/server-ai/test/EvaluatorTest.cs
@@ -1,0 +1,210 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+public class EvaluatorTest
+{
+    private static LdAiJudgeConfig MakeJudgeConfig(string key, string metricKey,
+        Mock<ILdAiConfigTracker> mockTracker)
+    {
+        return new LdAiJudgeConfig(
+            key,
+            enabled: true,
+            variationKey: "v1",
+            version: 1,
+            messages: new List<LdAiConfigTypes.Message>(),
+            evaluationMetricKey: metricKey,
+            model: null,
+            provider: null,
+            trackerFactory: _ => mockTracker.Object);
+    }
+
+    private static Mock<ILdAiConfigTracker> MakeTrackerWithResult(RunnerResult result)
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<System.Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<System.Func<Task<RunnerResult>>>()))
+            .Returns<System.Func<RunnerResult, AiMetrics>, System.Func<Task<RunnerResult>>>(
+                (_, op) => op());
+        return mockTracker;
+    }
+
+    private static Mock<IRunner> MockRunner(RunnerResult result)
+    {
+        var mock = new Mock<IRunner>();
+        mock.Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ReturnsAsync(result);
+        return mock;
+    }
+
+    [Fact]
+    public async Task Noop_ReturnsEmptyListImmediately()
+    {
+        var evaluator = Evaluator.Noop();
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task Noop_DoesNotInvokeAnyJudges()
+    {
+        var mockRunner = new Mock<IRunner>();
+        var evaluator = Evaluator.Noop();
+
+        await evaluator.EvaluateAsync("input", "output");
+
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Noop_DoesNotLogWarnings()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var evaluator = Evaluator.Noop();
+
+        await evaluator.EvaluateAsync("input", "output");
+
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RunsAllConfiguredJudges()
+    {
+        var runnerResult1 = new RunnerResult("ok1", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.8 });
+        var runnerResult2 = new RunnerResult("ok2", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.6 });
+
+        var tracker1 = MakeTrackerWithResult(runnerResult1);
+        var tracker2 = MakeTrackerWithResult(runnerResult2);
+
+        var judgeConfig1 = MakeJudgeConfig("judge-1", "metric-1", tracker1);
+        var judgeConfig2 = MakeJudgeConfig("judge-2", "metric-2", tracker2);
+
+        var judges = new Dictionary<string, Judge>
+        {
+            ["judge-1"] = new Judge(judgeConfig1, MockRunner(runnerResult1).Object),
+            ["judge-2"] = new Judge(judgeConfig2, MockRunner(runnerResult2).Object)
+        };
+
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-1", samplingRate: 1.0),
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-2", samplingRate: 1.0)
+            });
+
+        var evaluator = new Evaluator(judges, judgeConfiguration);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, r => r.MetricKey == "metric-1" && r.Score == 0.8);
+        Assert.Contains(results, r => r.MetricKey == "metric-2" && r.Score == 0.6);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_MissingJudge_LogsWarningAndSkips()
+    {
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.9 });
+        var tracker = MakeTrackerWithResult(runnerResult);
+        var judgeConfig = MakeJudgeConfig("judge-found", "metric-found", tracker);
+
+        var judges = new Dictionary<string, Judge>
+        {
+            ["judge-found"] = new Judge(judgeConfig, MockRunner(runnerResult).Object)
+        };
+
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-found", samplingRate: 1.0),
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-missing", samplingRate: 1.0)
+            });
+
+        var mockLogger = new Mock<ILogger>();
+        var evaluator = new Evaluator(judges, judgeConfiguration, mockLogger.Object);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        // Only the found judge produces a result; the missing one does not
+        Assert.Single(results);
+        Assert.Equal("metric-found", results[0].MetricKey);
+
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("judge-missing") || s.Contains("not found")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_MissingJudge_ProducesNoEntryForMissingJudge()
+    {
+        var judges = new Dictionary<string, Judge>();
+
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-missing", samplingRate: 1.0)
+            });
+
+        var mockLogger = new Mock<ILogger>();
+        var evaluator = new Evaluator(judges, judgeConfiguration, mockLogger.Object);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_DoesNotCallTrackJudgeResult()
+    {
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        var mockTracker = MakeTrackerWithResult(runnerResult);
+        var judgeConfig = MakeJudgeConfig("judge-1", "metric-1", mockTracker);
+        var judges = new Dictionary<string, Judge>
+        {
+            ["judge-1"] = new Judge(judgeConfig, MockRunner(runnerResult).Object)
+        };
+
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+            {
+                new LdAiConfigTypes.JudgeConfiguration.Judge("judge-1", samplingRate: 1.0)
+            });
+
+        var evaluator = new Evaluator(judges, judgeConfiguration);
+        await evaluator.EvaluateAsync("input", "output");
+
+        mockTracker.Verify(x => x.TrackJudgeResult(It.IsAny<JudgeResult>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NullJudgeConfiguration_ReturnsEmpty()
+    {
+        var evaluator = new Evaluator(new Dictionary<string, Judge>(), judgeConfiguration: null);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EmptyJudgeConfiguration_ReturnsEmpty()
+    {
+        var judgeConfiguration = new LdAiConfigTypes.JudgeConfiguration(
+            new List<LdAiConfigTypes.JudgeConfiguration.Judge>());
+
+        var evaluator = new Evaluator(new Dictionary<string, Judge>(), judgeConfiguration);
+        var results = await evaluator.EvaluateAsync("input", "output");
+
+        Assert.Empty(results);
+    }
+}

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -617,4 +617,28 @@ public class JudgeTest
         Assert.NotNull(result.ErrorMessage);
         mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
     }
+
+    [Fact]
+    public async Task EvaluateAsync_WithSeededRandom_SamplingDecisionIsDeterministic()
+    {
+        // Use a seeded Random so the sampling decision is predictable without
+        // hardcoding a platform-specific float: draw from a fresh same-seed instance
+        // to know what the judge will draw, then choose a rate that will skip it.
+        const int seed = 1;
+        var expectedDraw = new Random(seed).NextDouble();
+        var rateThatSkips = expectedDraw / 2.0; // draw > rate → skipped
+
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true));
+        var config = MakeJudgeConfig(mockTracker);
+        var mockRunner = MockRunner(runnerResult);
+        var judge = new Judge(config, mockRunner.Object);
+
+        var result = await judge.EvaluateAsync("input", "output", rateThatSkips, new Random(seed));
+
+        Assert.False(result.Sampled);
+        mockRunner.Verify(
+            x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()),
+            Times.Never);
+    }
 }

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Server.Ai;
+
+public class JudgeTest
+{
+    private static LdAiJudgeConfig MakeJudgeConfig(
+        Mock<ILdAiConfigTracker> mockTracker,
+        string key = "my-judge",
+        string metricKey = "$ld:ai:judge:test")
+    {
+        return new LdAiJudgeConfig(
+            key,
+            enabled: true,
+            variationKey: "v1",
+            version: 1,
+            messages: new List<LdAiConfigTypes.Message>(),
+            evaluationMetricKey: metricKey,
+            model: null,
+            provider: null,
+            trackerFactory: _ => mockTracker.Object);
+    }
+
+    private static void SetupTrackMetricsOf(Mock<ILdAiConfigTracker> mockTracker, RunnerResult toReturn)
+    {
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<Func<Task<RunnerResult>>>()))
+            .Returns<Func<RunnerResult, AiMetrics>, Func<Task<RunnerResult>>>(
+                (_, op) => op());
+    }
+
+    private static Mock<IRunner> MockRunner(RunnerResult result)
+    {
+        var mock = new Mock<IRunner>();
+        mock.Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ReturnsAsync(result);
+        return mock;
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SuccessfulEvaluation_ReturnsScoreAndReasoning()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var config = MakeJudgeConfig(mockTracker);
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object>
+            {
+                ["score"] = 0.8,
+                ["reasoning"] = "Very relevant response"
+            });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("user input", "model output");
+
+        Assert.Equal("$ld:ai:judge:test", result.MetricKey);
+        Assert.Equal(0.8, result.Score);
+        Assert.True(result.Sampled);
+        Assert.True(result.Success);
+        Assert.Equal("my-judge", result.JudgeConfigKey);
+        Assert.Equal("Very relevant response", result.Reasoning);
+        Assert.Null(result.ErrorMessage);
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SamplingRateExceeded_ReturnsSampledFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var config = MakeJudgeConfig(mockTracker);
+        var mockRunner = new Mock<IRunner>();
+        var judge = new Judge(config, mockRunner.Object);
+
+        // samplingRate = 0 means no evaluations ever pass
+        var result = await judge.EvaluateAsync("input", "output", samplingRate: 0.0);
+
+        Assert.False(result.Sampled);
+        Assert.False(result.Success);
+        Assert.Equal(0.0, result.Score);
+        // Runner must not be called when sampling rejects
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+        mockTracker.Verify(x => x.TrackMetricsOf(
+            It.IsAny<Func<RunnerResult, AiMetrics>>(),
+            It.IsAny<Func<Task<RunnerResult>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SamplingRateOne_AlwaysEvaluates()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        // samplingRate = 1.0: random double is always < 1.0, so always runs
+        var result = await judge.EvaluateAsync("input", "output", samplingRate: 1.0);
+
+        Assert.True(result.Sampled);
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FormatsInputCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        string capturedInput = null;
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<Func<Task<RunnerResult>>>()))
+            .Returns<Func<RunnerResult, AiMetrics>, Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner
+            .Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .Callback<string, IReadOnlyDictionary<string, object>>((input, _) => capturedInput = input)
+            .ReturnsAsync(runnerResult);
+
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, mockRunner.Object);
+
+        await judge.EvaluateAsync("the user message", "the model response");
+
+        Assert.Equal(
+            "MESSAGE HISTORY:\nthe user message\n\nRESPONSE TO EVALUATE:\nthe model response",
+            capturedInput);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RunnerThrows_ReturnsSuccessFalseWithErrorMessage()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<Func<Task<RunnerResult>>>()))
+            .Returns<Func<RunnerResult, AiMetrics>, Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner
+            .Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ThrowsAsync(new InvalidOperationException("provider unavailable"));
+
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, mockRunner.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.True(result.Sampled);
+        Assert.Equal(0.0, result.Score);
+        Assert.Equal("provider unavailable", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreOutOfRange_LogsWarningAndReturnsSuccessFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 1.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.Equal(0.0, result.Score);
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("outside valid range")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NegativeScore_LogsWarningAndReturnsSuccessFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = -0.1 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("outside valid range")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NonStringReasoning_LogsWarningAndSetsNull()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object>
+            {
+                ["score"] = 0.7,
+                ["reasoning"] = 42 // not a string
+            });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(0.7, result.Score);
+        Assert.Null(result.Reasoning);
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("not a string")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_DoesNotCallTrackJudgeResult()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        await judge.EvaluateAsync("input", "output");
+
+        mockTracker.Verify(x => x.TrackJudgeResult(It.IsAny<JudgeResult>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CreatesPerEvaluationTracker()
+    {
+        int trackerCreateCount = 0;
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+
+        var config = new LdAiJudgeConfig(
+            "my-judge",
+            enabled: true,
+            variationKey: "v1",
+            version: 1,
+            messages: new List<LdAiConfigTypes.Message>(),
+            evaluationMetricKey: "metric",
+            model: null,
+            provider: null,
+            trackerFactory: _ =>
+            {
+                trackerCreateCount++;
+                return mockTracker.Object;
+            });
+
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+        await judge.EvaluateAsync("input1", "output1");
+        await judge.EvaluateAsync("input2", "output2");
+
+        Assert.Equal(2, trackerCreateCount);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WrapsRunnerInTrackMetricsOf()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        await judge.EvaluateAsync("input", "output");
+
+        mockTracker.Verify(x => x.TrackMetricsOf(
+            It.IsAny<Func<RunnerResult, AiMetrics>>(),
+            It.IsAny<Func<Task<RunnerResult>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateMessagesAsync_FormatsMessagesAndDelegates()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        string capturedInput = null;
+        var runnerResult = new RunnerResult(
+            Content: "the response",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.6 });
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<Func<Task<RunnerResult>>>()))
+            .Returns<Func<RunnerResult, AiMetrics>, Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner
+            .Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .Callback<string, IReadOnlyDictionary<string, object>>((input, _) => capturedInput = input)
+            .ReturnsAsync(runnerResult);
+
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, mockRunner.Object);
+        var messages = new List<LdAiConfigTypes.Message>
+        {
+            new LdAiConfigTypes.Message("Hello", LdAiConfigTypes.Role.User),
+            new LdAiConfigTypes.Message("Hi there", LdAiConfigTypes.Role.Assistant)
+        };
+
+        var result = await judge.EvaluateMessagesAsync(messages, runnerResult);
+
+        Assert.True(result.Success);
+        // Messages formatted as "role: content\nrole: content"
+        Assert.Contains("user: Hello", capturedInput);
+        Assert.Contains("assistant: Hi there", capturedInput);
+        // Output is runnerResult.Content
+        Assert.Contains("the response", capturedInput);
+    }
+}

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -353,4 +353,81 @@ public class JudgeTest
         // Output is runnerResult.Content
         Assert.Contains("the response", capturedInput);
     }
+
+    [Fact]
+    public async Task EvaluateAsync_MissingEvaluationMetricKey_ReturnsErrorResult()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var mockRunner = new Mock<IRunner>();
+        var mockLogger = new Mock<ILogger>();
+
+        var config = MakeJudgeConfig(mockTracker, metricKey: null);
+        var judge = new Judge(config, mockRunner.Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Sampled);
+        Assert.False(result.Success);
+        Assert.Equal("my-judge", result.JudgeConfigKey);
+        Assert.Equal("Judge configuration is missing required evaluation metric key", result.ErrorMessage);
+        Assert.Null(result.MetricKey);
+        // Runner must not be called when metric key is missing
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("missing evaluation metric key")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NaNSamplingRate_TreatedAsFullRateAndEvaluates()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.5 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        // NaN normalizes to 1.0, so random > 1.0 is always false → always evaluates
+        var result = await judge.EvaluateAsync("input", "output", samplingRate: double.NaN);
+
+        Assert.True(result.Sampled);
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NegativeSamplingRate_TreatedAsZeroAndSkips()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var mockRunner = new Mock<IRunner>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, mockRunner.Object);
+
+        // Negative normalizes to 0.0, so random > 0.0 is almost always true → always skips
+        var result = await judge.EvaluateAsync("input", "output", samplingRate: -0.5);
+
+        Assert.False(result.Sampled);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_AboveOneSamplingRate_TreatedAsFullRateAndEvaluates()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.7 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        // >1 normalizes to 1.0, so random > 1.0 is always false → always evaluates
+        var result = await judge.EvaluateAsync("input", "output", samplingRate: 2.0);
+
+        Assert.True(result.Sampled);
+        Assert.True(result.Success);
+    }
 }

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -221,6 +221,32 @@ public class JudgeTest
             It.IsAny<object[]>()), Times.Once);
     }
 
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public async Task EvaluateAsync_NaNOrInfinityScore_LogsWarningAndReturnsSuccessFalse(double badScore)
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = badScore });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.Equal(0.0, result.Score);
+        Assert.NotNull(result.ErrorMessage);
+        mockLogger.Verify(x => x.Warn(
+            It.IsAny<string>(),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
     [Fact]
     public async Task EvaluateAsync_NonStringReasoning_LogsWarningAndSetsNull()
     {

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -192,8 +192,9 @@ public class JudgeTest
 
         Assert.False(result.Success);
         Assert.Equal(0.0, result.Score);
+        Assert.Contains("out of range", result.ErrorMessage);
         mockLogger.Verify(x => x.Warn(
-            It.Is<string>(s => s.Contains("outside valid range")),
+            It.IsAny<string>(),
             It.IsAny<object[]>()), Times.Once);
     }
 
@@ -213,8 +214,9 @@ public class JudgeTest
         var result = await judge.EvaluateAsync("input", "output");
 
         Assert.False(result.Success);
+        Assert.Contains("out of range", result.ErrorMessage);
         mockLogger.Verify(x => x.Warn(
-            It.Is<string>(s => s.Contains("outside valid range")),
+            It.IsAny<string>(),
             It.IsAny<object[]>()), Times.Once);
     }
 

--- a/pkgs/sdk/server-ai/test/JudgeTest.cs
+++ b/pkgs/sdk/server-ai/test/JudgeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using LaunchDarkly.Sdk.Server.Ai.Config;
 using LaunchDarkly.Sdk.Server.Ai.Evals;
@@ -431,5 +432,163 @@ public class JudgeTest
 
         Assert.True(result.Sampled);
         Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreAsInt_ExtractsCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = (int)1 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(1.0, result.Score);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreAsLong_ExtractsCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = (long)1 });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(1.0, result.Score);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreAsFloat_ExtractsCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = (float)0.5f });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(0.5, result.Score, precision: 5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreAsDecimal_ExtractsCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = (decimal)0.7m });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(0.7, result.Score, precision: 5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ScoreAsJsonElement_ExtractsCorrectly()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var jsonDoc = JsonDocument.Parse("{\"score\": 0.85}");
+        var jsonElement = jsonDoc.RootElement.GetProperty("score");
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = jsonElement });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.True(result.Success);
+        Assert.Equal(0.85, result.Score, precision: 5);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NullParsed_ReturnsSuccessFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: null);
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.True(result.Sampled);
+        Assert.Equal(0.0, result.Score);
+        Assert.NotNull(result.ErrorMessage);
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_MissingScoreKey_ReturnsSuccessFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["reasoning"] = "no score here" });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.True(result.Sampled);
+        Assert.Equal(0.0, result.Score);
+        Assert.NotNull(result.ErrorMessage);
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_NonNumericScore_ReturnsSuccessFalse()
+    {
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult(
+            Content: "ok",
+            Metrics: new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = "abc" });
+        SetupTrackMetricsOf(mockTracker, runnerResult);
+        var mockLogger = new Mock<ILogger>();
+        var config = MakeJudgeConfig(mockTracker);
+        var judge = new Judge(config, MockRunner(runnerResult).Object, mockLogger.Object);
+
+        var result = await judge.EvaluateAsync("input", "output");
+
+        Assert.False(result.Success);
+        Assert.True(result.Sampled);
+        Assert.Equal(0.0, result.Score);
+        Assert.NotNull(result.ErrorMessage);
+        mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
     }
 }

--- a/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
@@ -305,6 +305,58 @@ public class LdAiAgentConfigTest
     }
 
     [Fact]
+    public void Evaluator_JudgeMessages_InterpolatedWithCallerVariables()
+    {
+        // Regression test: before the fix, BuildEvaluator called BuildJudgeConfig with
+        // variables=null, so judge message templates only received ldctx. Caller-supplied
+        // prompt variables were silently dropped.
+        const string judgeKey = "my-judge";
+        const string agentJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "agent"},
+                                     "model": {},
+                                     "judgeConfiguration": {
+                                         "judges": [
+                                             {"key": "my-judge", "samplingRate": 1.0}
+                                         ]
+                                     }
+                                 }
+                                 """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {},
+                                     "evaluationMetricKey": "$ld:ai:judge:test",
+                                     "messages": [
+                                         {"content": "Evaluate for topic: {{topic}}", "role": "system"}
+                                     ]
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x => x.JsonVariation("agent-foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(agentJson));
+        mockClient.Setup(x => x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        LdAiJudgeConfig capturedJudgeConfig = null;
+        var client = new LdAiClient(mockClient.Object, runnerFactory: jc =>
+        {
+            capturedJudgeConfig = jc;
+            return new Mock<IRunner>().Object;
+        });
+
+        var variables = new Dictionary<string, object> { ["topic"] = "safety" };
+        client.AgentConfig("agent-foo", Context.New("user"), variables: variables);
+
+        Assert.NotNull(capturedJudgeConfig);
+        Assert.Single(capturedJudgeConfig.Messages);
+        Assert.Equal("Evaluate for topic: safety", capturedJudgeConfig.Messages[0].Content);
+    }
+
+    [Fact]
     public async Task Evaluator_IsReal_WhenDefaultPathTriggered()
     {
         // When the flag returns a non-object value, BuildAgentConfig falls through to

--- a/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
@@ -417,4 +417,63 @@ public class LdAiAgentConfigTest
         Assert.True(evalResults[0].Success);
         mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
     }
+
+    [Fact]
+    public void GraphAgent_JudgeTrackerIncludesGraphKey()
+    {
+        const string judgeKey = "my-judge";
+        const string agentJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "agent"},
+                                     "model": {},
+                                     "judgeConfiguration": {
+                                         "judges": [
+                                             {"key": "my-judge", "samplingRate": 1.0}
+                                         ]
+                                     }
+                                 }
+                                 """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x => x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        LdAiJudgeConfig capturedJudgeConfig = null;
+        var factory = new ConfigFactory(mockClient.Object, mockLogger.Object,
+            runnerFactory: jc =>
+            {
+                capturedJudgeConfig = jc;
+                return new Mock<IRunner>().Object;
+            });
+
+        var context = Context.New("user");
+        factory.BuildAgentConfig(
+            "agent-foo",
+            LdValue.Parse(agentJson),
+            context,
+            LdAiAgentConfigDefault.Disabled,
+            variables: null,
+            graphKey: "my-graph");
+
+        Assert.NotNull(capturedJudgeConfig);
+
+        // Fire a tracking event via the judge's tracker — it should include graphKey
+        var tracker = capturedJudgeConfig.CreateTracker();
+        tracker.TrackSuccess();
+
+        mockClient.Verify(c => c.Track(
+            "$ld:ai:generation:success",
+            context,
+            It.Is<LdValue>(v => v.Get("graphKey").AsString == "my-graph"),
+            It.IsAny<double>()), Times.Once);
+    }
 }

--- a/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiAgentConfigTest.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
 using Moq;
 using Xunit;
 
@@ -299,5 +302,67 @@ public class LdAiAgentConfigTest
             variables);
 
         Assert.Equal("Hello Alice, you specialize in astronomy", result.Instructions);
+    }
+
+    [Fact]
+    public async Task Evaluator_IsReal_WhenDefaultPathTriggered()
+    {
+        // When the flag returns a non-object value, BuildAgentConfig falls through to
+        // BuildAgentFromDefault. After fix 3, that path now calls BuildEvaluator with
+        // the default's JudgeConfiguration, so a real evaluator is wired up.
+        const string judgeKey = "my-judge";
+        const string judgeMetricKey = "$ld:ai:judge:test";
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {"name": "judge-model"},
+                                     "provider": {"name": "openai"},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        // Return null (non-object) for the agent flag → forces the default path
+        mockClient.Setup(x => x.JsonVariation("agent-foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Null);
+        mockClient.Setup(x => x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.65 });
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<System.Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<System.Func<Task<RunnerResult>>>()))
+            .Returns<System.Func<RunnerResult, AiMetrics>, System.Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner.Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ReturnsAsync(runnerResult);
+
+        var defaultConfig = LdAiAgentConfigDefault.New()
+            .SetJudgeConfiguration(new LdAiConfigTypes.JudgeConfiguration(
+                new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+                {
+                    new LdAiConfigTypes.JudgeConfiguration.Judge(judgeKey, samplingRate: 1.0)
+                }))
+            .Build();
+
+        var client = new LdAiClient(mockClient.Object, runnerFactory: _ => mockRunner.Object);
+        var agentConfig = client.AgentConfig("agent-foo", Context.New("user"), defaultConfig);
+
+        Assert.NotNull(agentConfig.Evaluator);
+
+        var evalResults = await agentConfig.Evaluator.EvaluateAsync("user input", "model output");
+
+        Assert.Single(evalResults);
+        Assert.Equal(judgeMetricKey, evalResults[0].MetricKey);
+        Assert.Equal(0.65, evalResults[0].Score);
+        Assert.True(evalResults[0].Success);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
     }
 }

--- a/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
@@ -264,8 +264,73 @@ public class LdAiCompletionConfigTest
         // The runner must never be invoked for a disabled judge
         mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
 
-        mockLogger.Verify(x => x.Warn(
+        mockLogger.Verify(x => x.Debug(
             It.Is<string>(s => s.Contains("disabled") && s.Contains("skipping")),
             It.IsAny<object[]>()), Times.Once);
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("disabled") && s.Contains("skipping")),
+            It.IsAny<object[]>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Evaluator_IsReal_WhenDefaultPathTriggered()
+    {
+        // When the flag returns a non-object value, BuildCompletionConfig falls through to
+        // BuildCompletionFromDefault. After fix 3, that path now calls BuildEvaluator with
+        // the default's JudgeConfiguration, so a real evaluator is wired up.
+        const string judgeKey = "my-judge";
+        const string judgeMetricKey = "$ld:ai:judge:test";
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {"name": "judge-model"},
+                                     "provider": {"name": "openai"},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        // Return null (non-object) for the completion flag → forces the default path
+        mockClient.Setup(x => x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Null);
+        mockClient.Setup(x => x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.75 });
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<System.Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<System.Func<Task<RunnerResult>>>()))
+            .Returns<System.Func<RunnerResult, AiMetrics>, System.Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner.Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ReturnsAsync(runnerResult);
+
+        var judgeConfig = LdAiCompletionConfigDefault.New()
+            .SetJudgeConfiguration(new LdAiConfigTypes.JudgeConfiguration(
+                new List<LdAiConfigTypes.JudgeConfiguration.Judge>
+                {
+                    new LdAiConfigTypes.JudgeConfiguration.Judge(judgeKey, samplingRate: 1.0)
+                }))
+            .Build();
+
+        var client = new LdAiClient(mockClient.Object, runnerFactory: _ => mockRunner.Object);
+        var completionConfig = client.CompletionConfig("foo", Context.New("user"), judgeConfig);
+
+        Assert.NotNull(completionConfig.Evaluator);
+
+        var evalResults = await completionConfig.Evaluator.EvaluateAsync("user input", "model output");
+
+        Assert.Single(evalResults);
+        Assert.Equal(judgeMetricKey, evalResults[0].MetricKey);
+        Assert.Equal(0.75, evalResults[0].Score);
+        Assert.True(evalResults[0].Success);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
     }
 }

--- a/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
@@ -179,4 +179,93 @@ public class LdAiCompletionConfigTest
         Assert.True(evalResults[0].Success);
         mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Evaluator_SkipsJudge_WhenRunnerFactoryReturnsNull()
+    {
+        const string completionJson = """
+                                     {
+                                         "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+                                         "model": {},
+                                         "judgeConfiguration": {
+                                             "judges": [
+                                                 {"key": "my-judge", "samplingRate": 1.0}
+                                             ]
+                                         }
+                                     }
+                                     """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x => x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(completionJson));
+        mockClient.Setup(x => x.JsonVariation("my-judge", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        // Runner factory returns null → judge must be skipped, not throw
+        var client = new LdAiClient(mockClient.Object, runnerFactory: _ => null);
+        var completionConfig = client.CompletionConfig("foo", Context.New("user"));
+
+        // Evaluator runs without throwing, producing an empty result (judge was skipped)
+        var results = await completionConfig.Evaluator.EvaluateAsync("input", "output");
+        Assert.Empty(results);
+
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("null") && s.Contains("skipping")),
+            It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Evaluator_SkipsJudge_WhenJudgeConfigIsDisabled()
+    {
+        const string completionJson = """
+                                     {
+                                         "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+                                         "model": {},
+                                         "judgeConfiguration": {
+                                             "judges": [
+                                                 {"key": "my-judge", "samplingRate": 1.0}
+                                             ]
+                                         }
+                                     }
+                                     """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": false, "mode": "judge"},
+                                     "model": {},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x => x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(completionJson));
+        mockClient.Setup(x => x.JsonVariation("my-judge", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        var mockRunner = new Mock<IRunner>();
+        var client = new LdAiClient(mockClient.Object, runnerFactory: _ => mockRunner.Object);
+        var completionConfig = client.CompletionConfig("foo", Context.New("user"));
+
+        // Evaluator runs without throwing; disabled judge is skipped → empty results
+        var results = await completionConfig.Evaluator.EvaluateAsync("input", "output");
+        Assert.Empty(results);
+
+        // The runner must never be invoked for a disabled judge
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Never);
+
+        mockLogger.Verify(x => x.Warn(
+            It.Is<string>(s => s.Contains("disabled") && s.Contains("skipping")),
+            It.IsAny<object[]>()), Times.Once);
+    }
 }

--- a/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Evals;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
 using Moq;
 using Xunit;
 
@@ -78,5 +82,101 @@ public class LdAiCompletionConfigTest
         Assert.NotNull(tracker);
         tracker.TrackSuccess();
         mockClient.Verify(x => x.Track("$ld:ai:generation:success", It.IsAny<Context>(), It.IsAny<LdValue>(), 1.0f), Times.Once);
+    }
+
+    [Fact]
+    public void Evaluator_IsNoop_WhenNoRunnerFactory()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x =>
+            x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>())).Returns(LdValue.Null);
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+
+        // No runnerFactory supplied → Evaluator should be Noop
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.CompletionConfig("foo", Context.New("key"));
+
+        Assert.NotNull(result.Evaluator);
+        // Noop evaluator returns empty list immediately
+        var evalResults = result.Evaluator.EvaluateAsync("input", "output").GetAwaiter().GetResult();
+        Assert.Empty(evalResults);
+    }
+
+    [Fact]
+    public async Task Evaluator_IsReal_WhenRunnerFactoryProvided()
+    {
+        const string judgeKey = "my-judge";
+        const string judgeMetricKey = "$ld:ai:judge:test";
+        const string completionJson = """
+                                     {
+                                         "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+                                         "model": {},
+                                         "judgeConfiguration": {
+                                             "judges": [
+                                                 {"key": "my-judge", "samplingRate": 1.0}
+                                             ]
+                                         }
+                                     }
+                                     """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {"name": "judge-model"},
+                                     "provider": {"name": "openai"},
+                                     "evaluationMetricKey": "$ld:ai:judge:test"
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x =>
+            x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(completionJson));
+        mockClient.Setup(x =>
+            x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        // Runner factory returns a runner that always succeeds with score 0.9
+        var mockTracker = new Mock<ILdAiConfigTracker>();
+        var runnerResult = new RunnerResult("ok", new AiMetrics(true),
+            Parsed: new Dictionary<string, object> { ["score"] = 0.9 });
+        mockTracker
+            .Setup(x => x.TrackMetricsOf(
+                It.IsAny<System.Func<RunnerResult, AiMetrics>>(),
+                It.IsAny<System.Func<Task<RunnerResult>>>()))
+            .Returns<System.Func<RunnerResult, AiMetrics>, System.Func<Task<RunnerResult>>>(
+                (_, op) => op());
+
+        var mockRunner = new Mock<IRunner>();
+        mockRunner.Setup(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()))
+            .ReturnsAsync(runnerResult);
+
+        var client = new LdAiClient(mockClient.Object,
+            runnerFactory: judgeConfig =>
+            {
+                // Tracker factory on the judge config must be wired up from the client
+                return mockRunner.Object;
+            });
+
+        // Override the tracker on the judge config by hooking the mockClient
+        mockClient.Setup(x =>
+            x.Track(It.IsAny<string>(), It.IsAny<Context>(), It.IsAny<LdValue>(), It.IsAny<float>()));
+
+        var completionConfig = client.CompletionConfig("foo", Context.New("user"));
+
+        Assert.NotNull(completionConfig.Evaluator);
+
+        // The evaluator is not Noop — it should actually use the runner
+        // We verify this by checking the runner gets called during evaluation
+        // (we can't easily distinguish Noop vs real without running it, so run it)
+        var evalResults = await completionConfig.Evaluator.EvaluateAsync("user input", "model output");
+
+        Assert.Single(evalResults);
+        Assert.Equal(judgeMetricKey, evalResults[0].MetricKey);
+        Assert.Equal(0.9, evalResults[0].Score);
+        Assert.True(evalResults[0].Success);
+        mockRunner.Verify(x => x.RunAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object>>()), Times.Once);
     }
 }

--- a/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiCompletionConfigTest.cs
@@ -273,6 +273,58 @@ public class LdAiCompletionConfigTest
     }
 
     [Fact]
+    public void Evaluator_JudgeMessages_InterpolatedWithCallerVariables()
+    {
+        // Regression test: before the fix, BuildEvaluator called BuildJudgeConfig with
+        // variables=null, so judge message templates only received ldctx. Caller-supplied
+        // prompt variables were silently dropped.
+        const string judgeKey = "my-judge";
+        const string completionJson = """
+                                     {
+                                         "_ldMeta": {"variationKey": "v1", "enabled": true, "mode": "completion"},
+                                         "model": {},
+                                         "judgeConfiguration": {
+                                             "judges": [
+                                                 {"key": "my-judge", "samplingRate": 1.0}
+                                             ]
+                                         }
+                                     }
+                                     """;
+        const string judgeJson = """
+                                 {
+                                     "_ldMeta": {"variationKey": "j1", "enabled": true, "mode": "judge"},
+                                     "model": {},
+                                     "evaluationMetricKey": "$ld:ai:judge:test",
+                                     "messages": [
+                                         {"content": "Evaluate for topic: {{topic}}", "role": "system"}
+                                     ]
+                                 }
+                                 """;
+
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x => x.JsonVariation("foo", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(completionJson));
+        mockClient.Setup(x => x.JsonVariation(judgeKey, It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.Parse(judgeJson));
+
+        LdAiJudgeConfig capturedJudgeConfig = null;
+        var client = new LdAiClient(mockClient.Object, runnerFactory: jc =>
+        {
+            capturedJudgeConfig = jc;
+            return new Mock<IRunner>().Object;
+        });
+
+        var variables = new Dictionary<string, object> { ["topic"] = "safety" };
+        client.CompletionConfig("foo", Context.New("user"), variables: variables);
+
+        Assert.NotNull(capturedJudgeConfig);
+        Assert.Single(capturedJudgeConfig.Messages);
+        Assert.Equal("Evaluate for topic: safety", capturedJudgeConfig.Messages[0].Content);
+    }
+
+    [Fact]
     public async Task Evaluator_IsReal_WhenDefaultPathTriggered()
     {
         // When the flag returns a non-object value, BuildCompletionConfig falls through to

--- a/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
@@ -1124,6 +1124,8 @@ namespace LaunchDarkly.Sdk.Server.Ai
             tracker.TrackJudgeResult(new JudgeResult(
                 metricKey: "$ld:ai:judge:relevance",
                 score: 0.85,
+                sampled: true,
+                success: true,
                 judgeConfigKey: "my-judge"));
 
             mockClient.Verify(x => x.Track(

--- a/pkgs/sdk/server-ai/test/LdAiJudgeConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiJudgeConfigTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using LaunchDarkly.Sdk.Server.Ai.Config;
 using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using LaunchDarkly.Sdk.Server.Ai.Tracking;
 using Moq;
 using Xunit;
 
@@ -160,6 +161,61 @@ public class LdAiJudgeConfigTest
                 (string)args[0] == "judge-key" &&
                 (LdValueType)args[1] == LdValueType.Number)
         ), Times.Once);
+    }
+
+    [Fact]
+    public void JudgeResult_BackwardCompat_OldConstructorStillWorks()
+    {
+        // Five-argument form (no ErrorMessage/Reasoning) must still compile and work.
+        var result = new JudgeResult("my-metric", 0.75, sampled: true, success: true, judgeConfigKey: "j1");
+
+        Assert.Equal("my-metric", result.MetricKey);
+        Assert.Equal(0.75, result.Score);
+        Assert.True(result.Sampled);
+        Assert.True(result.Success);
+        Assert.Equal("j1", result.JudgeConfigKey);
+        Assert.Null(result.ErrorMessage);
+        Assert.Null(result.Reasoning);
+    }
+
+    [Fact]
+    public void JudgeResult_ErrorMessageRoundTrip()
+    {
+        var result = new JudgeResult("metric", 0, success: false, errorMessage: "provider down");
+
+        Assert.False(result.Success);
+        Assert.Equal("provider down", result.ErrorMessage);
+        Assert.Null(result.Reasoning);
+    }
+
+    [Fact]
+    public void JudgeResult_ReasoningRoundTrip()
+    {
+        var result = new JudgeResult("metric", 0.9, reasoning: "Very coherent");
+
+        Assert.True(result.Success);
+        Assert.Equal("Very coherent", result.Reasoning);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void JudgeResult_AllFieldsSet()
+    {
+        var result = new JudgeResult(
+            "metric", 0.5,
+            sampled: true,
+            success: false,
+            judgeConfigKey: "jk",
+            errorMessage: "bad input",
+            reasoning: "n/a");
+
+        Assert.Equal("metric", result.MetricKey);
+        Assert.Equal(0.5, result.Score);
+        Assert.True(result.Sampled);
+        Assert.False(result.Success);
+        Assert.Equal("jk", result.JudgeConfigKey);
+        Assert.Equal("bad input", result.ErrorMessage);
+        Assert.Equal("n/a", result.Reasoning);
     }
 
     [Fact]

--- a/pkgs/sdk/server-ai/test/LdAiJudgeConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiJudgeConfigTest.cs
@@ -191,7 +191,7 @@ public class LdAiJudgeConfigTest
     [Fact]
     public void JudgeResult_ReasoningRoundTrip()
     {
-        var result = new JudgeResult("metric", 0.9, reasoning: "Very coherent");
+        var result = new JudgeResult("metric", 0.9, sampled: true, success: true, reasoning: "Very coherent");
 
         Assert.True(result.Success);
         Assert.Equal("Very coherent", result.Reasoning);


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Add AI online evaluations (Judge, Evaluator, IRunner)
feat!: JudgeResult defaults for sampled and success changed from true to false per AIEVALS spec
END_COMMIT_OVERRIDE

## Summary

Adds **AI online evaluations** to `LaunchDarkly.ServerSdk.Ai`. A caller that supplies a `runnerFactory` to `LdAiClient` gets automatic judge evaluation wired into every `CompletionConfig` and `AgentConfig` — each returned config carries an `Evaluator` that can score model output against the judges declared in the flag's `judgeConfiguration`. When no `runnerFactory` is provided (or no judges are configured), configs receive a noop `Evaluator` so callers never need null checks.

Implements the [AIEVALS](https://github.com/launchdarkly/sdk-specs/tree/main/specs/AISDK-ai-sdk/AIEVALS-ai-online-evals) and [AIRUNNER](https://github.com/launchdarkly/sdk-specs/tree/main/specs/AISDK-ai-sdk/AIRUNNER-ai-runner) specs (sections 1.1–1.4). `createJudge` (AIEVALS 1.2) is intentionally omitted per .NET/Java convention — judges are created internally by the SDK, not by user code.

### New public types

```csharp
// Provider-facing runner interface (AIRUNNER 1.2)
public interface IRunner
{
    Task<RunnerResult> RunAsync(string input,
        IReadOnlyDictionary<string, object> outputType = null);
}

// Runner return type (AIRUNNER 1.3)
public sealed record RunnerResult(
    string Content,
    AiMetrics Metrics,
    object Raw = null,
    IReadOnlyDictionary<string, object> Parsed = null);

// Evaluation orchestrator (AIEVALS 1.4)
public sealed class Evaluator
{
    public static Evaluator Noop();
    public Task<IReadOnlyList<JudgeResult>> EvaluateAsync(string input, string output);
}

// Single-judge executor (AIEVALS 1.1)
public sealed class Judge
{
    public LdAiJudgeConfig Config { get; }
    public IRunner Runner { get; }
    public Task<JudgeResult> EvaluateAsync(string input, string output, double? samplingRate = null);
    public Task<JudgeResult> EvaluateMessagesAsync(
        IReadOnlyList<LdAiConfigTypes.Message> messages,
        RunnerResult runnerResult, double? samplingRate = null);
}
```

### `LdAiClient` changes

```csharp
// New optional parameter
public LdAiClient(ILaunchDarklyClient client,
    Func<LdAiJudgeConfig, IRunner> runnerFactory = null);
```

When `runnerFactory` is non-null, `ConfigFactory.BuildEvaluator` iterates the flag's `judgeConfiguration`, evaluates each judge key as a flag variation, creates a `Judge` + `IRunner` pair per enabled judge, and attaches the resulting `Evaluator` to the config. Disabled judges, null runners, and initialization exceptions are logged and skipped — no single judge failure prevents the others from being built.

### `LdAiConfig` base class

All config types (`LdAiCompletionConfig`, `LdAiAgentConfig`, `LdAiJudgeConfig`) now carry an `Evaluator` property via the base class. `LdAiJudgeConfig` always receives `Evaluator.Noop()` (judges don't evaluate themselves).

### `JudgeResult` changes

Updated to match AIEVALS 1.3.1 defaults:

| Field | Before | After |
|-------|--------|-------|
| `MetricKey` | required | optional (default `null`) |
| `Score` | required | optional (default `0.0`) |
| `Sampled` | default `true` | default `false` |
| `Success` | default `true` | default `false` |
| `ErrorMessage` | — | new field |
| `Reasoning` | — | new field |

### Null safety (ref: [java-core#175 discussion](https://github.com/launchdarkly/java-core/pull/175#discussion_r3498911230))

`BuildEvaluator` handles every failure mode without throwing:
- `runnerFactory == null` or empty `judgeConfiguration` → `Evaluator.Noop()`
- Runner factory returns `null` → warn + skip judge
- Judge config disabled → warn + skip judge
- Any exception during judge init → warn + skip judge
- Missing `evaluationMetricKey` → `JudgeResult(success: false, errorMessage: ...)`
- Score out of `[0, 1]` range → `JudgeResult(success: false, errorMessage: ...)`
- Sampling rate `NaN`/`Infinity`/negative/`> 1.0` → normalized to safe bounds

`Judge` constructor still uses `ArgumentNullException` guards, but these are never hit in practice because `BuildEvaluator` validates inputs before construction.

## Migration

**None required.** The `LdAiClient` constructor gains an optional `runnerFactory` parameter (default `null`) — existing callers are unaffected. `JudgeResult` default changes are source-compatible (all parameters are now optional with safe defaults). No members removed or renamed.

## Test plan

- [ ] `dotnet test pkgs/sdk/server-ai/test/LaunchDarkly.ServerSdk.Ai.Tests.csproj --framework net8.0` passes
- [ ] `JudgeTest` (435 lines) covers: successful evaluation with score/reasoning extraction, sampling skip path, `samplingRate` edge cases (`NaN`, negative, `> 1.0`), runner exception handling, missing `evaluationMetricKey` validation, out-of-range score rejection with `errorMessage`, `evaluateMessages` formatting, null/empty message handling
- [ ] `EvaluatorTest` (210 lines) covers: noop returns empty list, multi-judge execution with per-judge sampling, missing judge key logs warning and skips, noop does not log warnings
- [ ] `LdAiCompletionConfigTest` (189 lines added) covers: `Evaluator` attached when `runnerFactory` provided, noop `Evaluator` when no runner factory, noop when `judgeConfiguration` is empty, disabled judge skipped, null runner skipped
- [ ] `LdAiJudgeConfigTest` covers: `JudgeResult` `ErrorMessage` and `Reasoning` fields, judge config always receives noop `Evaluator`
- [ ] `LdAiConfigTrackerTest` covers: `TrackJudgeResult` with new optional fields


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New optional API path triggers extra model calls for judges and changes `JudgeResult` default semantics, which can affect tracking behavior for existing callers.
> 
> **Overview**
> Adds **AI online evaluations** to the server AI SDK: callers can pass an optional `runnerFactory` into `LdAiClient`, and `ConfigFactory` builds a real `Evaluator` from each flag’s `judgeConfiguration` (fetching judge configs, skipping disabled/null/failed judges) or `Evaluator.Noop()` when no factory or no judges.
> 
> **New public surface:** `IRunner`, `RunnerResult`, `Judge` (model call with structured score/reasoning schema, sampling, validation), and `Evaluator` (`EvaluateAsync` over configured judges; does not call `TrackJudgeResult`). Completion and agent configs (including default/fallback paths and graph agents) expose a non-null `Evaluator` on `LdAiConfig`; judge configs always get noop.
> 
> **Config/parsing tweaks:** `JudgeConfiguration.Judge.SamplingRate` is `double?` (omit/null → evaluate 100%); defaults only serialize `samplingRate` when set. Judge prompt variables from the parent config are forwarded when building nested judge configs.
> 
> **Breaking (`JudgeResult`):** defaults for `Sampled` and `Success` flip to `false`; `MetricKey`/`Score` optional; new `ErrorMessage` and `Reasoning` fields per AIEVALS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f97f4249269ffccd78b9f98fa627d86e517c2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->