### PR TITLE
test: support context-comparison capability

### DIFF
--- a/pkgs/sdk/server/contract-tests/Representations.cs
+++ b/pkgs/sdk/server/contract-tests/Representations.cs
@@ -254,10 +254,6 @@ namespace TestService
         public string Kind { get; set; }
         public string Key { get; set; }
         public AttributeDefinition[] Attributes { get; set; }
-
-        // The harness emits this key literally as "privateAttributes:omitempty" because of a
-        // malformed json struct tag in servicedef (a colon where a comma should be). Match it verbatim.
-        [JsonPropertyName("privateAttributes:omitempty")]
         public PrivateAttribute[] PrivateAttributes { get; set; }
     }
 

--- a/pkgs/sdk/server/contract-tests/Representations.cs
+++ b/pkgs/sdk/server/contract-tests/Representations.cs
@@ -231,9 +231,52 @@ namespace TestService
         public SecureModeHashParams SecureModeHash { get; set; }
         public MigrationVariationParams MigrationVariation { get; set; }
         public MigrationOperationParams MigrationOperation { get; set; }
+        public ContextComparisonPairParams ContextComparison { get; set; }
         public RegisterFlagChangeListenerParams RegisterFlagChangeListener { get; set; }
         public RegisterFlagValueChangeListenerParams RegisterFlagValueChangeListener { get; set; }
         public UnregisterListenerParams UnregisterListener { get; set; }
+    }
+
+    public class ContextComparisonPairParams
+    {
+        public ContextComparisonParams Context1 { get; set; }
+        public ContextComparisonParams Context2 { get; set; }
+    }
+
+    public class ContextComparisonParams
+    {
+        public ContextComparisonSingleParams Single { get; set; }
+        public ContextComparisonSingleParams[] Multi { get; set; }
+    }
+
+    public class ContextComparisonSingleParams
+    {
+        public string Kind { get; set; }
+        public string Key { get; set; }
+        public AttributeDefinition[] Attributes { get; set; }
+
+        // The harness emits this key literally as "privateAttributes:omitempty" because of a
+        // malformed json struct tag in servicedef (a colon where a comma should be). Match it verbatim.
+        [JsonPropertyName("privateAttributes:omitempty")]
+        public PrivateAttribute[] PrivateAttributes { get; set; }
+    }
+
+    public class AttributeDefinition
+    {
+        public string Name { get; set; }
+        public LdValue Value { get; set; }
+    }
+
+    public class PrivateAttribute
+    {
+        public string Value { get; set; }
+        public bool Literal { get; set; }
+    }
+
+    public class ContextComparisonResponse
+    {
+        [JsonPropertyName("equals")]
+        public bool AreEqual { get; set; }
     }
 
     public class RegisterFlagChangeListenerParams

--- a/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
+++ b/pkgs/sdk/server/contract-tests/SdkClientEntity.cs
@@ -128,6 +128,10 @@ namespace TestService
                     response = DoMigrationOperation(command.MigrationOperation);
                     break;
 
+                case "contextComparison":
+                    response = DoContextComparison(command.ContextComparison);
+                    break;
+
                 case "registerFlagChangeListener":
                 {
                     var p = command.RegisterFlagChangeListener;
@@ -314,6 +318,46 @@ namespace TestService
             }
             return b.Build();
         }
+        private ContextComparisonResponse DoContextComparison(ContextComparisonPairParams p) =>
+            new ContextComparisonResponse
+            {
+                AreEqual = BuildComparisonContext(p.Context1).Equals(BuildComparisonContext(p.Context2))
+            };
+
+        private Context BuildComparisonContext(ContextComparisonParams p)
+        {
+            if (p.Single != null)
+            {
+                return BuildComparisonSingle(p.Single);
+            }
+            var b = Context.MultiBuilder();
+            foreach (var s in p.Multi)
+            {
+                b.Add(BuildComparisonSingle(s));
+            }
+            return b.Build();
+        }
+
+        private Context BuildComparisonSingle(ContextComparisonSingleParams s)
+        {
+            var b = Context.Builder(s.Key).Kind(s.Kind);
+            if (s.Attributes != null)
+            {
+                foreach (var a in s.Attributes)
+                {
+                    b.Set(a.Name, a.Value);
+                }
+            }
+            if (s.PrivateAttributes != null)
+            {
+                foreach (var pa in s.PrivateAttributes)
+                {
+                    b.Private(pa.Literal ? AttributeRef.FromLiteral(pa.Value) : AttributeRef.FromPath(pa.Value));
+                }
+            }
+            return b.Build();
+        }
+
         private ContextBuildResponse DoContextConvert(ContextConvertParams p)
         {
             try

--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -31,6 +31,7 @@ namespace TestService
             "all-flags-with-reasons",
             "big-segments",
             "context-type",
+            "context-comparison",
             "secure-mode-hash",
             "server-side-polling",
             "service-endpoints",


### PR DESCRIPTION
## What

Implements the `context-comparison` contract-test capability for the .NET **server** SDK. Present in **both** v2 and v3 harnesses.

Part of epic **SDK-2724** · ticket **SDK-2727**.

## Changes

- **`Representations.cs`** — add the `contextComparison` command params (`context1`/`context2`, each `single` or `multi`, with `attributes` + private attributes) and the `{ equals }` response.
- **`SdkClientEntity.cs`** — build both `Context` objects (single/multi, honoring literal vs path private-attribute refs via `AttributeRef.FromLiteral`/`FromPath`) and return `Context.Equals`.
- **`TestService.cs`** — declare `context-comparison`.

No SDK change needed — `Context.Equals` already provides order-independent multi-kind and private-attribute comparison. (Neither Go nor Java implements this yet.)

### Note: harness malformed JSON tag
The harness's `PrivateAttributes` field has a malformed struct tag — `json:"privateAttributes:omitempty"` (a colon where a comma belongs) — in both v2 and v3, so it serializes the key literally as `privateAttributes:omitempty`. Matched verbatim with `[JsonPropertyName("privateAttributes:omitempty")]`. Worth fixing upstream in sdk-test-harness, but matching it here keeps the tests green today.

## Verification

- **CI-pinned v3.0.0-alpha.6** (full suite, fdv2 suppression): **4813 ran, 0 failed**.
- **v2**: all context-comparison tests pass (14 ran).
- All comparison subtests pass in both: identical, out-of-order attributes/private-attrs, equivalent literal-vs-escaped-path private attrs, different kinds, multi out-of-order, multi-with-one-kind == single, extra/differing kinds.

## Follow-ups (epic SDK-2724)

Persistent data stores (SDK-2728).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only changes in contract-tests; no production SDK or runtime behavior modified.
> 
> **Overview**
> Adds **context-comparison** support to the .NET server SDK contract-test harness so the shared test suite can verify `Context` equality semantics.
> 
> The harness accepts a `contextComparison` command with two contexts (each single- or multi-kind), builds them from kind, key, attributes, and private-attribute refs (literal vs path via `AttributeRef`), and returns `{ equals }` from `Context.Equals`. **Representations.cs** adds the DTOs; **SdkClientEntity.cs** wires the command and builders; **TestService.cs** advertises the `context-comparison` capability.
> 
> No production SDK changes—the existing `Context.Equals` implementation is what gets exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4024b99995121071b706f4b1b0e8e8a240566545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->