### PR TITLE
fix: treat unknown/constrained network access as connected

### DIFF
--- a/pkgs/sdk/client/src/Internal/DataSources/DefaultConnectivityStateManager.cs
+++ b/pkgs/sdk/client/src/Internal/DataSources/DefaultConnectivityStateManager.cs
@@ -32,7 +32,15 @@ namespace LaunchDarkly.Sdk.Client.Internal.DataSources
 
         private void UpdateConnectedStatus()
         {
-            isConnected = PlatformConnectivity.LdNetworkAccess == LdNetworkAccess.Internet;
+            isConnected = IsConsideredConnected(PlatformConnectivity.LdNetworkAccess);
         }
+
+        // Unknown covers MAUI Connectivity's cold-start race; ConstrainedInternet typically
+        // resolves upward. Local stays disconnected so the transition to Internet triggers
+        // a fresh reconnect via ConnectivityChanged.
+        internal static bool IsConsideredConnected(LdNetworkAccess access) =>
+            access == LdNetworkAccess.Internet
+            || access == LdNetworkAccess.Unknown
+            || access == LdNetworkAccess.ConstrainedInternet;
     }
 }

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Internal/DataSources/DefaultConnectivityStateManagerTest.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Internal/DataSources/DefaultConnectivityStateManagerTest.cs
@@ -1,0 +1,28 @@
+using LaunchDarkly.Sdk.Client.PlatformSpecific;
+using Xunit;
+
+namespace LaunchDarkly.Sdk.Client.Internal.DataSources
+{
+    public class DefaultConnectivityStateManagerTest
+    {
+        [Fact]
+        public void Internet_IsConsideredConnected() =>
+            Assert.True(DefaultConnectivityStateManager.IsConsideredConnected(LdNetworkAccess.Internet));
+
+        [Fact]
+        public void Unknown_IsConsideredConnected() =>
+            Assert.True(DefaultConnectivityStateManager.IsConsideredConnected(LdNetworkAccess.Unknown));
+
+        [Fact]
+        public void None_IsNotConsideredConnected() =>
+            Assert.False(DefaultConnectivityStateManager.IsConsideredConnected(LdNetworkAccess.None));
+
+        [Fact]
+        public void Local_IsNotConsideredConnected() =>
+            Assert.False(DefaultConnectivityStateManager.IsConsideredConnected(LdNetworkAccess.Local));
+
+        [Fact]
+        public void ConstrainedInternet_IsConsideredConnected() =>
+            Assert.True(DefaultConnectivityStateManager.IsConsideredConnected(LdNetworkAccess.ConstrainedInternet));
+    }
+}


### PR DESCRIPTION
## Summary

`Microsoft.Maui.Networking.Connectivity.Current.NetworkAccess` can transiently report `Unknown` at process start — MAUI's platform callback (`NetworkCallback` on Android, `NWPathMonitor` on iOS/macOS, `NetworkInformation` on Windows) hasn't yet been given the initial availability signal by the framework. Because `DefaultConnectivityStateManager.UpdateConnectedStatus` previously required *exactly* `Internet`, `LdClient`'s constructor read `_networkEnabled = false`, `Start()` took the offline fast-exit branch in `ConnectionManager.OpenOrCloseConnectionIfNecessary`, and `Init` returned "success" in ~300ms with an empty flag store. The SDK then had to wait for MAUI to fire `ConnectivityChanged` before it would even attempt to open a stream.

This PR updates `IsConsideredConnected` to treat `Unknown` and `ConstrainedInternet` as connected in addition to `Internet`. `Local` and `None` remain disconnected.

## Scope

- Affects **all MAUI targets** (Android / iOS / Mac Catalyst / Windows) because `DefaultConnectivityStateManager` is shared code and `PlatformConnectivity.LdNetworkAccess` maps directly to MAUI's cross-platform `Connectivity.NetworkAccess`. The `Connectivity.maui.cs` implementation is compiled into every MAUI target via `<Compile Include="**\*.maui.cs"/>` in each target's ItemGroup.
- **Not** affected: netstandard consumers. `Connectivity.netstandard.cs` returns `LdNetworkAccess.Internet` unconditionally, so it never hit the buggy branch and doesn't hit the new one either.

## Why not "anything but `None`"

`ConnectionManager.SetNetworkEnabled(bool)` is a no-op when the value doesn't change. If we optimistically treated `Local` as connected, the eventual `Local -> Internet` transition wouldn't trigger `OpenOrCloseConnectionIfNecessary` (the boolean already matches), and the SDK would rely on the `EventSource`'s internal retry backoff — up to ~30s late reconnecting after network fully recovers. Keeping `Local` disconnected preserves the deterministic wake-up on that transition. `ConstrainedInternet` (captive portals, metered restrictions) typically resolves upward to `Internet`, so attempting is cheap and the same race isn't a concern in practice.

## Test plan

- [x] `dotnet test pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests -f net8.0` — 377/377 passing, including 5 new tests in `DefaultConnectivityStateManagerTest` covering every `LdNetworkAccess` enum value.
- [x] Cross-target compile check under .NET 8 SDK — all six target frameworks build 0 errors: `netstandard2.0`, `net8.0`, `net8.0-android`, `net8.0-ios`, `net8.0-maccatalyst`, `net8.0-windows`. Confirmed `IsConsideredConnected` is present in the iOS and Mac Catalyst output DLLs.
- [ ] Manual verification on a MAUI Android app that fresh-install cold start no longer hits the offline branch.