### PR TITLE
fix: enable anonymous-context redaction for server events (SDK-2735)

### DIFF
--- a/pkgs/sdk/server/contract-tests/test-supressions.txt
+++ b/pkgs/sdk/server/contract-tests/test-supressions.txt
@@ -1,4 +1,1 @@
 tags/disallowed characters
-events/custom events/single-kind anonymous context redacts all attributes
-events/custom events/multi-kind with anonymous context redacts attributes appropriately
-migrations/redacts anonymous context attributes

--- a/pkgs/sdk/server/src/Integrations/EventProcessorBuilder.cs
+++ b/pkgs/sdk/server/src/Integrations/EventProcessorBuilder.cs
@@ -258,6 +258,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
             return new EventsConfiguration
             {
                 AllAttributesPrivate = _allAttributesPrivate,
+                RedactAnonymousAllEvents = true, // server-side SDKs redact anonymous contexts in custom & migration_op events
                 DiagnosticRecordingInterval = _diagnosticRecordingInterval,
                 EventCapacity = _capacity,
                 EventFlushInterval = _flushInterval,

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1" />
-    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.8.0" />
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.9.0" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
   </ItemGroup>
 

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1" />
-    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.6.1" />
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.8.0" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## ⚠️ Draft — blocked on #313 + an InternalSdk release

Server-side half of **SDK-2735**. Opts the server SDK into anonymous-context redaction for `custom` and `migration_op` events, and bumps the `LaunchDarkly.InternalSdk` dependency to pick up the flag.

**Depends on #313** (the `pkgs/shared/internal` change that adds `RedactAnonymousAllEvents`). This PR cannot compile until #313 lands **and** `LaunchDarkly.InternalSdk` is released with the flag — this won't build against the currently-referenced 3.6.1.

## Change

- `EventProcessorBuilder.MakeEventsConfiguration`: set `RedactAnonymousAllEvents = true` (server-side only; client SDK leaves it default `false`).
- `LaunchDarkly.ServerSdk.csproj`: bump `LaunchDarkly.InternalSdk` `3.6.1 → 3.8.0`. **The `3.8.0` here is a placeholder** — update to whatever version the #313 internal release actually publishes.

## Verification

Validated end-to-end locally (server temporarily project-referencing the in-repo internal from #313): full **v2.38.1** contract-test suite green (**4863 ran, 0 failed**), fixing the 3 previously-failing anonymous-redaction tests. Client SDK behavior unchanged (flag stays `false` there).

## Merge order
1. Merge #313 (internal fix).
2. Release `LaunchDarkly.InternalSdk` from the monorepo.
3. Update the version bump here to the released version, then merge this. Turns the repo-wide server CI redaction failures green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what context attributes are emitted in analytics events for anonymous users, which affects privacy/compliance behavior across all server SDK event pipelines.
> 
> **Overview**
> Turns on **anonymous-context attribute redaction** for server-side analytics by setting `RedactAnonymousAllEvents = true` when building `EventsConfiguration` in `EventProcessorBuilder`, so inlined contexts in **`custom`** and **`migration_op`** events match server SDK expectations (feature events already behaved this way).
> 
> Bumps **`LaunchDarkly.InternalSdk`** to **3.9.0** to use the shared flag and serialization path, and **drops three contract-test suppressions** that were masking anonymous-redaction failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35fe6573505e4c4846e0e8b87b2f36a70d5b7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->