### PR TITLE
feat(server-ai): stamp modelKey and modelVersion on AI usage events (…

### DIFF
--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -57,7 +57,7 @@ internal sealed class ConfigFactory
             return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
+        var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -70,6 +70,8 @@ internal sealed class ConfigFactory
             enabled,
             variationKey,
             version,
+            modelKey,
+            modelVersion,
             messages,
             tools,
             judgeConfiguration,
@@ -95,6 +97,8 @@ internal sealed class ConfigFactory
             defaultValue.Enabled ?? true,
             variationKey: "",
             version: 1,
+            modelKey: null,
+            modelVersion: 1,
             messages,
             tools: ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty,
             defaultValue.JudgeConfiguration,
@@ -133,7 +137,7 @@ internal sealed class ConfigFactory
             return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
+        var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
         var tools = ParseTools(ldValue.Get("tools"));
         var instructions = interpolate
@@ -146,6 +150,8 @@ internal sealed class ConfigFactory
             enabled,
             variationKey,
             version,
+            modelKey,
+            modelVersion,
             instructions,
             tools,
             model,
@@ -169,6 +175,8 @@ internal sealed class ConfigFactory
             defaultValue.Enabled ?? true,
             variationKey: "",
             version: 1,
+            modelKey: null,
+            modelVersion: 1,
             instructions,
             tools: ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty,
             defaultValue.Model,
@@ -206,7 +214,7 @@ internal sealed class ConfigFactory
             return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
+        var model = ParseModel(ldValue.Get("model"));
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -218,6 +226,8 @@ internal sealed class ConfigFactory
             enabled,
             variationKey,
             version,
+            modelKey,
+            modelVersion,
             messages,
             evaluationMetricKey,
             model,
@@ -240,6 +250,8 @@ internal sealed class ConfigFactory
             defaultValue.Enabled ?? true,
             variationKey: "",
             version: 1,
+            modelKey: null,
+            modelVersion: 1,
             messages,
             defaultValue.EvaluationMetricKey,
             defaultValue.Model,
@@ -305,8 +317,8 @@ internal sealed class ConfigFactory
             context,
             cfg.Model?.Name,
             cfg.Provider?.Name,
-            cfg.Model?.ModelKey,
-            cfg.Model?.ModelVersion ?? 1,
+            cfg.ModelKey,
+            cfg.ModelVersion,
             graphKey);
     }
 
@@ -331,12 +343,12 @@ internal sealed class ConfigFactory
         return new Meta(enabled, variationKey, version, mode, modelKey, modelVersion);
     }
 
-    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue modelValue, string modelKey, int modelVersion)
+    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue modelValue)
     {
         var name = modelValue.Get("name").AsString ?? "";
         var parameters = LdValueObjectToDictionary(modelValue.Get("parameters"));
         var custom = LdValueObjectToDictionary(modelValue.Get("custom"));
-        return new LdAiConfigTypes.ModelConfig(name, parameters, custom, modelKey, modelVersion);
+        return new LdAiConfigTypes.ModelConfig(name, parameters, custom);
     }
 
     private static LdAiConfigTypes.ProviderConfig ParseProvider(LdValue providerValue)

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -47,7 +47,7 @@ internal sealed class ConfigFactory
             return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
+        var (enabled, variationKey, version, mode, modelKey, modelVersion) = ParseMeta(ldValue);
 
         if (mode != LdAiCompletionConfig.Mode)
         {
@@ -57,7 +57,7 @@ internal sealed class ConfigFactory
             return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue);
+        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -123,7 +123,7 @@ internal sealed class ConfigFactory
             return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
+        var (enabled, variationKey, version, mode, modelKey, modelVersion) = ParseMeta(ldValue);
 
         if (mode != LdAiAgentConfig.Mode)
         {
@@ -133,7 +133,7 @@ internal sealed class ConfigFactory
             return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue);
+        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
         var provider = ParseProvider(ldValue.Get("provider"));
         var tools = ParseTools(ldValue.Get("tools"));
         var instructions = interpolate
@@ -196,7 +196,7 @@ internal sealed class ConfigFactory
             return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var (enabled, variationKey, version, mode) = ParseMeta(ldValue);
+        var (enabled, variationKey, version, mode, modelKey, modelVersion) = ParseMeta(ldValue);
 
         if (mode != LdAiJudgeConfig.Mode)
         {
@@ -206,7 +206,7 @@ internal sealed class ConfigFactory
             return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue);
+        var model = ParseModel(ldValue.Get("model"), modelKey, modelVersion);
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -310,7 +310,12 @@ internal sealed class ConfigFactory
             graphKey);
     }
 
-    private static (bool Enabled, string VariationKey, int Version, string Mode) ParseMeta(LdValue value)
+    // _ldMeta carries modelKey/modelVersion alongside the variation-level fields (rather than
+    // the model object) so modelVersion can't be mistaken for the underlying LLM's own version.
+    private readonly record struct Meta(
+        bool Enabled, string VariationKey, int Version, string Mode, string ModelKey, int ModelVersion);
+
+    private static Meta ParseMeta(LdValue value)
     {
         var meta = value.Get("_ldMeta");
         var enabled = meta.Get("enabled").AsBool;
@@ -320,19 +325,17 @@ internal sealed class ConfigFactory
         // Default to the completion mode when _ldMeta.mode is missing or non-string: legacy
         // flags predate the mode tag and were always served as completion configs.
         var mode = meta.Get("mode").AsString ?? LdAiCompletionConfig.Mode;
-        return (enabled, variationKey, version, mode);
-    }
-
-    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue value)
-    {
-        var modelValue = value.Get("model");
-        var name = modelValue.Get("name").AsString ?? "";
-        var parameters = LdValueObjectToDictionary(modelValue.Get("parameters"));
-        var custom = LdValueObjectToDictionary(modelValue.Get("custom"));
-        var meta = value.Get("_ldMeta");
         var modelKey = meta.Get("modelKey").AsString;
         var modelVersionValue = meta.Get("modelVersion");
         var modelVersion = modelVersionValue.IsNull ? 1 : modelVersionValue.AsInt;
+        return new Meta(enabled, variationKey, version, mode, modelKey, modelVersion);
+    }
+
+    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue modelValue, string modelKey, int modelVersion)
+    {
+        var name = modelValue.Get("name").AsString ?? "";
+        var parameters = LdValueObjectToDictionary(modelValue.Get("parameters"));
+        var custom = LdValueObjectToDictionary(modelValue.Get("custom"));
         return new LdAiConfigTypes.ModelConfig(name, parameters, custom, modelKey, modelVersion);
     }
 

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -57,7 +57,7 @@ internal sealed class ConfigFactory
             return BuildCompletionFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"));
+        var model = ParseModel(ldValue);
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -133,7 +133,7 @@ internal sealed class ConfigFactory
             return BuildAgentFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"));
+        var model = ParseModel(ldValue);
         var provider = ParseProvider(ldValue.Get("provider"));
         var tools = ParseTools(ldValue.Get("tools"));
         var instructions = interpolate
@@ -206,7 +206,7 @@ internal sealed class ConfigFactory
             return BuildJudgeFromDefault(key, defaultValue, mergedVars, trackerFactory, interpolate);
         }
 
-        var model = ParseModel(ldValue.Get("model"));
+        var model = ParseModel(ldValue);
         var provider = ParseProvider(ldValue.Get("provider"));
         var messages = interpolate
             ? InterpolateMessages(ParseMessages(ldValue.Get("messages")), mergedVars, key)
@@ -323,13 +323,15 @@ internal sealed class ConfigFactory
         return (enabled, variationKey, version, mode);
     }
 
-    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue modelValue)
+    private static LdAiConfigTypes.ModelConfig ParseModel(LdValue value)
     {
+        var modelValue = value.Get("model");
         var name = modelValue.Get("name").AsString ?? "";
         var parameters = LdValueObjectToDictionary(modelValue.Get("parameters"));
         var custom = LdValueObjectToDictionary(modelValue.Get("custom"));
-        var modelKey = modelValue.Get("modelKey").AsString;
-        var modelVersionValue = modelValue.Get("modelVersion");
+        var meta = value.Get("_ldMeta");
+        var modelKey = meta.Get("modelKey").AsString;
+        var modelVersionValue = meta.Get("modelVersion");
         var modelVersion = modelVersionValue.IsNull ? 1 : modelVersionValue.AsInt;
         return new LdAiConfigTypes.ModelConfig(name, parameters, custom, modelKey, modelVersion);
     }

--- a/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
+++ b/pkgs/sdk/server-ai/src/Config/ConfigFactory.cs
@@ -305,6 +305,8 @@ internal sealed class ConfigFactory
             context,
             cfg.Model?.Name,
             cfg.Provider?.Name,
+            cfg.Model?.ModelKey,
+            cfg.Model?.ModelVersion ?? 1,
             graphKey);
     }
 
@@ -326,7 +328,10 @@ internal sealed class ConfigFactory
         var name = modelValue.Get("name").AsString ?? "";
         var parameters = LdValueObjectToDictionary(modelValue.Get("parameters"));
         var custom = LdValueObjectToDictionary(modelValue.Get("custom"));
-        return new LdAiConfigTypes.ModelConfig(name, parameters, custom);
+        var modelKey = modelValue.Get("modelKey").AsString;
+        var modelVersionValue = modelValue.Get("modelVersion");
+        var modelVersion = modelVersionValue.IsNull ? 1 : modelVersionValue.AsInt;
+        return new LdAiConfigTypes.ModelConfig(name, parameters, custom, modelKey, modelVersion);
     }
 
     private static LdAiConfigTypes.ProviderConfig ParseProvider(LdValue providerValue)

--- a/pkgs/sdk/server-ai/src/Config/LdAiAgentConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiAgentConfig.cs
@@ -41,13 +41,15 @@ public sealed class LdAiAgentConfig : LdAiConfig
         bool enabled,
         string variationKey,
         int version,
+        string modelKey,
+        int modelVersion,
         string instructions,
         IReadOnlyDictionary<string, LdAiConfigTypes.Tool> tools,
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
         LdAiConfigTypes.JudgeConfiguration judgeConfiguration,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        : base(key, enabled, variationKey, version, modelKey, modelVersion, model, provider, trackerFactory)
     {
         Instructions = instructions;
         Tools = tools?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty;

--- a/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiCompletionConfig.cs
@@ -39,11 +39,12 @@ public sealed class LdAiCompletionConfig : LdAiConfig
     public LdAiConfigTypes.JudgeConfiguration JudgeConfiguration { get; }
 
     internal LdAiCompletionConfig(string key, bool enabled, string variationKey, int version,
+        string modelKey, int modelVersion,
         IEnumerable<LdAiConfigTypes.Message> messages, IReadOnlyDictionary<string, LdAiConfigTypes.Tool> tools,
         LdAiConfigTypes.JudgeConfiguration judgeConfiguration,
         LdAiConfigTypes.ModelConfig model, LdAiConfigTypes.ProviderConfig provider,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        : base(key, enabled, variationKey, version, modelKey, modelVersion, model, provider, trackerFactory)
     {
         Messages = messages?.ToList() ?? new List<LdAiConfigTypes.Message>();
         Tools = tools ?? ImmutableDictionary<string, LdAiConfigTypes.Tool>.Empty;

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfig.cs
@@ -41,10 +41,22 @@ public abstract class LdAiConfig
     internal int Version { get; }
 
     /// <summary>
+    /// This field meant for internal LaunchDarkly usage. Not exposed on <see cref="Model"/> so
+    /// it can't be mistaken for the underlying LLM's own version (e.g. "GPT-5.4").
+    /// </summary>
+    internal string ModelKey { get; }
+
+    /// <summary>
+    /// This field meant for internal LaunchDarkly usage.
+    /// </summary>
+    internal int ModelVersion { get; }
+
+    /// <summary>
     /// Factory that produces a tracker for the config. The factory is mode-agnostic — it
     /// operates only on the shared fields (<see cref="Key"/>, <see cref="Model"/>,
-    /// <see cref="Provider"/>, <see cref="VariationKey"/>, <see cref="Version"/>), so the
-    /// same tracker class serves all config modes.
+    /// <see cref="Provider"/>, <see cref="VariationKey"/>, <see cref="Version"/>,
+    /// <see cref="ModelKey"/>, <see cref="ModelVersion"/>), so the same tracker class serves
+    /// all config modes.
     /// </summary>
     private readonly Func<LdAiConfig, ILdAiConfigTracker> _trackerFactory;
 
@@ -64,6 +76,8 @@ public abstract class LdAiConfig
         bool enabled,
         string variationKey,
         int version,
+        string modelKey,
+        int modelVersion,
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
@@ -72,6 +86,8 @@ public abstract class LdAiConfig
         Enabled = enabled;
         VariationKey = variationKey ?? "";
         Version = version;
+        ModelKey = modelKey;
+        ModelVersion = modelVersion;
         Model = model ?? new LdAiConfigTypes.ModelConfig("", new Dictionary<string, LdValue>(), new Dictionary<string, LdValue>());
         Provider = provider ?? new LdAiConfigTypes.ProviderConfig("");
         _trackerFactory = trackerFactory ?? throw new ArgumentNullException(nameof(trackerFactory));

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
@@ -71,23 +71,10 @@ public static class LdAiConfigTypes
         /// </summary>
         public readonly IReadOnlyDictionary<string, LdValue> Custom;
 
-        /// <summary>
-        /// The stable, unique key of the model (used for direct lookup; distinct from
-        /// <see cref="Name"/>, which is not guaranteed unique).
-        /// </summary>
-        public readonly string ModelKey;
-
-        /// <summary>
-        /// The pinned version of the model that this config variation references.
-        /// </summary>
-        public readonly int ModelVersion;
-
         internal ModelConfig(
             string name,
             IReadOnlyDictionary<string, LdValue> parameters,
-            IReadOnlyDictionary<string, LdValue> custom,
-            string modelKey = null,
-            int modelVersion = 1)
+            IReadOnlyDictionary<string, LdValue> custom)
         {
             Name = name;
             // Materialize into an ImmutableDictionary so a consumer that downcasts to
@@ -96,8 +83,6 @@ public static class LdAiConfigTypes
             // NotSupportedException at runtime, matching the typed read-only promise.
             Parameters = parameters?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdValue>.Empty;
             Custom = custom?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdValue>.Empty;
-            ModelKey = modelKey;
-            ModelVersion = modelVersion;
         }
     }
 

--- a/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiConfigTypes.cs
@@ -71,7 +71,23 @@ public static class LdAiConfigTypes
         /// </summary>
         public readonly IReadOnlyDictionary<string, LdValue> Custom;
 
-        internal ModelConfig(string name, IReadOnlyDictionary<string, LdValue> parameters, IReadOnlyDictionary<string, LdValue> custom)
+        /// <summary>
+        /// The stable, unique key of the model (used for direct lookup; distinct from
+        /// <see cref="Name"/>, which is not guaranteed unique).
+        /// </summary>
+        public readonly string ModelKey;
+
+        /// <summary>
+        /// The pinned version of the model that this config variation references.
+        /// </summary>
+        public readonly int ModelVersion;
+
+        internal ModelConfig(
+            string name,
+            IReadOnlyDictionary<string, LdValue> parameters,
+            IReadOnlyDictionary<string, LdValue> custom,
+            string modelKey = null,
+            int modelVersion = 1)
         {
             Name = name;
             // Materialize into an ImmutableDictionary so a consumer that downcasts to
@@ -80,6 +96,8 @@ public static class LdAiConfigTypes
             // NotSupportedException at runtime, matching the typed read-only promise.
             Parameters = parameters?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdValue>.Empty;
             Custom = custom?.ToImmutableDictionary() ?? ImmutableDictionary<string, LdValue>.Empty;
+            ModelKey = modelKey;
+            ModelVersion = modelVersion;
         }
     }
 

--- a/pkgs/sdk/server-ai/src/Config/LdAiJudgeConfig.cs
+++ b/pkgs/sdk/server-ai/src/Config/LdAiJudgeConfig.cs
@@ -36,12 +36,14 @@ public sealed class LdAiJudgeConfig : LdAiConfig
         bool enabled,
         string variationKey,
         int version,
+        string modelKey,
+        int modelVersion,
         IEnumerable<LdAiConfigTypes.Message> messages,
         string evaluationMetricKey,
         LdAiConfigTypes.ModelConfig model,
         LdAiConfigTypes.ProviderConfig provider,
         Func<LdAiConfig, ILdAiConfigTracker> trackerFactory)
-        : base(key, enabled, variationKey, version, model, provider, trackerFactory)
+        : base(key, enabled, variationKey, version, modelKey, modelVersion, model, provider, trackerFactory)
     {
         Messages = messages?.ToList() ?? new List<LdAiConfigTypes.Message>();
         EvaluationMetricKey = evaluationMetricKey;

--- a/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
+++ b/pkgs/sdk/server-ai/src/LdAiConfigTracker.cs
@@ -76,7 +76,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     /// </summary>
     internal LdAiConfigTracker(ILaunchDarklyClient client, string runId, string configKey,
         string variationKey, int version, Context context, string modelName, string providerName,
-        string graphKey = null)
+        string modelKey = null, int modelVersion = 1, string graphKey = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _configKey = configKey ?? throw new ArgumentNullException(nameof(configKey));
@@ -96,6 +96,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
             { "version", LdValue.Of(_version) },
             { "modelName", LdValue.Of(_modelName) },
             { "providerName", LdValue.Of(_providerName) },
+            { "modelVersion", LdValue.Of(modelVersion) },
         };
         if (!string.IsNullOrEmpty(_graphKey))
         {
@@ -104,6 +105,10 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         if (!string.IsNullOrEmpty(_variationKey))
         {
             trackDataBuilder.Add("variationKey", LdValue.Of(_variationKey));
+        }
+        if (!string.IsNullOrEmpty(modelKey))
+        {
+            trackDataBuilder.Add("modelKey", LdValue.Of(modelKey));
         }
         _trackData = LdValue.ObjectFrom(trackDataBuilder);
 
@@ -118,6 +123,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         // Utf8JsonWriter gives stable key ordering and avoids the runtime cost of
         // anonymous-type reflection. The wire format omits empty optional fields so that
         // resumption tokens round-trip exactly for configs that never carried them.
+        // modelName, providerName, modelKey, and modelVersion are not included.
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
         {
@@ -426,7 +432,8 @@ public class LdAiConfigTracker : ILdAiConfigTracker
     /// process or at a later time.
     ///
     /// The reconstructed tracker will have empty model and provider names, as these are not
-    /// included in the resumption token.
+    /// included in the resumption token. modelKey and modelVersion are also not included;
+    /// modelVersion defaults to 1 on reconstructed trackers.
     /// </summary>
     /// <param name="token">the resumption token obtained from <see cref="ResumptionToken"/></param>
     /// <param name="client">the LaunchDarkly client</param>
@@ -466,7 +473,7 @@ public class LdAiConfigTracker : ILdAiConfigTracker
         }
 
         return new LdAiConfigTracker(client, payload.RunId, payload.ConfigKey,
-            payload.VariationKey, payload.Version ?? 1, context, "", "", payload.GraphKey);
+            payload.VariationKey, payload.Version ?? 1, context, "", "", graphKey: payload.GraphKey);
     }
 
     private class ResumptionPayload

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -23,6 +23,8 @@ public class AgentGraphDefinitionTest
             enabled: enabled,
             variationKey: "v1",
             version: 1,
+            modelKey: null,
+            modelVersion: 1,
             instructions: null,
             tools: new Dictionary<string, LdAiConfigTypes.Tool>(),
             model: null,

--- a/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
+++ b/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using LaunchDarkly.Sdk.Server.Ai.Config;
+using LaunchDarkly.Sdk.Server.Ai.Interfaces;
+using Moq;
 using Xunit;
 
 namespace LaunchDarkly.Sdk.Server.Ai;
@@ -203,5 +205,117 @@ public class ConfigFactoryParserTest
         Assert.Empty(tools);
         Assert.Null(judgeConfig);
         Assert.Null(evaluationMetricKey);
+    }
+
+    [Fact]
+    public void CompletionConfigReadsModelKeyAndVersionFromFlag()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x =>
+            x.JsonVariation("model-config-with-key-version", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["variationKey"] = LdValue.Of("v1"),
+                    ["version"] = LdValue.Of(1)
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("gpt-4"),
+                    ["modelKey"] = LdValue.Of("my-model"),
+                    ["modelVersion"] = LdValue.Of(2)
+                }),
+                ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("openai")
+                }),
+                ["messages"] = LdValue.ArrayOf()
+            }));
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.CompletionConfig("model-config-with-key-version", Context.New("user-key"));
+
+        Assert.Equal("my-model", result.Model.ModelKey);
+        Assert.Equal(2, result.Model.ModelVersion);
+    }
+
+    [Fact]
+    public void CompletionConfigDefaultsModelVersionWhenAbsent()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x =>
+            x.JsonVariation("model-config-no-version", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["variationKey"] = LdValue.Of("v1"),
+                    ["version"] = LdValue.Of(1)
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("gpt-4")
+                }),
+                ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("openai")
+                }),
+                ["messages"] = LdValue.ArrayOf()
+            }));
+
+        var client = new LdAiClient(mockClient.Object);
+        var result = client.CompletionConfig("model-config-no-version", Context.New("user-key"));
+
+        Assert.Null(result.Model.ModelKey);
+        Assert.Equal(1, result.Model.ModelVersion);
+    }
+
+    [Fact]
+    public void CreateTrackerStampsModelKeyAndVersionOnTrackData()
+    {
+        var mockClient = new Mock<ILaunchDarklyClient>();
+        var mockLogger = new Mock<ILogger>();
+        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
+        mockClient.Setup(x =>
+            x.JsonVariation("my-config-key", It.IsAny<Context>(), It.IsAny<LdValue>()))
+            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
+            {
+                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["enabled"] = LdValue.Of(true),
+                    ["variationKey"] = LdValue.Of("var-abc"),
+                    ["version"] = LdValue.Of(7)
+                }),
+                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("gpt-4"),
+                    ["modelKey"] = LdValue.Of("my-model"),
+                    ["modelVersion"] = LdValue.Of(2)
+                }),
+                ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
+                {
+                    ["name"] = LdValue.Of("openai")
+                }),
+                ["messages"] = LdValue.ArrayOf()
+            }));
+
+        var client = new LdAiClient(mockClient.Object);
+        var context = Context.New("user-key");
+        var config = client.CompletionConfig("my-config-key", context);
+        var tracker = config.CreateTracker();
+        tracker.TrackSuccess();
+
+        mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+            It.Is<LdValue>(d =>
+                d.Get("modelKey").AsString == "my-model" &&
+                d.Get("modelVersion").AsInt == 2),
+            1.0f), Times.Once);
     }
 }

--- a/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
+++ b/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
@@ -221,13 +221,13 @@ public class ConfigFactoryParserTest
                 {
                     ["enabled"] = LdValue.Of(true),
                     ["variationKey"] = LdValue.Of("v1"),
-                    ["version"] = LdValue.Of(1)
+                    ["version"] = LdValue.Of(1),
+                    ["modelKey"] = LdValue.Of("my-model"),
+                    ["modelVersion"] = LdValue.Of(2)
                 }),
                 ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
                 {
-                    ["name"] = LdValue.Of("gpt-4"),
-                    ["modelKey"] = LdValue.Of("my-model"),
-                    ["modelVersion"] = LdValue.Of(2)
+                    ["name"] = LdValue.Of("gpt-4")
                 }),
                 ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
                 {
@@ -291,13 +291,13 @@ public class ConfigFactoryParserTest
                 {
                     ["enabled"] = LdValue.Of(true),
                     ["variationKey"] = LdValue.Of("var-abc"),
-                    ["version"] = LdValue.Of(7)
+                    ["version"] = LdValue.Of(7),
+                    ["modelKey"] = LdValue.Of("my-model"),
+                    ["modelVersion"] = LdValue.Of(2)
                 }),
                 ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
                 {
-                    ["name"] = LdValue.Of("gpt-4"),
-                    ["modelKey"] = LdValue.Of("my-model"),
-                    ["modelVersion"] = LdValue.Of(2)
+                    ["name"] = LdValue.Of("gpt-4")
                 }),
                 ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
                 {

--- a/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
+++ b/pkgs/sdk/server-ai/test/ConfigFactoryParserTest.cs
@@ -208,44 +208,11 @@ public class ConfigFactoryParserTest
     }
 
     [Fact]
-    public void CompletionConfigReadsModelKeyAndVersionFromFlag()
+    public void CreateTrackerDefaultsModelVersionAndOmitsModelKeyWhenAbsentFromFlag()
     {
-        var mockClient = new Mock<ILaunchDarklyClient>();
-        var mockLogger = new Mock<ILogger>();
-        mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
-        mockClient.Setup(x =>
-            x.JsonVariation("model-config-with-key-version", It.IsAny<Context>(), It.IsAny<LdValue>()))
-            .Returns(LdValue.ObjectFrom(new Dictionary<string, LdValue>
-            {
-                ["_ldMeta"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
-                {
-                    ["enabled"] = LdValue.Of(true),
-                    ["variationKey"] = LdValue.Of("v1"),
-                    ["version"] = LdValue.Of(1),
-                    ["modelKey"] = LdValue.Of("my-model"),
-                    ["modelVersion"] = LdValue.Of(2)
-                }),
-                ["model"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
-                {
-                    ["name"] = LdValue.Of("gpt-4")
-                }),
-                ["provider"] = LdValue.ObjectFrom(new Dictionary<string, LdValue>
-                {
-                    ["name"] = LdValue.Of("openai")
-                }),
-                ["messages"] = LdValue.ArrayOf()
-            }));
-
-        var client = new LdAiClient(mockClient.Object);
-        var result = client.CompletionConfig("model-config-with-key-version", Context.New("user-key"));
-
-        Assert.Equal("my-model", result.Model.ModelKey);
-        Assert.Equal(2, result.Model.ModelVersion);
-    }
-
-    [Fact]
-    public void CompletionConfigDefaultsModelVersionWhenAbsent()
-    {
+        // modelKey/modelVersion are intentionally not exposed on Model (they'd read as
+        // properties of the LLM itself, e.g. a version like "5.4"); the only place they
+        // surface is the tracker's stamped event data, mirroring variationKey/version.
         var mockClient = new Mock<ILaunchDarklyClient>();
         var mockLogger = new Mock<ILogger>();
         mockClient.Setup(x => x.GetLogger()).Returns(mockLogger.Object);
@@ -271,10 +238,16 @@ public class ConfigFactoryParserTest
             }));
 
         var client = new LdAiClient(mockClient.Object);
-        var result = client.CompletionConfig("model-config-no-version", Context.New("user-key"));
+        var context = Context.New("user-key");
+        var config = client.CompletionConfig("model-config-no-version", context);
+        var tracker = config.CreateTracker();
+        tracker.TrackSuccess();
 
-        Assert.Null(result.Model.ModelKey);
-        Assert.Equal(1, result.Model.ModelVersion);
+        mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+            It.Is<LdValue>(d =>
+                d.Get("modelKey").IsNull &&
+                d.Get("modelVersion").AsInt == 1),
+            1.0f), Times.Once);
     }
 
     [Fact]

--- a/pkgs/sdk/server-ai/test/LdAiAgentGraphConfigTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiAgentGraphConfigTest.cs
@@ -24,7 +24,7 @@ public class LdAiAgentGraphConfigTest
         string graphKey = null)
     {
         return new LdAiConfigTracker(client, Guid.NewGuid().ToString(), "config-key",
-            "v1", 1, context, "model", "provider", graphKey);
+            "v1", 1, context, "model", "provider", graphKey: graphKey);
     }
 
     // Test 1: Tracker created with graphKey → events include graphKey in data

--- a/pkgs/sdk/server-ai/test/LdAiClientTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiClientTest.cs
@@ -668,7 +668,9 @@ public class LdAiClientTest
                 d.Get("variationKey").AsString == "var-1" &&
                 d.Get("version").AsInt == 2 &&
                 d.Get("modelName").AsString == "" &&
-                d.Get("providerName").AsString == ""),
+                d.Get("providerName").AsString == "" &&
+                d.Get("modelVersion").AsInt == 1 &&
+                d.Get("modelKey").IsNull),
             1.0f), Times.Once);
     }
 

--- a/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
@@ -686,6 +686,84 @@ namespace LaunchDarkly.Sdk.Server.Ai
             // modelName and providerName should NOT be in the token
             Assert.False(doc.RootElement.TryGetProperty("modelName", out _));
             Assert.False(doc.RootElement.TryGetProperty("providerName", out _));
+            Assert.False(doc.RootElement.TryGetProperty("modelKey", out _));
+            Assert.False(doc.RootElement.TryGetProperty("modelVersion", out _));
+        }
+
+        [Fact]
+        public void TrackDataIncludesModelVersionByDefault()
+        {
+            var mockClient = new Mock<ILaunchDarklyClient>();
+            var context = Context.New("key");
+
+            var tracker = new LdAiConfigTracker(mockClient.Object, "test-run-id",
+                "config-key", "variation-key", 3, context, "fakeModel", "fakeProvider");
+            tracker.TrackSuccess();
+
+            mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+                It.Is<LdValue>(d => d.Get("modelVersion").AsInt == 1), 1.0f), Times.Once);
+        }
+
+        [Fact]
+        public void TrackDataIncludesModelKeyWhenSet()
+        {
+            var mockClient = new Mock<ILaunchDarklyClient>();
+            var context = Context.New("key");
+
+            var tracker = new LdAiConfigTracker(mockClient.Object, "test-run-id",
+                "config-key", "variation-key", 3, context, "fakeModel", "fakeProvider",
+                modelKey: "my-model", modelVersion: 2);
+            tracker.TrackSuccess();
+
+            mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+                It.Is<LdValue>(d =>
+                    d.Get("modelKey").AsString == "my-model" &&
+                    d.Get("modelVersion").AsInt == 2),
+                1.0f), Times.Once);
+        }
+
+        [Fact]
+        public void TrackDataOmitsModelKeyWhenEmpty()
+        {
+            var mockClient = new Mock<ILaunchDarklyClient>();
+            var context = Context.New("key");
+
+            var tracker = new LdAiConfigTracker(mockClient.Object, "test-run-id",
+                "config-key", "variation-key", 3, context, "fakeModel", "fakeProvider",
+                modelKey: "", modelVersion: 3);
+            tracker.TrackSuccess();
+
+            mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+                It.Is<LdValue>(d =>
+                    d.Get("modelVersion").AsInt == 3 &&
+                    d.Get("modelKey").IsNull),
+                1.0f), Times.Once);
+        }
+
+        [Fact]
+        public void FromResumptionTokenDefaultsModelVersionAndOmitsModelKey()
+        {
+            var mockClient = new Mock<ILaunchDarklyClient>();
+            var context = Context.New("key");
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                runId = "test-run-id",
+                configKey = "test-key",
+                variationKey = "var-1",
+                version = 2,
+            });
+            var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+            var token = base64.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+            var tracker = LdAiConfigTracker.FromResumptionToken(token, mockClient.Object, context);
+            tracker.TrackSuccess();
+
+            mockClient.Verify(x => x.Track("$ld:ai:generation:success", context,
+                It.Is<LdValue>(d =>
+                    d.Get("modelVersion").AsInt == 1 &&
+                    d.Get("modelKey").IsNull),
+                1.0f), Times.Once);
         }
 
         [Fact]

--- a/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
+++ b/pkgs/sdk/server-ai/test/LdAiConfigTrackerTest.cs
@@ -25,6 +25,8 @@ namespace LaunchDarkly.Sdk.Server.Ai
                 enabled: false,
                 variationKey: "",
                 version: 1,
+                modelKey: null,
+                modelVersion: 1,
                 messages: new List<LdAiConfigTypes.Message>(),
                 tools: new Dictionary<string, LdAiConfigTypes.Tool>(),
                 judgeConfiguration: null,


### PR DESCRIPTION
…AIC-2856)

Read modelKey and modelVersion from the AI Config variation payload and stamp them on all LdAiConfigTracker metric event payloads alongside existing modelName/providerName fields.

- Add ModelKey/ModelVersion to ModelConfig
- Parse new fields from variation payload in ConfigFactory
- Include modelVersion unconditionally (default 1) and modelKey when non-empty in track data; exclude both from resumption token
- Additive/backward compatible — older payloads without the new fields continue to work

Part of AIC-2849. Depends on AIC-2876 (backend payload).

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry on existing track payloads with defaults for legacy flags and resumption tokens; no public API surface change beyond internal config fields.
> 
> **Overview**
> Adds **LaunchDarkly model identity** (`modelKey`, `modelVersion`) from AI Config flag `_ldMeta` and threads it through completion, agent, and judge configs into **`LdAiConfigTracker`** metric payloads.
> 
> **Parsing & config:** `ParseMeta` reads `modelKey` / `modelVersion` from `_ldMeta` (not the `model` object so `modelVersion` isn’t confused with the LLM name/version). Missing `modelVersion` defaults to **1**; caller defaults use `modelKey: null` and `modelVersion: 1`. New internal fields live on **`LdAiConfig`**, not `ModelConfig`.
> 
> **Tracking:** All tracker events include **`modelVersion`**; **`modelKey`** is added only when non-empty. **Resumption tokens** are unchanged—neither field is encoded; resumed trackers still get `modelVersion` **1** and no `modelKey`.
> 
> Tests cover flag parsing → `TrackSuccess` payloads and resumption defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ad0d3259ea10fa697ac1a79643a837094ea21c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->