### PR TITLE
fix: update LaunchDarkly.EventSource to 5.3.1 for Authenticode-signed assemblies

### DIFF
--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -50,7 +50,7 @@
         <Folder Include="Properties\"/>
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"/>
         <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0"/>
-        <PackageReference Include="LaunchDarkly.EventSource" Version="5.2.1"/>
+        <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1"/>
         <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.7.0" />
         <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0"/>
         <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.100" />

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
-    <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.0" />
+    <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1" />
     <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.6.1" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
**Related issues**

- https://github.com/launchdarkly/dotnet-eventsource/pull/121 — fixed incorrect `dll_name` in the publish workflow that prevented Authenticode signing

**Describe the solution you've provided**

Updates `LaunchDarkly.EventSource` from 5.3.0 → 5.3.1 in ServerSdk and from 5.2.1 → 5.3.1 in ClientSdk. Version 5.3.1 is the first release with correct Authenticode (DigiCert) signing — prior versions shipped unsigned due to a typo in the publish workflow.

**Describe alternatives you've considered**

N/A — this is a dependency bump to pick up correctly signed assemblies.

**Additional context**

No functional changes in 5.3.1; it is a re-release of 5.3.0 with the signing fix applied.

Link to Devin session: https://app.devin.ai/sessions/226ed88b8e8a4434920f2d7e3a49ee61
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps with no functional or API changes in this repo.
> 
> **Overview**
> Bumps the **LaunchDarkly.EventSource** NuGet dependency to **5.3.1** in both SDK packages so consumers get Authenticode (DigiCert)–signed assemblies. **ServerSdk** moves from 5.3.0 → 5.3.1; **ClientSdk** from 5.2.1 → 5.3.1.
> 
> There are no application code changes—only `PackageReference` version lines in `LaunchDarkly.ServerSdk.csproj` and `LaunchDarkly.ClientSdk.csproj`. 5.3.1 is a re-release of 5.3.0 with corrected publish/signing workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9979f2cec8f86bbc3b3194a24008ab6bdef93139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->