### PR TITLE
fix(ci): pin client SDK macOS jobs to macos-15 for Xcode 16.2

### DIFF
--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash
@@ -123,7 +123,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 # Building is done on mac runner due to xcode build dependencies
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       id-token: write
       contents: write
@@ -28,7 +28,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '26.3'
+          xcode-version: '16.2'
 
       - name: Setup Env from project's Env file
         shell: bash
@@ -112,7 +112,7 @@ jobs:
 
 # Packing is done on Mac due to ios workload requirements.
   publish:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: sign-dlls
     permissions:
       id-token: write
@@ -123,7 +123,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '26.3'
+          xcode-version: '16.2'
 
       - name: Setup Env from project's Env file
         shell: bash

--- a/.github/workflows/sdk-client-ci.yml
+++ b/.github/workflows/sdk-client-ci.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '26.3'
+          xcode-version: '16.2'
 
       - name: Setup Env from project's Env file
         shell: bash

--- a/.github/workflows/sdk-client-ci.yml
+++ b/.github/workflows/sdk-client-ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash


### PR DESCRIPTION
## Summary

The `macos-latest` runner label is migrating to macOS 26 (started June 15, 2026), which does not ship Xcode 16.2. The client SDK build requires Xcode for its iOS workloads and pins `xcode-version: '16.2'` via the `./.github/actions/xcode-select` action.

Jobs that land on the new macOS 26 image fail immediately at the xcode-select step, since `/Applications/Xcode_16.2.app` does not exist there:

```
sudo xcode-select -switch /Applications/Xcode_16.2.app
```

Jobs that still land on macOS 15 pass, so CI is currently nondeterministic — the same commit `a03e942` produced both a passing and a failing `build-and-test (macos-latest)` run, and the failing run carries GitHub's own migration notice annotation.

This pins the macOS jobs to `macos-15`, where Xcode 16.2 remains installed, so the existing `xcode-version: '16.2'` pin stays valid:

- `sdk-client-ci.yml` — `build-and-test` matrix
- `release-sdk-client.yml` — `build` and `publish` jobs

## Notes

`macos-15` is itself a temporary target and will eventually be deprecated. The longer-term follow-up is validating the iOS build against Xcode 26 on the macOS 26 image; this change is the minimal hotfix to keep CI and releases green in the meantime.

## Testing

CI on this branch runs the client SDK `build-and-test` job on `macos-15` and completes the xcode-select step successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release runner label change only; no application code or secrets handling changes.
> 
> **Overview**
> Pins client SDK GitHub Actions jobs from **`macos-latest`** to **`macos-15`** so they stay on an image that still has **Xcode 16.2**, matching the existing `./.github/actions/xcode-select` pin.
> 
> **`sdk-client-ci.yml`** — `build-and-test` matrix OS label. **`release-sdk-client.yml`** — `build` and `publish` job `runs-on` values. This avoids nondeterministic failures when `macos-latest` moves to macOS 26, where `/Applications/Xcode_16.2.app` is missing and the xcode-select step fails immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e34974a36cf957108741510d41c18e2e5b2b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->