### PR TITLE
fix!: Make AgentGraph traversal topological

### DIFF
--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -94,12 +94,13 @@ public sealed class AgentGraphDefinition
     public AiGraphTracker CreateTracker() => _createTracker();
 
     /// <summary>
-    /// Performs a breadth-first traversal of the graph starting from the root node.
-    /// For each visited node, <paramref name="fn"/> is called with the node and the
-    /// accumulated context dictionary. The return value of <paramref name="fn"/> is
-    /// stored in the context under the node's key and passed to subsequent calls.
-    /// Cycle-safe: each node is visited at most once.
+    /// Visits each reachable node in topological order (predecessors first, root first).
+    /// Ties break by discovery order. Cycle-safe.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="fn"/> receives <paramref name="initialContext"/> plus results
+    /// from that node's reachable predecessors only.
+    /// </remarks>
     public void Traverse(
         Func<AgentGraphNode, Dictionary<string, object>, object> fn,
         Dictionary<string, object> initialContext = null)
@@ -108,91 +109,143 @@ public sealed class AgentGraphDefinition
         if (root == null) return;
 
         var context = initialContext ?? new Dictionary<string, object>();
+        var (reachable, order) = ReachableAndDiscovery(root.Key);
+
+        var indeg = reachable.ToDictionary(k => k, _ => 0);
+        foreach (var k in reachable)
+        {
+            foreach (var e in GetNode(k).Edges)
+            {
+                if (reachable.Contains(e.Key)) indeg[e.Key]++;
+            }
+        }
+        indeg[root.Key] = 0;
 
         var visited = new HashSet<string>();
-        var queue = new Queue<AgentGraphNode>();
-        queue.Enqueue(root);
-        visited.Add(root.Key);
+        var results = new Dictionary<string, object>();
+        var ancestors = new Dictionary<string, HashSet<string>>();
 
-        while (queue.Count > 0)
+        Dictionary<string, object> Scoped(HashSet<string> deps)
         {
-            var node = queue.Dequeue();
-            var result = fn(node, context);
-            context[node.Key] = result;
+            var c = new Dictionary<string, object>(context);
+            foreach (var k in deps) c[k] = results[k];
+            return c;
+        }
 
-            foreach (var child in GetChildNodes(node.Key))
+        while (visited.Count < reachable.Count)
+        {
+            var next = order.FirstOrDefault(k => !visited.Contains(k) && indeg[k] <= 0)
+                       ?? order.Where(k => !visited.Contains(k)).OrderBy(k => indeg[k]).First();
+
+            var anc = new HashSet<string>();
+            foreach (var parent in GetParentNodes(next))
             {
-                if (visited.Add(child.Key))
-                {
-                    queue.Enqueue(child);
-                }
+                if (!visited.Contains(parent.Key)) continue;
+                anc.Add(parent.Key);
+                anc.UnionWith(ancestors[parent.Key]);
+            }
+            ancestors[next] = anc;
+            visited.Add(next);
+
+            results[next] = fn(GetNode(next), Scoped(anc));
+            foreach (var e in GetNode(next).Edges)
+            {
+                if (reachable.Contains(e.Key)) indeg[e.Key]--;
             }
         }
     }
 
     /// <summary>
-    /// Performs a reverse breadth-first traversal: starts from terminal nodes and
-    /// works upward toward the root. The root node is always processed last.
-    /// Cycle-safe: each node is visited at most once.
+    /// Visits each reachable node in reverse topological order (descendants first,
+    /// root last). Ties break by discovery order. Cycle-safe.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="fn"/> receives <paramref name="initialContext"/> plus results
+    /// from that node's reachable descendants only.
+    /// </remarks>
     public void ReverseTraverse(
         Func<AgentGraphNode, Dictionary<string, object>, object> fn,
         Dictionary<string, object> initialContext = null)
     {
-        if (_nodes.Count == 0) return;
-
-        var context = initialContext ?? new Dictionary<string, object>();
-
         var root = RootNode();
-        var visited = new HashSet<string>();
-        var queue = new Queue<AgentGraphNode>();
+        if (root == null) return;
 
-        // Seed with terminal nodes (excluding root if it happens to be terminal and there are others)
-        foreach (var terminal in TerminalNodes())
+        var rootKey = root.Key;
+        var context = initialContext ?? new Dictionary<string, object>();
+        var (reachable, order) = ReachableAndDiscovery(rootKey);
+
+        var outdeg = reachable.ToDictionary(
+            k => k, k => GetNode(k).Edges.Count(e => reachable.Contains(e.Key)));
+
+        var visited = new HashSet<string>();
+        var results = new Dictionary<string, object>();
+        var descendants = new Dictionary<string, HashSet<string>>();
+
+        Dictionary<string, object> Scoped(HashSet<string> deps)
         {
-            if (root != null && terminal.Key == root.Key && _nodes.Count > 1)
+            var c = new Dictionary<string, object>(context);
+            foreach (var k in deps) c[k] = results[k];
+            return c;
+        }
+
+        bool NonRootRemaining() => reachable.Any(k => k != rootKey && !visited.Contains(k));
+        while (NonRootRemaining())
+        {
+            var next = order.FirstOrDefault(k => k != rootKey && !visited.Contains(k) && outdeg[k] <= 0)
+                       ?? order.Where(k => k != rootKey && !visited.Contains(k)).OrderBy(k => outdeg[k]).First();
+
+            var desc = new HashSet<string>();
+            foreach (var e in GetNode(next).Edges)
             {
-                continue;
+                if (!reachable.Contains(e.Key) || !visited.Contains(e.Key)) continue;
+                desc.Add(e.Key);
+                desc.UnionWith(descendants[e.Key]);
             }
-            if (visited.Add(terminal.Key))
+            descendants[next] = desc;
+            visited.Add(next);
+
+            results[next] = fn(GetNode(next), Scoped(desc));
+            foreach (var parent in GetParentNodes(next))
             {
-                queue.Enqueue(terminal);
+                if (parent.Key != rootKey && reachable.Contains(parent.Key))
+                    outdeg[parent.Key]--;
             }
         }
+
+        // Root last
+        var rootDeps = new HashSet<string>(reachable.Where(k => k != rootKey));
+        results[rootKey] = fn(root, Scoped(rootDeps));
+    }
+
+    /// <summary>
+    /// Reachable nodes from <paramref name="rootKey"/> and BFS discovery order
+    /// (declared edge order). Used as a topological tie-break.
+    /// </summary>
+    private (HashSet<string> reachable, List<string> order) ReachableAndDiscovery(string rootKey)
+    {
+        var reachable = new HashSet<string>();
+        var order = new List<string>();
+        var queue = new Queue<string>();
+        reachable.Add(rootKey);
+        order.Add(rootKey);
+        queue.Enqueue(rootKey);
 
         while (queue.Count > 0)
         {
-            var node = queue.Dequeue();
-
-            // Defer root until the very end (unless it's the only node)
-            if (root != null && node.Key == root.Key && _nodes.Count > 1)
+            var key = queue.Dequeue();
+            var node = GetNode(key);
+            if (node == null) continue;
+            foreach (var edge in node.Edges)
             {
-                continue;
-            }
-
-            var result = fn(node, context);
-            context[node.Key] = result;
-
-            foreach (var parent in GetParentNodes(node.Key))
-            {
-                if (root != null && parent.Key == root.Key)
+                if (GetNode(edge.Key) != null && reachable.Add(edge.Key))
                 {
-                    // Don't enqueue root yet — process it last
-                    continue;
-                }
-                if (visited.Add(parent.Key))
-                {
-                    queue.Enqueue(parent);
+                    order.Add(edge.Key);
+                    queue.Enqueue(edge.Key);
                 }
             }
         }
 
-        // Process root last
-        if (root != null && _nodes.Count > 1 && visited.Count > 0)
-        {
-            var result = fn(root, context);
-            context[root.Key] = result;
-        }
+        return (reachable, order);
     }
 
     /// <summary>

--- a/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
+++ b/pkgs/sdk/server-ai/src/Graph/AgentGraphDefinition.cs
@@ -134,7 +134,7 @@ public sealed class AgentGraphDefinition
 
         while (visited.Count < reachable.Count)
         {
-            var next = order.FirstOrDefault(k => !visited.Contains(k) && indeg[k] <= 0)
+            var next = order.FirstOrDefault(k => !visited.Contains(k) && indeg[k] == 0)
                        ?? order.Where(k => !visited.Contains(k)).OrderBy(k => indeg[k]).First();
 
             var anc = new HashSet<string>();
@@ -191,7 +191,7 @@ public sealed class AgentGraphDefinition
         bool NonRootRemaining() => reachable.Any(k => k != rootKey && !visited.Contains(k));
         while (NonRootRemaining())
         {
-            var next = order.FirstOrDefault(k => k != rootKey && !visited.Contains(k) && outdeg[k] <= 0)
+            var next = order.FirstOrDefault(k => k != rootKey && !visited.Contains(k) && outdeg[k] == 0)
                        ?? order.Where(k => k != rootKey && !visited.Contains(k)).OrderBy(k => outdeg[k]).First();
 
             var desc = new HashSet<string>();

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -179,9 +179,9 @@ public class AgentGraphDefinitionTest
         Assert.Same(flagValue, disabled.GetConfig());
     }
 
-    // Test 32: Traverse visits nodes BFS from root
+    // Test 32: Traverse visits nodes in topological order from root
     [Fact]
-    public void TraverseVisitsNodesInBfsOrder()
+    public void TraverseVisitsNodesInTopologicalOrder()
     {
         var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
 
@@ -229,7 +229,7 @@ public class AgentGraphDefinitionTest
         Assert.Equal("my-graph-key", tracker.GetTrackData().GraphKey);
     }
 
-    // Test 35: Cycle-safe — pure cycle has no terminal nodes, so reverse traversal is a no-op
+    // Test 35: Cycle-safe — pure cycle visits all nodes, root last
     [Fact]
     public void ReverseTraverseIsCycleSafe()
     {
@@ -261,8 +261,11 @@ public class AgentGraphDefinitionTest
             return null;
         });
 
-        // Pure cycle has no terminal nodes — reverse traversal is a no-op per spec AIGRAPH 1.4
-        Assert.Empty(visited);
+        Assert.Equal(3, visited.Count);
+        Assert.Equal("a", visited[visited.Count - 1]);
+        Assert.Contains("a", visited);
+        Assert.Contains("b", visited);
+        Assert.Contains("c", visited);
     }
 
     // Test 36: Cycle-safe — graph with cycles doesn't infinite loop
@@ -299,6 +302,7 @@ public class AgentGraphDefinitionTest
 
         // Each node visited exactly once despite cycle
         Assert.Equal(3, visited.Count);
+        Assert.Equal("a", visited[0]);
         Assert.Contains("a", visited);
         Assert.Contains("b", visited);
         Assert.Contains("c", visited);
@@ -361,20 +365,21 @@ public class AgentGraphDefinitionTest
     }
 
     [Fact]
-    public void TraversePassesContextBetweenNodes()
+    public void TraversePassesScopedResultsBetweenDependentNodes()
     {
         var graph = BuildEnabled(ThreeNodeFlagValue(), ThreeNodeConfigs());
 
-        var ctx = new Dictionary<string, object>();
+        var seen = new Dictionary<string, Dictionary<string, object>>();
         graph.Traverse((node, context) =>
         {
-            context[$"{node.Key}-visited"] = true;
+            seen[node.Key] = new Dictionary<string, object>(context);
             return node.Key.ToUpper();
-        }, ctx);
+        });
 
-        Assert.Equal("AGENT-A", ctx["agent-a"]);
-        Assert.Equal("AGENT-B", ctx["agent-b"]);
-        Assert.Equal("AGENT-C", ctx["agent-c"]);
+        Assert.Empty(seen["agent-a"]);
+        Assert.Equal("AGENT-A", seen["agent-b"]["agent-a"]);
+        Assert.Equal("AGENT-A", seen["agent-c"]["agent-a"]);
+        Assert.Equal("AGENT-B", seen["agent-c"]["agent-b"]);
     }
 
     [Fact]
@@ -421,5 +426,369 @@ public class AgentGraphDefinitionTest
         var flagValue = ThreeNodeFlagValue();
         var nodes = AgentGraphDefinition.BuildNodes(flagValue, ThreeNodeConfigs());
         Assert.Null(nodes["agent-a"].Edges[0].Handoff);
+    }
+
+    // -----------------------------------------------------------------------
+    // Topological parity fixtures (G1–G6)
+    // -----------------------------------------------------------------------
+
+    private static AgentGraphDefinition BuildGraph(string root,
+        Dictionary<string, IReadOnlyList<GraphEdge>> edges)
+    {
+        var keys = new HashSet<string> { root };
+        foreach (var kv in edges)
+        {
+            keys.Add(kv.Key);
+            foreach (var e in kv.Value) keys.Add(e.Key);
+        }
+        var configs = keys.ToDictionary(k => k, k => MakeAgentConfig(k));
+        var flagValue = new AgentGraphFlagValue
+        {
+            Root = root,
+            Edges = edges,
+            Meta = new LdMeta { Enabled = true }
+        };
+        return BuildEnabled(flagValue, configs);
+    }
+
+    private static List<string> CollectOrder(AgentGraphDefinition graph, bool reverse)
+    {
+        var order = new List<string>();
+        if (reverse)
+            graph.ReverseTraverse((node, _) => { order.Add(node.Key); return null; });
+        else
+            graph.Traverse((node, _) => { order.Add(node.Key); return null; });
+        return order;
+    }
+
+    private static void AssertExactContextKeys(
+        Dictionary<string, object> ctx, IEnumerable<string> expected)
+    {
+        var actual = ctx.Keys.OrderBy(k => k).ToArray();
+        var expectedSorted = expected.OrderBy(k => k).ToArray();
+        Assert.Equal(expectedSorted, actual);
+    }
+
+    [Fact]
+    public void G1_TraverseVisitsLinearChain()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("c", null) }
+        });
+        Assert.Equal(new[] { "a", "b", "c" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void G1_ReverseTraverseVisitsLinearChain()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("c", null) }
+        });
+        Assert.Equal(new[] { "c", "b", "a" }, CollectOrder(graph, reverse: true));
+    }
+
+    [Fact]
+    public void G2_TraverseVisitsSkewedDiamond()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void G2_ReverseTraverseVisitsSkewedDiamond()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+        Assert.Equal(new[] { "e", "b", "d", "c", "a" }, CollectOrder(graph, reverse: true));
+    }
+
+    [Fact]
+    public void G2b_TraverseKeepsELastWhenAEdgesReordered()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("c", null), new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+        var order = CollectOrder(graph, reverse: false);
+        Assert.Equal(new[] { "a", "c", "b", "d", "e" }, order);
+        Assert.True(order.IndexOf("d") < order.IndexOf("e"));
+    }
+
+    [Fact]
+    public void G2b_ReverseTraverseKeepsEBeforeDWhenAEdgesReordered()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("c", null), new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+        var order = CollectOrder(graph, reverse: true);
+        Assert.Equal("e", order[0]);
+        Assert.True(order.IndexOf("e") < order.IndexOf("d"));
+        Assert.True(order.IndexOf("e") < order.IndexOf("b"));
+        Assert.Equal("a", order[order.Count - 1]);
+    }
+
+    [Fact]
+    public void G3_TraverseVisitsSymmetricDiamond()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("d", null) },
+            ["c"] = new[] { new GraphEdge("d", null) }
+        });
+        Assert.Equal(new[] { "a", "b", "c", "d" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void G3_ReverseTraverseVisitsSymmetricDiamond()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("d", null) },
+            ["c"] = new[] { new GraphEdge("d", null) }
+        });
+        Assert.Equal(new[] { "d", "b", "c", "a" }, CollectOrder(graph, reverse: true));
+    }
+
+    [Fact]
+    public void G4_TraverseVisitsNestedParent()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("n", null) },
+            ["n"] = new[] { new GraphEdge("m", null), new GraphEdge("t", null) },
+            ["m"] = new[] { new GraphEdge("t", null) }
+        });
+        Assert.Equal(new[] { "a", "n", "m", "t" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void G4_ReverseTraverseVisitsNestedParent()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("n", null) },
+            ["n"] = new[] { new GraphEdge("m", null), new GraphEdge("t", null) },
+            ["m"] = new[] { new GraphEdge("t", null) }
+        });
+        Assert.Equal(new[] { "t", "m", "n", "a" }, CollectOrder(graph, reverse: true));
+    }
+
+    [Fact]
+    public void G5_TraverseVisitsMultiTerminal()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("d", null) }
+        });
+        Assert.Equal(new[] { "a", "b", "c", "d" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void G5_ReverseTraverseVisitsMultiTerminal()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("d", null) }
+        });
+        Assert.Equal(new[] { "c", "d", "b", "a" }, CollectOrder(graph, reverse: true));
+    }
+
+    [Fact]
+    public void G6_TraverseVisitsCycleDeterministically()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("c", null) },
+            ["c"] = new[] { new GraphEdge("b", null) }
+        });
+        var first = CollectOrder(graph, reverse: false);
+        var second = CollectOrder(graph, reverse: false);
+        Assert.Equal("a", first[0]);
+        Assert.Equal(3, first.Count);
+        Assert.Equal(new[] { "a", "b", "c" }, first.OrderBy(k => k).ToArray());
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void G6_ReverseTraverseVisitsCycleDeterministically()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("c", null) },
+            ["c"] = new[] { new GraphEdge("b", null) }
+        });
+        var first = CollectOrder(graph, reverse: true);
+        var second = CollectOrder(graph, reverse: true);
+        Assert.Equal("a", first[first.Count - 1]);
+        Assert.Equal(3, first.Count);
+        Assert.Equal(new[] { "a", "b", "c" }, first.OrderBy(k => k).ToArray());
+        Assert.Equal(first, second);
+        Assert.Equal(new[] { "b", "c", "a" }, first);
+    }
+
+    [Fact]
+    public void G2_TraverseScopesContextToExactPredecessors()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+
+        var expected = new Dictionary<string, string[]>
+        {
+            ["a"] = Array.Empty<string>(),
+            ["b"] = new[] { "a" },
+            ["c"] = new[] { "a" },
+            ["d"] = new[] { "a", "c" },
+            ["e"] = new[] { "a", "b", "c", "d" }
+        };
+
+        graph.Traverse((node, ctx) =>
+        {
+            AssertExactContextKeys(ctx, expected[node.Key]);
+            if (node.Key == "b") Assert.False(ctx.ContainsKey("c"));
+            if (node.Key == "d") Assert.False(ctx.ContainsKey("b"));
+            return $"result-of-{node.Key}";
+        });
+    }
+
+    [Fact]
+    public void G2_ReverseTraverseScopesContextToExactDescendants()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+
+        var expected = new Dictionary<string, string[]>
+        {
+            ["a"] = new[] { "b", "c", "d", "e" },
+            ["b"] = new[] { "e" },
+            ["c"] = new[] { "d", "e" },
+            ["d"] = new[] { "e" },
+            ["e"] = Array.Empty<string>()
+        };
+
+        graph.ReverseTraverse((node, ctx) =>
+        {
+            AssertExactContextKeys(ctx, expected[node.Key]);
+            if (node.Key == "b" || node.Key == "d")
+                Assert.False(ctx.ContainsKey("c"));
+            return $"result-of-{node.Key}";
+        });
+    }
+
+    [Fact]
+    public void G2b_TraverseContextScopingIndependentOfEdgeOrder()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("c", null), new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+
+        var expected = new Dictionary<string, string[]>
+        {
+            ["a"] = Array.Empty<string>(),
+            ["b"] = new[] { "a" },
+            ["c"] = new[] { "a" },
+            ["d"] = new[] { "a", "c" },
+            ["e"] = new[] { "a", "b", "c", "d" }
+        };
+
+        graph.Traverse((node, ctx) =>
+        {
+            AssertExactContextKeys(ctx, expected[node.Key]);
+            return $"result-of-{node.Key}";
+        });
+    }
+
+    [Fact]
+    public void TraverseIncludesInitialContextAlongsideScopedPredecessors()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+
+        var expectedDeps = new Dictionary<string, string[]>
+        {
+            ["a"] = Array.Empty<string>(),
+            ["b"] = new[] { "a" },
+            ["c"] = new[] { "a" },
+            ["d"] = new[] { "a", "c" },
+            ["e"] = new[] { "a", "b", "c", "d" }
+        };
+
+        graph.Traverse((node, ctx) =>
+        {
+            var expectedKeys = new List<string>(expectedDeps[node.Key]) { "seed" };
+            AssertExactContextKeys(ctx, expectedKeys);
+            Assert.Equal("value", ctx["seed"]);
+            return $"result-of-{node.Key}";
+        }, new Dictionary<string, object> { ["seed"] = "value" });
+    }
+
+    [Fact]
+    public void TraverseVisitsSelfLoopOnce()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("a", null) }
+        });
+        Assert.Equal(new[] { "a" }, CollectOrder(graph, reverse: false));
+    }
+
+    [Fact]
+    public void TraverseAndReverseTraverseAreDeterministic()
+    {
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+            ["b"] = new[] { new GraphEdge("e", null) },
+            ["c"] = new[] { new GraphEdge("d", null) },
+            ["d"] = new[] { new GraphEdge("e", null) }
+        });
+        Assert.Equal(CollectOrder(graph, reverse: false), CollectOrder(graph, reverse: false));
+        Assert.Equal(CollectOrder(graph, reverse: true), CollectOrder(graph, reverse: true));
     }
 }

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -490,7 +490,7 @@ public class AgentGraphDefinitionTest
         };
 
     /// <summary>
-    /// Canonical G1–G6/G2b vectors from sdk-specs test-vectors/vectors.json:
+    /// Canonical G1–G6/G2b agent-graph traversal vectors, shared across the LaunchDarkly AI SDKs:
     /// order plus exact traverse_context / reverse_traverse_context.
     /// </summary>
     public static IEnumerable<object[]> Vectors()

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -913,6 +913,34 @@ public class AgentGraphDefinitionTest
     }
 
     [Fact]
+    public void SelfLoopIsNotIncludedInOwnContext()
+    {
+        // a → b → b (self-loop on b)
+        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
+        {
+            ["a"] = new[] { new GraphEdge("b", null) },
+            ["b"] = new[] { new GraphEdge("b", null) }
+        });
+        var initial = new Dictionary<string, object> { ["seed"] = 1 };
+
+        graph.Traverse((node, ctx) =>
+        {
+            if (node.Key == "b")
+                AssertExactContextKeys(ctx, new[] { "seed", "a" });
+            return $"result-of-{node.Key}";
+        }, initial);
+
+        graph.ReverseTraverse((node, ctx) =>
+        {
+            if (node.Key == "b")
+                AssertExactContextKeys(ctx, new[] { "seed" });
+            if (node.Key == "a")
+                AssertExactContextKeys(ctx, new[] { "seed", "b" });
+            return $"result-of-{node.Key}";
+        }, initial);
+    }
+
+    [Fact]
     public void TraverseAndReverseTraverseAreDeterministic()
     {
         var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>

--- a/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
+++ b/pkgs/sdk/server-ai/test/AgentGraphDefinitionTest.cs
@@ -469,6 +469,225 @@ public class AgentGraphDefinitionTest
         Assert.Equal(expectedSorted, actual);
     }
 
+    private static readonly Dictionary<string, string[]> G2ForwardContext =
+        new Dictionary<string, string[]>
+        {
+            ["a"] = Array.Empty<string>(),
+            ["b"] = new[] { "a" },
+            ["c"] = new[] { "a" },
+            ["d"] = new[] { "a", "c" },
+            ["e"] = new[] { "a", "b", "c", "d" }
+        };
+
+    private static readonly Dictionary<string, string[]> G2ReverseContext =
+        new Dictionary<string, string[]>
+        {
+            ["a"] = new[] { "b", "c", "d", "e" },
+            ["b"] = new[] { "e" },
+            ["c"] = new[] { "d", "e" },
+            ["d"] = new[] { "e" },
+            ["e"] = Array.Empty<string>()
+        };
+
+    /// <summary>
+    /// Canonical G1–G6/G2b vectors from sdk-specs test-vectors/vectors.json:
+    /// order plus exact traverse_context / reverse_traverse_context.
+    /// </summary>
+    public static IEnumerable<object[]> Vectors()
+    {
+        yield return new object[]
+        {
+            "G1",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null) },
+                ["b"] = new[] { new GraphEdge("c", null) }
+            },
+            new[] { "a", "b", "c" },
+            new[] { "c", "b", "a" },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = Array.Empty<string>(),
+                ["b"] = new[] { "a" },
+                ["c"] = new[] { "a", "b" }
+            },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = new[] { "b", "c" },
+                ["b"] = new[] { "c" },
+                ["c"] = Array.Empty<string>()
+            }
+        };
+        yield return new object[]
+        {
+            "G2",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+                ["b"] = new[] { new GraphEdge("e", null) },
+                ["c"] = new[] { new GraphEdge("d", null) },
+                ["d"] = new[] { new GraphEdge("e", null) }
+            },
+            new[] { "a", "b", "c", "d", "e" },
+            new[] { "e", "b", "d", "c", "a" },
+            G2ForwardContext,
+            G2ReverseContext
+        };
+        yield return new object[]
+        {
+            "G2b",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("c", null), new GraphEdge("b", null) },
+                ["b"] = new[] { new GraphEdge("e", null) },
+                ["c"] = new[] { new GraphEdge("d", null) },
+                ["d"] = new[] { new GraphEdge("e", null) }
+            },
+            new[] { "a", "c", "b", "d", "e" },
+            new[] { "e", "b", "d", "c", "a" },
+            G2ForwardContext,
+            G2ReverseContext
+        };
+        yield return new object[]
+        {
+            "G3",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+                ["b"] = new[] { new GraphEdge("d", null) },
+                ["c"] = new[] { new GraphEdge("d", null) }
+            },
+            new[] { "a", "b", "c", "d" },
+            new[] { "d", "b", "c", "a" },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = Array.Empty<string>(),
+                ["b"] = new[] { "a" },
+                ["c"] = new[] { "a" },
+                ["d"] = new[] { "a", "b", "c" }
+            },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = new[] { "b", "c", "d" },
+                ["b"] = new[] { "d" },
+                ["c"] = new[] { "d" },
+                ["d"] = Array.Empty<string>()
+            }
+        };
+        yield return new object[]
+        {
+            "G4",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("n", null) },
+                ["n"] = new[] { new GraphEdge("m", null), new GraphEdge("t", null) },
+                ["m"] = new[] { new GraphEdge("t", null) }
+            },
+            new[] { "a", "n", "m", "t" },
+            new[] { "t", "m", "n", "a" },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = Array.Empty<string>(),
+                ["n"] = new[] { "a" },
+                ["m"] = new[] { "a", "n" },
+                ["t"] = new[] { "a", "m", "n" }
+            },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = new[] { "m", "n", "t" },
+                ["n"] = new[] { "m", "t" },
+                ["m"] = new[] { "t" },
+                ["t"] = Array.Empty<string>()
+            }
+        };
+        yield return new object[]
+        {
+            "G5",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
+                ["b"] = new[] { new GraphEdge("d", null) }
+            },
+            new[] { "a", "b", "c", "d" },
+            new[] { "c", "d", "b", "a" },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = Array.Empty<string>(),
+                ["b"] = new[] { "a" },
+                ["c"] = new[] { "a" },
+                ["d"] = new[] { "a", "b" }
+            },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = new[] { "b", "c", "d" },
+                ["b"] = new[] { "d" },
+                ["c"] = Array.Empty<string>(),
+                ["d"] = Array.Empty<string>()
+            }
+        };
+        yield return new object[]
+        {
+            "G6",
+            "a",
+            new Dictionary<string, IReadOnlyList<GraphEdge>>
+            {
+                ["a"] = new[] { new GraphEdge("b", null) },
+                ["b"] = new[] { new GraphEdge("c", null) },
+                ["c"] = new[] { new GraphEdge("b", null) }
+            },
+            new[] { "a", "b", "c" },
+            new[] { "b", "c", "a" },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = Array.Empty<string>(),
+                ["b"] = new[] { "a" },
+                ["c"] = new[] { "a", "b" }
+            },
+            new Dictionary<string, string[]>
+            {
+                ["a"] = new[] { "b", "c" },
+                ["b"] = Array.Empty<string>(),
+                ["c"] = new[] { "b" }
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Vectors))]
+    public void VectorTraversalOrderAndContext(
+        string id,
+        string root,
+        Dictionary<string, IReadOnlyList<GraphEdge>> edges,
+        string[] traverse,
+        string[] reverseTraverse,
+        Dictionary<string, string[]> forwardContext,
+        Dictionary<string, string[]> reverseContext)
+    {
+        Assert.NotNull(id);
+        var graph = BuildGraph(root, edges);
+
+        Assert.Equal(traverse, CollectOrder(graph, reverse: false));
+        Assert.Equal(reverseTraverse, CollectOrder(graph, reverse: true));
+
+        graph.Traverse((node, ctx) =>
+        {
+            AssertExactContextKeys(ctx, forwardContext[node.Key]);
+            return $"result-of-{node.Key}";
+        });
+
+        graph.ReverseTraverse((node, ctx) =>
+        {
+            AssertExactContextKeys(ctx, reverseContext[node.Key]);
+            return $"result-of-{node.Key}";
+        });
+    }
+
     [Fact]
     public void G1_TraverseVisitsLinearChain()
     {
@@ -652,91 +871,6 @@ public class AgentGraphDefinitionTest
         Assert.Equal(new[] { "a", "b", "c" }, first.OrderBy(k => k).ToArray());
         Assert.Equal(first, second);
         Assert.Equal(new[] { "b", "c", "a" }, first);
-    }
-
-    [Fact]
-    public void G2_TraverseScopesContextToExactPredecessors()
-    {
-        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
-        {
-            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
-            ["b"] = new[] { new GraphEdge("e", null) },
-            ["c"] = new[] { new GraphEdge("d", null) },
-            ["d"] = new[] { new GraphEdge("e", null) }
-        });
-
-        var expected = new Dictionary<string, string[]>
-        {
-            ["a"] = Array.Empty<string>(),
-            ["b"] = new[] { "a" },
-            ["c"] = new[] { "a" },
-            ["d"] = new[] { "a", "c" },
-            ["e"] = new[] { "a", "b", "c", "d" }
-        };
-
-        graph.Traverse((node, ctx) =>
-        {
-            AssertExactContextKeys(ctx, expected[node.Key]);
-            if (node.Key == "b") Assert.False(ctx.ContainsKey("c"));
-            if (node.Key == "d") Assert.False(ctx.ContainsKey("b"));
-            return $"result-of-{node.Key}";
-        });
-    }
-
-    [Fact]
-    public void G2_ReverseTraverseScopesContextToExactDescendants()
-    {
-        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
-        {
-            ["a"] = new[] { new GraphEdge("b", null), new GraphEdge("c", null) },
-            ["b"] = new[] { new GraphEdge("e", null) },
-            ["c"] = new[] { new GraphEdge("d", null) },
-            ["d"] = new[] { new GraphEdge("e", null) }
-        });
-
-        var expected = new Dictionary<string, string[]>
-        {
-            ["a"] = new[] { "b", "c", "d", "e" },
-            ["b"] = new[] { "e" },
-            ["c"] = new[] { "d", "e" },
-            ["d"] = new[] { "e" },
-            ["e"] = Array.Empty<string>()
-        };
-
-        graph.ReverseTraverse((node, ctx) =>
-        {
-            AssertExactContextKeys(ctx, expected[node.Key]);
-            if (node.Key == "b" || node.Key == "d")
-                Assert.False(ctx.ContainsKey("c"));
-            return $"result-of-{node.Key}";
-        });
-    }
-
-    [Fact]
-    public void G2b_TraverseContextScopingIndependentOfEdgeOrder()
-    {
-        var graph = BuildGraph("a", new Dictionary<string, IReadOnlyList<GraphEdge>>
-        {
-            ["a"] = new[] { new GraphEdge("c", null), new GraphEdge("b", null) },
-            ["b"] = new[] { new GraphEdge("e", null) },
-            ["c"] = new[] { new GraphEdge("d", null) },
-            ["d"] = new[] { new GraphEdge("e", null) }
-        });
-
-        var expected = new Dictionary<string, string[]>
-        {
-            ["a"] = Array.Empty<string>(),
-            ["b"] = new[] { "a" },
-            ["c"] = new[] { "a" },
-            ["d"] = new[] { "a", "c" },
-            ["e"] = new[] { "a", "b", "c", "d" }
-        };
-
-        graph.Traverse((node, ctx) =>
-        {
-            AssertExactContextKeys(ctx, expected[node.Key]);
-            return $"result-of-{node.Key}";
-        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes `AgentGraphDefinition` traversal **topological** and gives each visitor a **dependency-scoped
execution context**, aligning the traversal behavior across the LaunchDarkly AI SDKs.

Previously `Traverse` / `ReverseTraverse` were plain BFS over a single shared, accumulating context
dictionary. That had two problems:

1. **Ordering:** where branches of unequal length converge, the convergence node ran on first
   discovery — before all of its predecessors had run.
2. **Context leakage & mutation:** every callback saw the results of *all* previously-visited nodes
   (including unrelated parallel branches), and results were written back into the caller's
   `initialContext`.

## What changed

`pkgs/sdk/server-ai` — `Graph/AgentGraphDefinition.cs` only (no public API/signature changes):

- **`Traverse`** now visits a node only after **all of its reachable predecessors** have been visited
  (Kahn over in-degree; the root is always released first). On cycles, the unvisited node with the
  lowest remaining in-degree is chosen next, ties broken by discovery order.
- **`ReverseTraverse`** now visits a node only after **all of its reachable descendants** have been
  visited, so the root is visited **last** (Kahn over out-degree, root excluded from cycle-break
  selection). Pure cycles now visit every node instead of being a no-op.
- **Scoped context:** each callback receives a fresh dictionary = `initialContext` plus only that
  node's true dependency results (transitive ancestors forward / descendants reverse). Results are
  kept in a private map keyed by node; unrelated branches and self-loops are excluded, and the
  caller's dictionary is never mutated. Cross-node data flows only through callback return values.
- **Determinism:** discovery order is the graph's BFS encounter order (root first, then declared edge
  order), used only for tie-breaks. Ready-check uses `== 0` to match the reference algorithm and the
  other SDKs.

```csharp
void Traverse(Func<AgentGraphNode, Dictionary<string, object>, object> fn,
              Dictionary<string, object> initialContext = null);
```

## Behavior change (breaking)

Titled `fix!` because visit order and callback-context contents change for graphs with convergent
paths, cycles, or parallel branches. Simple linear graphs are unaffected. Cross-SDK parity with
JS/Python/.NET/Java.

## Tests

- A data-driven test over the canonical cross-SDK vectors `G1`–`G6` (+`G2b`) asserts **exact** visit
  order **and exact** context keys in both directions.
- Convergence runs the shared node last; pure cycle visits all nodes (root last); caller context not
  mutated; unrelated branches excluded; self-loop excluded from its own context; deterministic across
  runs.

## Notes

- No manual `CHANGELOG.md` edit — release-please generates it from the conventional-commit title.
- Graph tracking / wire parsing unchanged; this PR is scoped to traversal + context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **`Traverse` and `ReverseTraverse`** on `AgentGraphDefinition` no longer use plain BFS over one shared, mutating context dictionary. They now visit reachable nodes in **topological order** (predecessors first forward; descendants first backward, **root last** on reverse), with **cycle-safe** tie-breaking from BFS discovery order.
> 
> Each callback gets a **scoped** dictionary: `initialContext` plus only that node’s true dependency results (transitive ancestors or descendants). Node outputs live in a private map; unrelated parallel branches and self-loops are excluded, and the caller’s `initialContext` is not mutated.
> 
> **Breaking:** visit order and context keys change for convergent paths, cycles, and parallel branches; linear chains stay the same. Aligns traversal with other LaunchDarkly AI SDKs.
> 
> Tests add canonical **G1–G6 / G2b** vectors asserting exact order and context keys in both directions, plus updated cycle and scoped-context expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12826ecb9cfef24410c13fb04287d6fe58e75f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->