### PR TITLE
feat: enable gzip AutomaticDecompression on the default HTTP handler

### DIFF
--- a/pkgs/shared/internal/src/Http/HttpProperties.cs
+++ b/pkgs/shared/internal/src/Http/HttpProperties.cs
@@ -267,19 +267,28 @@ namespace LaunchDarkly.Sdk.Internal.Http
 
         private static HttpMessageHandler DefaultHttpMessageHandlerFactory(HttpProperties props)
         {
+            // AutomaticDecompression makes the runtime send "Accept-Encoding: gzip" and transparently
+            // decompress gzipped responses, so the SDK accepts compressed streaming/polling/event
+            // payloads (matching the transparent-gzip behavior of the Go and Java/OkHttp SDKs).
 #if NETCOREAPP
             return new SocketsHttpHandler
             {
+                AutomaticDecompression = DecompressionMethods.GZip,
                 ConnectTimeout = props.ConnectTimeout,
                 Proxy = props.Proxy
             };
 #else
+            // Always return a configured handler (not null) so AutomaticDecompression is applied even
+            // when no proxy is set; the platform default handler on these frameworks is HttpClientHandler.
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip
+            };
             if (props.Proxy != null)
             {
-                return new HttpClientHandler { Proxy = props.Proxy };
+                handler.Proxy = props.Proxy;
             }
-
-            return null;
+            return handler;
 #endif
         }
 


### PR DESCRIPTION
## What

Enables `AutomaticDecompression = DecompressionMethods.GZip` on the default HTTP message handler in `pkgs/shared/internal` (`HttpProperties.DefaultHttpMessageHandlerFactory`) — `SocketsHttpHandler` on .NET Core/5+, `HttpClientHandler` on net462/netstandard.

The runtime now sends `Accept-Encoding: gzip` and transparently decompresses gzipped responses on all requests — matching the transparent-gzip behavior of the Go (`net/http`) and Java/Android (OkHttp) SDKs.

This is the **internal-package half** of adding polling compression (`polling-gzip`) to the .NET server SDK — the last SDK under epic **SDK-950** · ticket **SDK-2744**.

## Why here (transport-level)

The harness's `polling-gzip` capability requires the SDK to send `Accept-Encoding: gzip` on polling and decompress the response, on **both** the FDv1 (`FeatureRequestor`) and FDv2 (`FDv2PollingRequestor`) paths (tested under harness v2 and v3). Doing it at the shared handler covers both uniformly (plus streaming/events), is idiomatic .NET, and needs no config gating — gzip decompression is universally safe for client and server SDKs alike.

The net462/netstandard branch previously returned `null` (platform default handler) when no proxy was set; it now always returns a configured `HttpClientHandler` so the setting applies there too.

## Verification

Validated end-to-end locally (server temporarily project-referencing this in-repo internal, with `polling-gzip` declared): the `polling/requests/method and headers` `Accept-Encoding: gzip` assertion and the compressed-payload polling tests pass on **both** harness versions (v2.38.1 FDv1 and v3.0.0-alpha.6 FDv2), and the full suites are green (v2.38.1: 4876 ran, 0 failed; v3.0.0-alpha.6: 4813 ran, 0 failed) — no streaming/events regressions.

## Follow-up

Server opt-in — bump the server SDK's `LaunchDarkly.InternalSdk` reference to the release that carries this + declare `polling-gzip` — is a **separate draft PR**, blocked until this is released (same pattern as SDK-2735 / #313→#314).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default HTTP transport for all consumers of `HttpProperties` (including net462 when no proxy), which could affect edge-case handler behavior even though gzip decompression is generally safe.
> 
> **Overview**
> Enables **transparent gzip** on the shared default HTTP message handler so all SDK traffic can advertise `Accept-Encoding: gzip` and decompress responses automatically, aligning .NET with Go and Java/OkHttp for **polling-gzip** (and compressed streaming/events).
> 
> On **.NET Core/5+**, `SocketsHttpHandler` now sets `AutomaticDecompression = DecompressionMethods.GZip` alongside existing connect timeout and proxy settings. On **net462/netstandard**, the factory **always** returns a configured `HttpClientHandler` with the same gzip setting instead of returning `null` when no proxy is set—so compression applies there too while proxy configuration is unchanged when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3149948b26ee91ddd8b456cee58259ea000793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->