### PR TITLE
fix: add defensive cycle guard to prerequisite evaluation

### DIFF
--- a/pkgs/sdk/client/contract-tests/TestService.cs
+++ b/pkgs/sdk/client/contract-tests/TestService.cs
@@ -42,6 +42,7 @@ namespace TestService
             "inline-context-all",
             "anonymous-redaction",
             "client-prereq-events",
+            "client-prereq-cycle-detection",
             "client-per-context-summaries"
         };
 

--- a/pkgs/sdk/client/src/LdClient.cs
+++ b/pkgs/sdk/client/src/LdClient.cs
@@ -755,7 +755,7 @@ namespace LaunchDarkly.Sdk.Client
         }
 
         EvaluationDetail<T> EvaluateInternal<T>(string featureKey, LdValue defaultJson, LdValue.Converter<T> converter,
-            bool checkType, EventFactory eventFactory)
+            bool checkType, EventFactory eventFactory, HashSet<string> visited = null)
         {
             T defaultValue = converter.ToType(defaultJson);
 
@@ -791,12 +791,33 @@ namespace LaunchDarkly.Sdk.Client
             }
 
             // Prerequisites are evaluated directly via EvaluateInternal to avoid triggering hooks.
-            if (flag.Prerequisites != null)
+            //
+            // `visited` tracks the chain of prerequisite dependencies from the top-level evaluation
+            // to (but not including) the current flag. It is allocated lazily: variation calls on
+            // prereq-less flags allocate no set. Once created it is shared for the rest of the walk
+            // via add-before-recurse / remove-after-recurse in a try/finally, so an exception below
+            // cannot leave a stale ancestor entry visible to a sibling branch.
+            if (flag.Prerequisites != null && flag.Prerequisites.Count > 0)
             {
-                foreach (var prerequisiteKey in flag.Prerequisites)
+                var ancestors = visited ?? new HashSet<string>();
+                ancestors.Add(featureKey);
+                try
                 {
-                    EvaluateInternal(prerequisiteKey, LdValue.Null, LdValue.Convert.Json, false,
-                        _eventFactoryWithReasons);
+                    foreach (var prerequisiteKey in flag.Prerequisites)
+                    {
+                        if (ancestors.Contains(prerequisiteKey))
+                        {
+                            // Cyclic edge: skip descent, continue with remaining prerequisites at this level.
+                            // The requested flag's value and reason (below) are unaffected.
+                            continue;
+                        }
+                        EvaluateInternal(prerequisiteKey, LdValue.Null, LdValue.Convert.Json, false,
+                            _eventFactoryWithReasons, ancestors);
+                    }
+                }
+                finally
+                {
+                    ancestors.Remove(featureKey);
                 }
             }
 

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs
@@ -373,6 +373,133 @@ namespace LaunchDarkly.Sdk.Client
             }
         }
 
+        // Cycle-detection tests exercise the ancestor-set cycle guard added to EvaluateInternal.
+        // Each test constructs a cyclic prereq graph, evaluates one flag on the cycle, and asserts
+        // (a) the requested flag returns its cached value unchanged and (b) the recorded evaluation
+        // events match exactly one entry per cycle-safe descent.
+
+        [Fact]
+        public void VariationSkipsSelfLoopPrerequisiteAndReturnsCachedValue()
+        {
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+
+            using (LdClient client = MakeClient(user))
+            {
+                Assert.True(client.BoolVariation("flagA"));
+                // Only flagA emits a feature event; the self-prereq is cycle-skipped.
+                Assert.Collection(eventProcessor.Events,
+                    e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagA")
+                );
+            }
+        }
+
+        [Fact]
+        public void VariationHandlesTwoCycleEvaluatingA()
+        {
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagB").Build();
+            var flagB = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+            _testData.Update(_testData.Flag("flagB").PreconfiguredFlag(flagB));
+
+            using (LdClient client = MakeClient(user))
+            {
+                Assert.True(client.BoolVariation("flagA"));
+                // A -> B -> [A skipped]. Events deepest-first: B (as prereq of A), then A.
+                Assert.Collection(eventProcessor.Events,
+                    e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagB"),
+                    e => CheckEvaluationEvent(e, "flagA")
+                );
+            }
+        }
+
+        [Fact]
+        public void VariationHandlesTwoCycleEvaluatingB()
+        {
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagB").Build();
+            var flagB = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+            _testData.Update(_testData.Flag("flagB").PreconfiguredFlag(flagB));
+
+            using (LdClient client = MakeClient(user))
+            {
+                Assert.True(client.BoolVariation("flagB"));
+                // Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
+                Assert.Collection(eventProcessor.Events,
+                    e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagA"),
+                    e => CheckEvaluationEvent(e, "flagB")
+                );
+            }
+        }
+
+        [Fact]
+        public void VariationHandlesThreeCycle()
+        {
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagB").Build();
+            var flagB = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagC").Build();
+            var flagC = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagA").Build();
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+            _testData.Update(_testData.Flag("flagB").PreconfiguredFlag(flagB));
+            _testData.Update(_testData.Flag("flagC").PreconfiguredFlag(flagC));
+
+            using (LdClient client = MakeClient(user))
+            {
+                Assert.True(client.BoolVariation("flagA"));
+                // A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
+                Assert.Collection(eventProcessor.Events,
+                    e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagC"),
+                    e => CheckEvaluationEvent(e, "flagB"),
+                    e => CheckEvaluationEvent(e, "flagA")
+                );
+            }
+        }
+
+        [Fact]
+        public void VariationEmitsSharedDescendantOncePerPathInDiamond()
+        {
+            // Diamond: A -> [B, C], B -> [D], C -> [D]. Not a cycle. Ancestor-set (current-path)
+            // semantics let D be reached on each of the two independent paths, so D emits twice.
+            // A naive "visited across the whole walk" implementation would drop the second event.
+            var flagA = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagB", "flagC").Build();
+            var flagB = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagD").Build();
+            var flagC = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Prerequisites("flagD").Build();
+            var flagD = new FeatureFlagBuilder().Value(LdValue.Of(true)).Variation(1).Version(1)
+                .TrackEvents(false).TrackReason(false).Build();
+            _testData.Update(_testData.Flag("flagA").PreconfiguredFlag(flagA));
+            _testData.Update(_testData.Flag("flagB").PreconfiguredFlag(flagB));
+            _testData.Update(_testData.Flag("flagC").PreconfiguredFlag(flagC));
+            _testData.Update(_testData.Flag("flagD").PreconfiguredFlag(flagD));
+
+            using (LdClient client = MakeClient(user))
+            {
+                Assert.True(client.BoolVariation("flagA"));
+                // Events (deepest-first per path): D (via B), B, D (via C), C, A. D appears twice.
+                Assert.Collection(eventProcessor.Events,
+                    e => CheckIdentifyEvent(e, user),
+                    e => CheckEvaluationEvent(e, "flagD"),
+                    e => CheckEvaluationEvent(e, "flagB"),
+                    e => CheckEvaluationEvent(e, "flagD"),
+                    e => CheckEvaluationEvent(e, "flagC"),
+                    e => CheckEvaluationEvent(e, "flagA")
+                );
+            }
+        }
+
         private void CheckIdentifyEvent(object e, Context c)
         {
             IdentifyEvent ie = Assert.IsType<IdentifyEvent>(e);


### PR DESCRIPTION
## Summary

Adds defensive cycle detection to the recursive prerequisite walk in `LdClient.EvaluateInternal`, bringing the .NET client SDK's behavior into line with the LaunchDarkly server SDK evaluators.

Tracker: [SDK-2708](https://launchdarkly.atlassian.net/browse/SDK-2708). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). Spec change: [sdk-specs#246](https://github.com/launchdarkly/sdk-specs/pull/246) (CSPE 1.2.5, 1.2.5.1, 1.2.5.2). Contract-test coverage: [sdk-test-harness#384](https://github.com/launchdarkly/sdk-test-harness/pull/384) (merged in v2.38.0). Companion PRs: [android-client-sdk#377](https://github.com/launchdarkly/android-client-sdk/pull/377), [ios-client-sdk#512](https://github.com/launchdarkly/ios-client-sdk/pull/512), [js-core#1816](https://github.com/launchdarkly/js-core/pull/1816), [flutter-client-sdk#329](https://github.com/launchdarkly/flutter-client-sdk/pull/329).

## Background

The LaunchDarkly service validates prerequisite graphs on every mutation and rejects any change that would produce a cycle, so under normal operation the SDK does not see a cyclic prerequisite graph. Server-side SDK evaluators nonetheless carry defensive cycle detection for exceptional cases — for example, delivery of updates out of order or a persisted state loaded from disk that predates a subsequent correction. Note that the .NET **server** SDK evaluator already carries this guard (`PrereqFlagKeyStack` in `Evaluator.cs`); this PR extends the same posture to the client SDK.

## The fix

`EvaluateInternal<T>` now threads a lazily-allocated `HashSet<string>` through the recursion carrying the flag keys on the current evaluation path. Before descending into a prerequisite, the walker checks whether that key is already on the path; if so, it skips that edge and continues with remaining prerequisites at the same level.

- **Lazy allocation**: variation calls on prereq-less flags (the common case) allocate zero collections. The `HashSet<string>` is created only when the walker descends into a prerequisite for the first time in a call, then reused for the rest of the walk.
- **Mutable `Add` / `finally Remove`**: no per-descent copy. `ancestors.Add(featureKey)` before recursing, `ancestors.Remove(featureKey)` in a `finally` — the invariant "the set contains exactly the current path" holds even under exceptions.
- **Ancestor-set (current-path) semantics** — this is deliberate. A prerequisite reached via multiple non-cyclic paths (a diamond `A -> [B, C], B -> [D], C -> [D]`) is not a cycle; each path should emit its own prerequisite event. A global visited-set would silently drop the second event; the ancestor-set pattern correctly emits D twice. There is a unit test guarding this.

The optional trailing parameter `HashSet<string> visited = null` is added to `EvaluateInternal<T>`, so all existing callers (the public `BoolVariation` / `IntVariation` / `StringVariation` / `DoubleVariation` / `JsonVariation` and their `*Detail` counterparts) work unchanged.

## Caller-visible behavior on a cycle

The requested flag returns its cached value and reason unchanged. A client-side prerequisite cycle is not surfaced as `MALFORMED_FLAG` and does not fall back to the caller-provided default value. This differs from server-side behavior — the client already holds an authoritative pre-evaluated result from the server; only the ancillary event walk is affected by the cycle.

## Files changed

- `pkgs/sdk/client/src/LdClient.cs` — cycle guard in `EvaluateInternal<T>`.
- `pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/LdClientEventTests.cs` — 5 new xUnit tests: self-loop, two-cycle (evaluating each end), three-cycle, and a non-cyclic diamond that asserts the shared descendant emits an event for each path (the ancestor-set regression fence).
- `pkgs/sdk/client/contract-tests/TestService.cs` — declares `client-prereq-cycle-detection` so the matching contract tests in sdk-test-harness v2.38.0+ activate for this SDK.

## Verification

- **Unit tests**: `dotnet test -f net8.0 --filter "Prerequisite|Cycle|Diamond"` → 6 passed, 0 failures (the original prereq event test plus 5 new cycle-detection tests).

## Changelog

> Updated prerequisite evaluation event emission to match server SDK behavior for cyclic prerequisite graphs.

[SDK-2708]: https://launchdarkly.atlassian.net/browse/SDK-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flag evaluation and analytics event emission for prerequisite walks; behavior change is defensive but affects event ordering/counts on malformed graphs.
> 
> **Overview**
> Adds **defensive cycle detection** to the recursive prerequisite walk in `LdClient.EvaluateInternal`, aligning client SDK behavior with server evaluators and sdk-spec CSPE 1.2.5.
> 
> Before descending into each prerequisite, the walker tracks flag keys on the **current path** in a lazily allocated `HashSet<string>` (add before recurse, remove in `finally`). If a prerequisite key is already on that path, that edge is skipped; the requested flag still returns its **cached value and reason** unchanged.
> 
> **Ancestor-set semantics** (not a global visited set) preserve correct analytics for diamond graphs: a shared prerequisite reached via separate branches still emits one evaluation event per path.
> 
> Contract tests declare capability `client-prereq-cycle-detection`. Five xUnit tests cover self-loops, 2- and 3-cycles, and the diamond regression case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fbdce1fac5f6b3dbab2b398312d1d933f9ceea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->