### PR TITLE
test: support flag-change-listeners and flag-value-change-listeners

### DIFF
--- a/pkgs/sdk/server/contract-tests/Representations.cs
+++ b/pkgs/sdk/server/contract-tests/Representations.cs
@@ -231,6 +231,43 @@ namespace TestService
         public SecureModeHashParams SecureModeHash { get; set; }
         public MigrationVariationParams MigrationVariation { get; set; }
         public MigrationOperationParams MigrationOperation { get; set; }
+        public RegisterFlagChangeListenerParams RegisterFlagChangeListener { get; set; }
+        public RegisterFlagValueChangeListenerParams RegisterFlagValueChangeListener { get; set; }
+        public UnregisterListenerParams UnregisterListener { get; set; }
+    }
+
+    public class RegisterFlagChangeListenerParams
+    {
+        public string ListenerId { get; set; }
+        public Uri CallbackUri { get; set; }
+    }
+
+    public class RegisterFlagValueChangeListenerParams
+    {
+        public string ListenerId { get; set; }
+        public string FlagKey { get; set; }
+        public Context Context { get; set; }
+        public LdValue DefaultValue { get; set; }
+        public Uri CallbackUri { get; set; }
+    }
+
+    public class UnregisterListenerParams
+    {
+        public string ListenerId { get; set; }
+    }
+
+    public class ListenerNotification
+    {
+        public string ListenerId { get; set; }
+        public string FlagKey { get; set; }
+
+        // OldValue/NewValue are sent only for flag-value-change notifications; they are omitted
+        // for general flag-change notifications (matching the harness's expectations).
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public LdValue? OldValue { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public LdValue? NewValue { get; set; }
     }
 
     public class EvaluateFlagParams

--- a/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
+++ b/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
@@ -8,6 +8,7 @@ using LaunchDarkly.Sdk.Json;
 using LaunchDarkly.Sdk.Server;
 using LaunchDarkly.Sdk.Server.Hooks;
 using LaunchDarkly.Sdk.Server.Integrations;
+using LaunchDarkly.Sdk.Server.Interfaces;
 using LaunchDarkly.Sdk.Server.Migrations;
 using LaunchDarkly.Sdk.Server.Subsystems;
 
@@ -19,6 +20,8 @@ namespace TestService
 
         private readonly LdClient _client;
         private readonly Logger _log;
+        private readonly Dictionary<string, EventHandler<FlagChangeEvent>> _flagListeners =
+            new Dictionary<string, EventHandler<FlagChangeEvent>>();
 
         public SdkClientEntity(
             SdkConfigParams sdkParams,
@@ -39,8 +42,23 @@ namespace TestService
 
         public void Close()
         {
+            foreach (var handler in _flagListeners.Values)
+            {
+                _client.FlagTracker.FlagChanged -= handler;
+            }
+            _flagListeners.Clear();
             _client.Dispose();
             _log.Info("Test ended");
+        }
+
+        private void RegisterFlagListener(string listenerId, EventHandler<FlagChangeEvent> handler)
+        {
+            if (_flagListeners.TryGetValue(listenerId, out var existing))
+            {
+                _client.FlagTracker.FlagChanged -= existing;
+            }
+            _flagListeners[listenerId] = handler;
+            _client.FlagTracker.FlagChanged += handler;
         }
 
         public bool DoCommand(CommandParams command, out object response)
@@ -109,6 +127,43 @@ namespace TestService
                 case "migrationOperation":
                     response = DoMigrationOperation(command.MigrationOperation);
                     break;
+
+                case "registerFlagChangeListener":
+                {
+                    var p = command.RegisterFlagChangeListener;
+                    var svc = new CallbackService(p.CallbackUri);
+                    EventHandler<FlagChangeEvent> handler = (sender, e) =>
+                        svc.Post("", new ListenerNotification { ListenerId = p.ListenerId, FlagKey = e.Key });
+                    RegisterFlagListener(p.ListenerId, handler);
+                    break;
+                }
+
+                case "registerFlagValueChangeListener":
+                {
+                    var p = command.RegisterFlagValueChangeListener;
+                    var svc = new CallbackService(p.CallbackUri);
+                    var handler = _client.FlagTracker.FlagValueChangeHandler(p.FlagKey, p.Context,
+                        (sender, e) => svc.Post("", new ListenerNotification
+                        {
+                            ListenerId = p.ListenerId,
+                            FlagKey = e.Key,
+                            OldValue = e.OldValue,
+                            NewValue = e.NewValue
+                        }));
+                    RegisterFlagListener(p.ListenerId, handler);
+                    break;
+                }
+
+                case "unregisterListener":
+                {
+                    var p = command.UnregisterListener;
+                    if (_flagListeners.TryGetValue(p.ListenerId, out var handler))
+                    {
+                        _client.FlagTracker.FlagChanged -= handler;
+                        _flagListeners.Remove(p.ListenerId);
+                    }
+                    break;
+                }
 
                 default:
                     return false;

--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -40,6 +40,8 @@ namespace TestService
             "inline-context-all",
             "anonymous-redaction",
             "evaluation-hooks",
+            "flag-change-listeners",
+            "flag-value-change-listeners",
             "client-prereq-events",
             "fdv1-fallback",
             "instance-id"


### PR DESCRIPTION
## What

Implements the `flag-change-listeners` and `flag-value-change-listeners` contract-test capabilities for the .NET **server** SDK — a v3-only harness feature.

Part of epic **SDK-2724** · ticket **SDK-2726**.

## Changes

- **`Representations.cs`** — add `registerFlagChangeListener`, `registerFlagValueChangeListener`, and `unregisterListener` command params, plus the `ListenerNotification` callback body. `oldValue`/`newValue` are omitted for general flag-change notifications and included for value-change (matching the harness contract).
- **`SdkClientEntity.cs`** — register handlers on `IFlagTracker.FlagChanged` (via `FlagValueChangeHandler` for value listeners), POST notifications to the harness callback URI through the existing `CallbackService`, track them by `listenerId`, and remove them on `unregisterListener` / `Close()`.
- **`TestService.cs`** — declare both capabilities.

The SDK already surfaces flag-change events under the FDv2 data system (`FDv2DataSystem` → `FlagChangedFacade` → `LdClient.FlagTracker`), so no SDK change was needed — only test-service plumbing.

## Verification

Ran the CI-pinned **v3.0.0-alpha.6** harness locally: the full suite is green (**4800 ran, 0 failed**), including all flag-change and flag-value-change listener tests (fires-on-config-change-even-when-value-unchanged, no-notify-when-unchanged, multiple listeners, context-specific, correct old/new JSON values). v2 has no such tests, so its run is unaffected.

## Follow-ups (epic SDK-2724)

Context comparison (SDK-2727), persistent data stores (SDK-2728).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-service-only changes; production flag-tracking behavior is unchanged.
> 
> **Overview**
> Adds **v3 harness** support for `flag-change-listeners` and `flag-value-change-listeners` in the .NET server SDK contract test service—no production SDK changes.
> 
> **Representations** gains command params for register/unregister listeners and a `ListenerNotification` payload; `oldValue`/`newValue` are omitted for general flag-change callbacks and included for value-change (per harness contract).
> 
> **SdkClientEntity** wires harness commands to `IFlagTracker`: general listeners POST `listenerId` + `flagKey` on `FlagChanged`; value listeners use `FlagValueChangeHandler` and include old/new values. Handlers are keyed by `listenerId`, replaced on re-register, and torn down on `unregisterListener` and `Close()`.
> 
> **TestService** advertises both capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6efe4bc9033e566d1b9ae1f0767aa0fe4caa48e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->