### PR TITLE
feat: Support server-side gzip for polling

### DIFF
--- a/pkgs/sdk/server/contract-tests/TestService.cs
+++ b/pkgs/sdk/server/contract-tests/TestService.cs
@@ -34,6 +34,7 @@ namespace TestService
             "context-comparison",
             "secure-mode-hash",
             "server-side-polling",
+            "polling-gzip",
             "service-endpoints",
             "migrations",
             "event-sampling",

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1" />
-    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.9.0" />
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.10.0" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Server-side half of **SDK-2744** (polling compression for the .NET server SDK, epic **SDK-950**). Declares the `polling-gzip` contract-test capability and bumps the `LaunchDarkly.InternalSdk` dependency to pick up gzip `AutomaticDecompression`.

**Depends on #318** (the `pkgs/shared/internal` `AutomaticDecompression` change). This can't validate until #318 lands **and** a new `LaunchDarkly.InternalSdk` is released.

## Changes
- `TestService.cs`: declare `polling-gzip`.
- `LaunchDarkly.ServerSdk.csproj`: bump `LaunchDarkly.InternalSdk` `3.9.0 → 3.10.0`. **The `3.10.0` is a placeholder** — update to whatever version the #318 release publishes.

## Verification
Validated end-to-end locally (server temporarily project-referencing the in-repo internal from #318, with `polling-gzip` declared): the `Accept-Encoding: gzip` polling assertion and compressed-payload polling tests pass on **both** harness versions (v2.38.1 FDv1 + v3.0.0-alpha.6 FDv2), full suites green.

## Merge order
1. Merge #318 (internal `AutomaticDecompression`).
2. Release `LaunchDarkly.InternalSdk`.
3. Update the version bump here to the released version, take out of draft, merge. That completes polling-gzip for .NET — the final SDK under SDK-950.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Capability declaration and a dependency bump only; no server SDK logic changes in this diff.
> 
> **Overview**
> Advertises **polling-gzip** support for the .NET server SDK in contract tests by adding that capability to the harness status response in `TestService.cs`.
> 
> Bumps **`LaunchDarkly.InternalSdk`** from `3.9.0` to `3.10.0` so the server SDK picks up transparent gzip on polling HTTP (via internal `AutomaticDecompression`), which the `polling-gzip` tests assert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7409aae27915f80341af98f11162ca1f0d524a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->