### PR TITLE
chore: Repair DebugLocalReferences and link common/internal locally

### DIFF
--- a/DotnetCore.sln
+++ b/DotnetCore.sln
@@ -59,16 +59,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.ServerSdk.SharedTests.Tests", "pkgs\shared\dotnet-server-sdk-shared-tests\test\LaunchDarkly.ServerSdk.SharedTests.Tests.csproj", "{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "server-ai", "server-ai", "{EF541D97-2C23-4FB8-BD87-ADFDF0FF83F3}"
-	ProjectSection(SolutionItems) = preProject
-		pkgs\sdk\server-ai\test\LaunchDarkly.ServerSdk.Ai.Tests.csproj = pkgs\sdk\server-ai\test\LaunchDarkly.ServerSdk.Ai.Tests.csproj
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.ServerSdk.Ai", "pkgs\sdk\server-ai\src\LaunchDarkly.ServerSdk.Ai.csproj", "{561F6F3D-09C5-470A-83AC-F0E97BAD609B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "telemetry", "telemetry", "{FF3153CA-F727-4666-BA1E-5459BE34FBAB}"
-	ProjectSection(SolutionItems) = preProject
-		pkgs\telemetry\test\LaunchDarkly.ServerSdk.Telemetry.Tests.csproj = pkgs\telemetry\test\LaunchDarkly.ServerSdk.Telemetry.Tests.csproj
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.ServerSdk.Telemetry", "pkgs\telemetry\src\LaunchDarkly.ServerSdk.Telemetry.csproj", "{DE321396-6459-4C02-AF61-1A2677A7CB65}"
 EndProject
@@ -89,6 +83,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.InternalSdk", "pkgs\shared\internal\src\LaunchDarkly.InternalSdk.csproj", "{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.InternalSdk.Tests", "pkgs\shared\internal\test\LaunchDarkly.InternalSdk.Tests.csproj", "{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.ServerSdk.Ai.Tests", "pkgs\sdk\server-ai\test\LaunchDarkly.ServerSdk.Ai.Tests.csproj", "{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.ServerSdk.Telemetry.Tests", "pkgs\telemetry\test\LaunchDarkly.ServerSdk.Telemetry.Tests.csproj", "{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -130,32 +128,34 @@ Global
 		{B19B9B2A-CCE2-4FA7-824E-7140F2E13E87} = {E2905C95-49E1-4194-88DD-B30AA68EEF98}
 		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2} = {B19B9B2A-CCE2-4FA7-824E-7140F2E13E87}
 		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2} = {B19B9B2A-CCE2-4FA7-824E-7140F2E13E87}
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61} = {EF541D97-2C23-4FB8-BD87-ADFDF0FF83F3}
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9} = {FF3153CA-F727-4666-BA1E-5459BE34FBAB}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{2D61D2EC-8D04-46E9-9E1B-1E029341F318}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{DB9C772D-00D1-47CD-940E-7D802D4FB59A}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{D1DF71E8-6037-4E35-813A-07F5A27153C2}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{A2733CF1-672F-41A8-8DF8-7340BF953457}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A2733CF1-672F-41A8-8DF8-7340BF953457}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A2733CF1-672F-41A8-8DF8-7340BF953457}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2733CF1-672F-41A8-8DF8-7340BF953457}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A2733CF1-672F-41A8-8DF8-7340BF953457}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{A2733CF1-672F-41A8-8DF8-7340BF953457}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{A2733CF1-672F-41A8-8DF8-7340BF953457}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{A2733CF1-672F-41A8-8DF8-7340BF953457}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{F91A1EFE-5411-4100-A2D1-7C8D72090F05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F91A1EFE-5411-4100-A2D1-7C8D72090F05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F91A1EFE-5411-4100-A2D1-7C8D72090F05}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -166,14 +166,14 @@ Global
 		{14026C03-B639-459C-8E23-B99E2FB68C10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{14026C03-B639-459C-8E23-B99E2FB68C10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{14026C03-B639-459C-8E23-B99E2FB68C10}.Release|Any CPU.Build.0 = Release|Any CPU
-		{14026C03-B639-459C-8E23-B99E2FB68C10}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{14026C03-B639-459C-8E23-B99E2FB68C10}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{14026C03-B639-459C-8E23-B99E2FB68C10}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{14026C03-B639-459C-8E23-B99E2FB68C10}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{73F7605E-9D64-4719-9DBB-77DFD5E06BE5}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{1D41FF94-B814-4FF3-A565-518DC9759140}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1D41FF94-B814-4FF3-A565-518DC9759140}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D41FF94-B814-4FF3-A565-518DC9759140}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -184,14 +184,14 @@ Global
 		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{540B751E-41AE-4D7C-9715-57BA5C97DAD7}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{A543C2DE-42AB-4E2F-85DC-F6BEC77E7695}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{06C06727-7A8F-417E-9164-5C70AD96A94F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{06C06727-7A8F-417E-9164-5C70AD96A94F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06C06727-7A8F-417E-9164-5C70AD96A94F}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -202,8 +202,8 @@ Global
 		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.Release|Any CPU.Build.0 = Release|Any CPU
-		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{537C0A25-938B-4B6D-B7BA-ED16DC0F5B11}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{CC8B417E-30D6-4654-BB6A-0BC9433CDE8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CC8B417E-30D6-4654-BB6A-0BC9433CDE8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC8B417E-30D6-4654-BB6A-0BC9433CDE8C}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -214,8 +214,8 @@ Global
 		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{DC897FFA-36AA-4863-B23F-0ECEF5D17839}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{F6FFC943-F464-4E36-B07D-EB16D5DF6D32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F6FFC943-F464-4E36-B07D-EB16D5DF6D32}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6FFC943-F464-4E36-B07D-EB16D5DF6D32}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -226,8 +226,8 @@ Global
 		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{8C027074-CF8D-437F-9CE8-0F8180E496AA}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{ED864025-2BDC-4AED-8A53-FAB852772132}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED864025-2BDC-4AED-8A53-FAB852772132}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED864025-2BDC-4AED-8A53-FAB852772132}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -238,8 +238,8 @@ Global
 		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{8C9BDA1A-6AB3-4B52-8CBB-6B702FABC292}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{561F6F3D-09C5-470A-83AC-F0E97BAD609B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{561F6F3D-09C5-470A-83AC-F0E97BAD609B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{561F6F3D-09C5-470A-83AC-F0E97BAD609B}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
@@ -260,15 +260,27 @@ Global
 		{A10B580F-D937-4EA8-8CF8-4F130FBF6C16}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF4400E1-3831-4E28-AB05-F9B93FF9E2B2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.DebugLocalReferences|Any CPU.ActiveCfg = Debug|Any CPU
-		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.DebugLocalReferences|Any CPU.Build.0 = Debug|Any CPU
+		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
 		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F66CD4A8-9DE2-498B-BBA2-B24E9955D1F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B7A1C42-6E58-4D0A-9F13-7C2E5A9B4D61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.DebugLocalReferences|Any CPU.ActiveCfg = DebugLocalReferences|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.DebugLocalReferences|Any CPU.Build.0 = DebugLocalReferences|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D4E2F08-5B31-47C6-8A72-1E6D3F80B5A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -49,13 +49,23 @@
     <ItemGroup>
         <Folder Include="Properties\"/>
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"/>
-        <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0"/>
         <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.2"/>
-        <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.7.0" />
         <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0"/>
         <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.100" />
         <Compile Include="**\*.cs" Exclude="PlatformSpecific\*.cs;bin\**\*.cs;obj\**\*.cs"/>
         <Compile Include="PlatformSpecific\*.shared.cs"/>
+    </ItemGroup>
+
+    <!-- Use PackageReference in Debug/Release -->
+    <ItemGroup Condition="'$(Configuration)' != 'DebugLocalReferences'">
+        <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0"/>
+        <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.7.0" />
+    </ItemGroup>
+
+    <!-- Use ProjectReference in DebugLocalReferences -->
+    <ItemGroup Condition="'$(Configuration)' == 'DebugLocalReferences'">
+        <ProjectReference Include="../../../shared/common/src/LaunchDarkly.CommonSdk.csproj" />
+        <ProjectReference Include="../../../shared/internal/src/LaunchDarkly.InternalSdk.csproj" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">

--- a/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
+++ b/pkgs/sdk/server/src/LaunchDarkly.ServerSdk.csproj
@@ -46,10 +46,20 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1" />
-    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.10.0" />
     <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0" />
+  </ItemGroup>
+
+  <!-- Use PackageReference in Debug/Release -->
+  <ItemGroup Condition="'$(Configuration)' != 'DebugLocalReferences'">
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0" />
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.10.0" />
+  </ItemGroup>
+
+  <!-- Use ProjectReference in DebugLocalReferences -->
+  <ItemGroup Condition="'$(Configuration)' == 'DebugLocalReferences'">
+    <ProjectReference Include="../../../shared/common/src/LaunchDarkly.CommonSdk.csproj" />
+    <ProjectReference Include="../../../shared/internal/src/LaunchDarkly.InternalSdk.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">

--- a/pkgs/shared/internal/src/LaunchDarkly.InternalSdk.csproj
+++ b/pkgs/shared/internal/src/LaunchDarkly.InternalSdk.csproj
@@ -25,6 +25,12 @@
     <PackageProjectUrl>https://github.com/launchdarkly/dotnet-core</PackageProjectUrl>
     <RepositoryUrl>https://github.com/launchdarkly/dotnet-core</RepositoryUrl>
     <RepositoryBranch>main</RepositoryBranch>
+    <Configurations>Debug;Release;DebugLocalReferences</Configurations>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'DebugLocalReferences'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
@@ -32,8 +38,36 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="[7.2.0,8.0.0)" />
     <PackageReference Include="LaunchDarkly.Logging" Version="[2.0.0,3.0.0)" />
+  </ItemGroup>
+
+  <!-- Use PackageReference in Debug/Release -->
+  <ItemGroup Condition="'$(Configuration)' != 'DebugLocalReferences'">
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="[7.2.0,8.0.0)" />
+  </ItemGroup>
+
+  <!-- Use ProjectReference in DebugLocalReferences -->
+  <ItemGroup Condition="'$(Configuration)' == 'DebugLocalReferences'">
+    <ProjectReference Include="../../common/src/LaunchDarkly.CommonSdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\CHANGELOG.md">
+      <Link>CHANGELOG.md</Link>
+      <Pack>false</Pack>
+    </None>
+    <None Include="..\CONTRIBUTING.md">
+      <Link>CONTRIBUTING.md</Link>
+      <Pack>false</Pack>
+    </None>
+    <None Include="..\docfx.json">
+      <Link>docfx.json</Link>
+      <Pack>false</Pack>
+    </None>
+    <None Include="..\README.md">
+      <Link>README.md</Link>
+      <Pack>false</Pack>
+    </None>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
SDK-2866

#213 added a `DebugLocalReferences` build configuration so in-repo packages link to each other by `ProjectReference` instead of NuGet. It could only be applied partially at the time — quoting that PR:

> It cannot yet link common locally because of its use by internal. Once internal is added to the solution it can be extended.

Internal is now in the monorepo, so the remaining work can be finished. Reviewing #213 also turned up two defects that are broken on `main` today.

Four files. No production-facing change: package metadata, dependency versions, and the Debug/Release dependency graphs are untouched.

## 1. `DebugLocalReferences` has never built, since #213 landed

```
dotnet build DotnetCore.sln -c DebugLocalReferences   →  120 errors
```

Confirmed by checking out #213's own merge commit and building it there — same 120 errors, same project, same error codes. It shipped untested; nothing later broke it.

All errors are in `LaunchDarkly.ServerSdk.SharedTests`:

```
CS0433: The type 'IBigSegmentStore' exists in both
  'LaunchDarkly.ServerSdk, Version=7.0.0.0' and
  'LaunchDarkly.ServerSdk, Version=8.16.0.0'
```

The cause is in `DotnetCore.sln`, not the project files. 28 of the `DebugLocalReferences` entries mapped to `Debug|Any CPU` — including `LaunchDarkly.ServerSdk.SharedTests.Tests`, which project-references `SharedTests`. `SharedTests` was therefore restored under *both* configurations into a single `obj/project.assets.json`. The `Debug` pass won and left the NuGet `LaunchDarkly.ServerSdk 7.0.0-alpha.3` in the dependency graph; the compile then ran as `DebugLocalReferences` and added the local project reference on top, putting both assemblies in scope.

Every project in the dependency closure now maps to `DebugLocalReferences`.

## 2. Two test projects were never built by the solution

`LaunchDarkly.ServerSdk.Ai.Tests` and `LaunchDarkly.ServerSdk.Telemetry.Tests` were attached to the solution as `ProjectSection(SolutionItems)` entries under the `server-ai` and `telemetry` folders instead of as `Project(...)` entries, so `dotnet build DotnetCore.sln` skipped them entirely.

This dates to #201, the commit that created the solution — every other test project was added as a real project there; these two are the only exceptions, and they're also the only two solution folders carrying a `SolutionItems` block. Both are now real projects. They pass (241 and 21 tests) — they hadn't rotted, just been invisible to the solution. The per-package CI workflows have been covering them all along, which is why nobody noticed.

## 3. Internal now participates in `DebugLocalReferences`

`LaunchDarkly.InternalSdk.csproj` gains the `<Configurations>` property, the `DEBUG;TRACE` define, a conditional `ProjectReference` to common, and the linked repo docs (README / CHANGELOG / CONTRIBUTING / docfx.json) its siblings already had.

The `DEBUG` define is load-bearing: `pkgs/shared/internal/src/AssemblyInfo.cs` wraps its `InternalsVisibleTo` in `#if DEBUG`, which is why every other project in #213 received that same `DefineConstants` override.

## 4. Server and client SDKs link common and internal locally

Both used NuGet packages for `LaunchDarkly.CommonSdk` and `LaunchDarkly.InternalSdk` in every configuration, so a change to either shared package couldn't be validated against the SDKs without publishing. They now use a `ProjectReference` under `DebugLocalReferences` and keep the `PackageReference` for Debug and Release.

## Verification

Run in freshly-created worktrees at this commit, one per configuration, so no prior build artifacts could affect the result.

| Check | Result |
|---|---|
| `dotnet build DotnetCore.sln -c DebugLocalReferences` | 0 errors (was 120) |
| `dotnet build DotnetCore.sln -c Debug` | 0 errors |
| ServerSdk / ClientSdk / InternalSdk refs under `DebugLocalReferences` | `CommonSdk`, `InternalSdk` → `project` |
| Same under `Debug` | → `package`, versions unchanged |
| `LaunchDarkly.ServerSdk.Tests` | 1595 passed |
| `LaunchDarkly.CommonSdk.Tests` | 273 passed |
| `LaunchDarkly.ServerSdk.Ai.Tests` | 241 passed |
| `LaunchDarkly.InternalSdk.Tests` | 180 passed |
| `LaunchDarkly.ServerSdk.Telemetry.Tests` | 21 passed |

`Release` fails locally on `CS7027` missing `.snk` files, which is pre-existing on `main` — the signing keys are CI secrets.

One note for reviewers: because NuGet's assets file lives at `obj/project.assets.json` and is not per-configuration, switching between `Debug` and `DebugLocalReferences` requires a restore. `dotnet test --no-restore` right after building the other configuration will produce duplicate-type errors. IDEs restore on configuration switch, so this only bites scripted invocations.

## Follow-up

Not in this PR: the client SDK pins `LaunchDarkly.InternalSdk 3.7.0` while the repo builds 3.10.0. It compiles fine against 3.10.0 under the local configuration, but bumping the pin is a behavioral change and gets its own PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Makes `DebugLocalReferences` actually build and lets in-repo packages consume local `CommonSdk` / `InternalSdk` instead of NuGet.
> 
> **Solution mapping.** Many `DebugLocalReferences` entries in `DotnetCore.sln` were mapped to `Debug`, which mixed NuGet and project refs (duplicate types in SharedTests). Every project now maps to `DebugLocalReferences`. AI and Telemetry test projects are real solution projects instead of SolutionItems, so they participate in `dotnet build`.
> 
> **Local refs.** Client, server, and InternalSdk use `ProjectReference` to common/internal only under `DebugLocalReferences`; Debug/Release keep the existing PackageReferences. InternalSdk also gets the `DEBUG;TRACE` define and linked docs so `InternalsVisibleTo` works in that configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171bfdc9246e1c19f02b588f9e50ab99cf855b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->