### PR TITLE
fix: Change trackDuration argument from float to double

### DIFF
--- a/pkgs/sdk/server-ai/src/Interfaces/ILdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/Interfaces/ILdAiConfigTracker.cs
@@ -37,7 +37,7 @@ public interface ILdAiConfigTracker
     /// </summary>
     /// <remarks>Records at most once per Tracker; further calls are ignored.</remarks>
     /// <param name="durationMs">the duration in milliseconds</param>
-    public void TrackDuration(float durationMs);
+    public void TrackDuration(double durationMs);
 
     /// <summary>
     /// Wraps a callable operation, measures its wall-clock duration, and records the result via

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -160,7 +160,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     }
 
     /// <inheritdoc/>
-    public void TrackDuration(float durationMs)
+    public void TrackDuration(double durationMs)
     {
         if (Interlocked.CompareExchange(ref _durationMs,
                 new StrongBox<double>(durationMs), null) != null)
@@ -183,7 +183,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         finally
         {
             sw.Stop();
-            TrackDuration((float)sw.Elapsed.TotalMilliseconds);
+            TrackDuration(sw.Elapsed.TotalMilliseconds);
         }
     }
 
@@ -273,7 +273,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         catch (Exception)
         {
             sw.Stop();
-            TrackDuration((float)sw.Elapsed.TotalMilliseconds);
+            TrackDuration(sw.Elapsed.TotalMilliseconds);
             TrackError();
             throw;
         }
@@ -291,12 +291,12 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         }
         catch (Exception)
         {
-            TrackDuration((float)operationElapsedMs);
+            TrackDuration(operationElapsedMs);
             throw;
         }
 
         // Honor an explicit duration override from the caller; fall back to the measured value.
-        TrackDuration((float)(metrics.DurationMs ?? operationElapsedMs));
+        TrackDuration(metrics.DurationMs ?? operationElapsedMs);
 
         if (metrics.Success)
         {

--- a/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
@@ -113,7 +113,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
 
             var tracker = config.CreateTracker();
 
-            tracker.TrackDuration(1.0f);
+            tracker.TrackDuration(1.0);
             mockClient.Verify(x => x.Track("$ld:ai:duration:total", context,
                 It.Is<LdValue>(d =>
                     d.Get("runId").Type == LdValueType.String &&
@@ -130,7 +130,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var config = BuildConfig(mockClient.Object, flagKey, context);
             var tracker = config.CreateTracker();
 
-            tracker.TrackDuration(1.0f);
+            tracker.TrackDuration(1.0);
             mockClient.Verify(x => x.Track("$ld:ai:duration:total", context,
                 It.Is<LdValue>(d => MatchesTrackData(d, flagKey, config)), 1.0f), Times.Once);
         }
@@ -368,8 +368,8 @@ namespace LaunchDarkly.Sdk.Server.Ai
 
             var tracker = config.CreateTracker();
 
-            tracker.TrackDuration(1.0f);
-            tracker.TrackDuration(2.0f);
+            tracker.TrackDuration(1.0);
+            tracker.TrackDuration(2.0);
 
             mockClient.Verify(x => x.Track("$ld:ai:duration:total", context,
                 It.IsAny<LdValue>(), It.IsAny<double>()), Times.Once);
@@ -583,8 +583,8 @@ namespace LaunchDarkly.Sdk.Server.Ai
             var tracker1 = config.CreateTracker();
             var tracker2 = config.CreateTracker();
 
-            tracker1.TrackDuration(10.0f);
-            tracker2.TrackDuration(20.0f);
+            tracker1.TrackDuration(10.0);
+            tracker2.TrackDuration(20.0);
 
             string runId1 = null;
             string runId2 = null;
@@ -615,11 +615,11 @@ namespace LaunchDarkly.Sdk.Server.Ai
 
             // Track duration on the first tracker (exhausts at-most-once)
             var tracker1 = config.CreateTracker();
-            tracker1.TrackDuration(1.0f);
+            tracker1.TrackDuration(1.0);
 
             // A second tracker has fresh tracking state
             var tracker2 = config.CreateTracker();
-            tracker2.TrackDuration(2.0f);
+            tracker2.TrackDuration(2.0);
 
             // Both calls should have gone through
             mockClient.Verify(x => x.Track("$ld:ai:duration:total", context,
@@ -868,7 +868,7 @@ namespace LaunchDarkly.Sdk.Server.Ai
             Assert.Null(summary.TimeToFirstTokenMs);
 
             // Track some metrics
-            tracker.TrackDuration(100.5f);
+            tracker.TrackDuration(100.5);
             tracker.TrackTimeToFirstToken(10.2f);
             tracker.TrackFeedback(Feedback.Positive);
             tracker.TrackSuccess();
@@ -978,8 +978,8 @@ namespace LaunchDarkly.Sdk.Server.Ai
                 var tracker = config.CreateTracker();
 
                 var barrier = new Barrier(2);
-                var t1 = Task.Run(() => { barrier.SignalAndWait(); tracker.TrackDuration(123.0f); });
-                var t2 = Task.Run(() => { barrier.SignalAndWait(); tracker.TrackDuration(123.0f); });
+                var t1 = Task.Run(() => { barrier.SignalAndWait(); tracker.TrackDuration(123.0); });
+                var t2 = Task.Run(() => { barrier.SignalAndWait(); tracker.TrackDuration(123.0); });
                 Task.WaitAll(t1, t2);
 
                 var calls = mockClient.Invocations.Count(inv =>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public interface signature change on ILdAiConfigTracker is a binary-breaking change for external implementers, though call sites passing float literals still compile via implicit widening.
> 
> **Overview**
> **`ILdAiConfigTracker.TrackDuration`** and **`LdAiConfigTracker.TrackDuration`** now take **`double durationMs`** instead of **`float`**, matching how durations are already stored internally and how **`Stopwatch.Elapsed.TotalMilliseconds`** / **`AiMetrics.DurationMs`** are produced.
> 
> Internal call sites in **`TrackDurationOf`** and **`TrackMetricsOf`** no longer cast millisecond values to **`float`** before recording. Unit tests were updated to pass **`double`** literals where they exercise **`TrackDuration`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6cb49dfe969b6b03a6f0b9086152358ffd02276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->