### PR TITLE
fix: restore client SDK CI to macos-latest with Xcode 26.3 and Android 34 install (SDK-2623)

### DIFF
--- a/.github/actions/xcode-select/action.yml
+++ b/.github/actions/xcode-select/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The version of Xcode to select'
     required: true
-    default: '16.2'
+    default: '26.3'
 
 runs:
   using: composite

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           dotnet-version: 8.0
 
+      - name: Copy global.json in place
+        shell: bash
+        run: cp global.example.json global.json
+
       - name: Restore workloads
         shell: bash
         run: dotnet workload restore ${{ env.PROJECT_FILE }}

--- a/.github/workflows/release-sdk-client.yml
+++ b/.github/workflows/release-sdk-client.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 # Building is done on mac runner due to xcode build dependencies
   build:
-    runs-on: macos-15
+    runs-on: macos-latest
     permissions:
       id-token: write
       contents: write
@@ -28,11 +28,28 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash
         run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0
+
+      - name: Restore workloads
+        shell: bash
+        run: dotnet workload restore ${{ env.PROJECT_FILE }}
+
+      # The macOS runner image no longer ships the API level 34 platform.
+      - name: Install Android SDK dependencies
+        shell: bash
+        run: >
+          dotnet build ${{ env.PROJECT_FILE }} -f net8.0-android -t:InstallAndroidDependencies
+          -p:AndroidSdkDirectory="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+          -p:AcceptAndroidSDKLicenses=True
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: Get secrets
@@ -112,7 +129,7 @@ jobs:
 
 # Packing is done on Mac due to ios workload requirements.
   publish:
-    runs-on: macos-15
+    runs-on: macos-latest
     needs: sign-dlls
     permissions:
       id-token: write
@@ -123,7 +140,7 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash

--- a/.github/workflows/sdk-client-ci.yml
+++ b/.github/workflows/sdk-client-ci.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           dotnet-version: 8.0
 
+      - name: Copy global.json in place
+        shell: bash
+        run: cp global.example.json global.json
+
       - name: Restore workloads
         shell: bash
         run: dotnet workload restore ${{ env.PROJECT_FILE }}

--- a/.github/workflows/sdk-client-ci.yml
+++ b/.github/workflows/sdk-client-ci.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [macos-15]
+        os: [macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:
@@ -24,11 +24,28 @@ jobs:
 
       - uses: ./.github/actions/xcode-select
         with:
-          xcode-version: '16.2'
+          xcode-version: '26.3'
 
       - name: Setup Env from project's Env file
         shell: bash
         run: echo "$(cat pkgs/sdk/client/github_actions.env)" >> $GITHUB_ENV
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0
+
+      - name: Restore workloads
+        shell: bash
+        run: dotnet workload restore ${{ env.PROJECT_FILE }}
+
+      # The macOS runner image no longer ships the API level 34 platform.
+      - name: Install Android SDK dependencies
+        shell: bash
+        run: >
+          dotnet build ${{ env.PROJECT_FILE }} -f net8.0-android -t:InstallAndroidDependencies
+          -p:AndroidSdkDirectory="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+          -p:AcceptAndroidSDKLicenses=True
 
       - uses: ./.github/actions/ci
         with:


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
ci: restore client SDK CI to macos-latest with Xcode 26.3 and Android 34 install (SDK-2623)
END_COMMIT_OVERRIDE

## Summary

Reverts the interim \`macos-15\` pin from #302 and addresses the two underlying issues that made the pin necessary. The client SDK CI moves back onto \`macos-latest\`.

Two issues break the client SDK CI when the runner lands on macOS 26 (the new \`macos-latest\`):

1. **Xcode 16.2 not present on macOS 26.** \`macos-latest\` began migrating to macOS 26 on June 15, 2026. That image ships only Xcode 26.x. The client SDK's \`./.github/actions/xcode-select\` step tries to switch to \`/Applications/Xcode_16.2.app\` and fails immediately.
2. **Android SDK Platform 34 no longer preinstalled on macos-latest.** The runner-image rolling window aged out API 34; \`net8.0-android\` builds fail with \`XA5207: Could not find android.jar for API level 34\`.

## Changes

- \`.github/actions/xcode-select/action.yml\`: default \`xcode-version\` \`16.2\` → \`26.3\`. Xcode 26.3 is present on both \`macos-latest\` (macOS 26) and \`macos-15\` (fallback) per the current runner-image manifests.
- \`.github/workflows/sdk-client-ci.yml\`: matrix \`os: [macos-15]\` → \`[macos-latest]\`; explicit \`xcode-version\` \`'16.2'\` → \`'26.3'\`; add \`Setup .NET\` + \`Restore workloads\` + \`Install Android SDK dependencies\` steps before the shared \`./.github/actions/ci\` composite.
- \`.github/workflows/release-sdk-client.yml\`: same three-step block added to the \`build\` job; both \`build\` and \`publish\` jobs move from \`macos-15\` → \`macos-latest\` and bump their explicit \`xcode-version\` to \`26.3\`. The \`publish\` job doesn't get the Android install step because it runs \`dotnet pack --no-build\` and doesn't recompile.

The Android install step follows the same pattern as launchdarkly/hello-dotnet-client#21, invoking the .NET Android workload's \`InstallAndroidDependencies\` MSBuild target so the workload itself declares which platform components it needs. Scoped to the two client-SDK workflows only — not added to the shared \`./.github/actions/ci\` composite that other SDKs use, since only the client SDK builds \`net8.0-android\`.

## Notes

- Release-please commit override at the top of this description reclassifies the merged commit from \`fix:\` to \`ci:\`, since this is a CI/build-infrastructure change only and should not trigger a patch release of any published SDK package.
- The \`net8.0-android\` target defaults to API 34 via the .NET 8 Android workload manifest, which Microsoft only ships in the \`8.0.100\` feature-band (capped at \`34.0.154\`). Moving to API 35+ would require bumping the SDK's TargetFramework to \`net9.0-android\` — a customer-facing .NET major bump. Deferred; this PR is the pragmatic unblock.

## Test plan

- [x] YAML validated locally with \`YAML.load_file\`.
- [ ] Watch \`macos-latest\` CI on this PR to confirm \`xcode-select\`, workload restore, Android install, and downstream build all succeed.
- [ ] Once merged, confirm subsequent release-please PRs from server-side SDKs no longer fail on the client-SDK required check.