### PR TITLE
test: declare server-side-polling and service-endpoints capabilities

### DIFF
--- a/pkgs/sdk/server/contract-tests/Representations.cs
+++ b/pkgs/sdk/server/contract-tests/Representations.cs
@@ -28,6 +28,8 @@ namespace TestService
         public long? StartWaitTimeMs { get; set; }
         public bool InitCanFail { get; set; }
         public SdkConfigStreamParams Streaming { get; set; }
+        public SdkConfigPollingParams Polling { get; set; }
+        public SdkConfigServiceEndpointsParams ServiceEndpoints { get; set; }
         public SdkConfigEventParams Events { get; set; }
         public SdkConfigBigSegmentsParams BigSegments { get; set; }
         public SdkTagParams Tags { get; set; }
@@ -69,6 +71,13 @@ namespace TestService
     {
         public Uri BaseUri { get; set; }
         public long? InitialRetryDelayMs { get; set; }
+    }
+
+    public class SdkConfigServiceEndpointsParams
+    {
+        public Uri Streaming { get; set; }
+        public Uri Polling { get; set; }
+        public Uri Events { get; set; }
     }
 
     public class SdkConfigEventParams

--- a/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
+++ b/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
@@ -289,14 +289,49 @@ namespace TestService
                 builder.StartWaitTime(TimeSpan.FromMilliseconds(sdkParams.StartWaitTimeMs.Value));
             }
 
+            var serviceEndpointsParams = sdkParams.ServiceEndpoints;
+            if (serviceEndpointsParams != null)
+            {
+                if (serviceEndpointsParams.Streaming != null)
+                {
+                    endpoints.Streaming(serviceEndpointsParams.Streaming);
+                }
+                if (serviceEndpointsParams.Polling != null)
+                {
+                    endpoints.Polling(serviceEndpointsParams.Polling);
+                }
+                if (serviceEndpointsParams.Events != null)
+                {
+                    endpoints.Events(serviceEndpointsParams.Events);
+                }
+            }
+
             var streamingParams = sdkParams.Streaming;
             if (streamingParams != null)
             {
-                endpoints.Streaming(streamingParams.BaseUri);
+                if (streamingParams.BaseUri != null)
+                {
+                    endpoints.Streaming(streamingParams.BaseUri);
+                }
                 var dataSource = Components.StreamingDataSource();
                 if (streamingParams.InitialRetryDelayMs.HasValue)
                 {
                     dataSource.InitialReconnectDelay(TimeSpan.FromMilliseconds(streamingParams.InitialRetryDelayMs.Value));
+                }
+                builder.DataSource(dataSource);
+            }
+
+            var pollingParams = sdkParams.Polling;
+            if (pollingParams != null)
+            {
+                if (pollingParams.BaseUri != null)
+                {
+                    endpoints.Polling(pollingParams.BaseUri);
+                }
+                var dataSource = Components.PollingDataSource();
+                if (pollingParams.PollIntervalMs.HasValue)
+                {
+                    dataSource.PollInterval(TimeSpan.FromMilliseconds(pollingParams.PollIntervalMs.Value));
                 }
                 builder.DataSource(dataSource);
             }
@@ -308,7 +343,10 @@ namespace TestService
             }
             else
             {
-                endpoints.Events(eventParams.BaseUri);
+                if (eventParams.BaseUri != null)
+                {
+                    endpoints.Events(eventParams.BaseUri);
+                }
                 var events = Components.SendEvents()
                     .AllAttributesPrivate(eventParams.AllAttributesPrivate);
                 if (eventParams.Capacity.HasValue && eventParams.Capacity.Value > 0)

--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -32,6 +32,8 @@ namespace TestService
             "big-segments",
             "context-type",
             "secure-mode-hash",
+            "server-side-polling",
+            "service-endpoints",
             "migrations",
             "event-sampling",
             "tags",


### PR DESCRIPTION
## What

Declares two contract-test capabilities the .NET **server** SDK supports but wasn't advertising, and adds the test-service plumbing needed to actually pass their suites:

- `server-side-polling`
- `service-endpoints`

Part of epic **SDK-2724** · ticket **SDK-2725**.

## Changes

- **`TestService.cs`** — declare `server-side-polling` and `service-endpoints`.
- **`Representations.cs`** — add `Polling` and `ServiceEndpoints` to `SdkConfigParams`, plus a `SdkConfigServiceEndpointsParams` type (reuses the existing `SdkConfigPollingParams`).
- **`SdkClientEntity.cs`** — the legacy (non-`dataSystem`) config branch only handled `streaming`, so the SDK never polled and never honored a top-level `serviceEndpoints`. Added:
  - a legacy polling data source path (`Components.PollingDataSource()` + `PollInterval`),
  - `serviceEndpoints` parsing (streaming / polling / events base URIs),
  - null-guards on the per-component base-URI setters so a `serviceEndpoints`-only config isn't overwritten with null.

## Why the plumbing was needed

CI runs the contract tests against **both** the v2 (FDv1 polling) and v3 (FDv2) harnesses. Declaring the capabilities turned on the v2 polling suite and the "separate service endpoints properties" tests — 23 tests (polling/*, `tags/poll requests`, `instance id/poll`, service-endpoints) that failed because the test service didn't implement legacy polling config or `serviceEndpoints`. The SDK itself already supports both; only the test service needed wiring.

## Verification

- **CI-pinned v3.0.0-alpha.6** (FDv2 run, with the fdv2 suppression file): **4790 ran, 0 failed**.
- **v2 harness**: all previously-failing categories (polling, service endpoints, tags/poll, instance-id) pass.

## Follow-ups (separate tickets under SDK-2724)

Flag change/value listeners (SDK-2726), context comparison (SDK-2727), persistent data stores (SDK-2728) — each needs its own test-service command plumbing. Genuinely-unsupported features (event gzip, payload filtering, track hooks, omit-anonymous-contexts) are out of scope.