### PR TITLE
fix: update LaunchDarkly.EventSource to 5.3.2 for MAUI Android SSE stall

### DIFF
--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -50,7 +50,7 @@
         <Folder Include="Properties\"/>
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"/>
         <PackageReference Include="LaunchDarkly.CommonSdk" Version="7.2.0"/>
-        <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.1"/>
+        <PackageReference Include="LaunchDarkly.EventSource" Version="5.3.2"/>
         <PackageReference Include="LaunchDarkly.InternalSdk" Version="3.7.0" />
         <PackageReference Include="LaunchDarkly.Logging" Version="2.0.0"/>
         <PackageReference Include="Microsoft.Maui.Essentials" Version="8.0.100" />


### PR DESCRIPTION
**Related issues**

- Fix PR in dotnet-eventsource: https://github.com/launchdarkly/dotnet-eventsource/pull/124
- 5.3.2 release notes: https://github.com/launchdarkly/dotnet-eventsource/releases/tag/5.3.2

**Describe the solution you've provided**

Bumps `LaunchDarkly.EventSource` from 5.3.1 to 5.3.2 in `LaunchDarkly.ClientSdk`. The 5.3.2 release increases the SSE read buffer from 1024 to 8192 bytes to bypass a stall in `Xamarin.Android.Net.AndroidMessageHandler`'s BufferedStream small-count code path, which caused MAUI Android consumers' SSE reads to block for ~60 s waiting for the next server keepalive.

The fix was validated end-to-end with a new sse-contract-tests payload-size sweep run against a .NET-for-Android build of the SSE test service in an Android emulator; the sweep flags every regression to a sub-4096-byte buffer.

**Describe alternatives you've considered**

- Working around the stall in-repo (e.g., swapping out `AndroidMessageHandler` for a different HTTP handler) was rejected as riskier than adjusting the buffer size at the SSE layer.
- The `ServerSdk` consumer of `LaunchDarkly.EventSource` is out of scope for this PR: the stall is Android-only, so bumping `ServerSdk` would be pure hygiene rather than a fix.

**Additional context**

- No API changes; single-line `PackageReference` version bump.
- Companion to previously merged #323, which addressed the network-connectivity side of the same customer-reported symptom.
- Verified locally that `LaunchDarkly.ClientSdk` builds cleanly against 5.3.2 for both `netstandard2.0` and `net8.0-android`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Bumps** `LaunchDarkly.EventSource` from **5.3.1** to **5.3.2** in `LaunchDarkly.ClientSdk` only (no API or source changes).
> 
> The newer EventSource release increases the SSE read buffer (1024 → 8192 bytes) so MAUI Android clients avoid long (~60s) stalls when `AndroidMessageHandler`’s buffered stream blocks on small reads until the next keepalive. `LaunchDarkly.ServerSdk` is intentionally left on 5.3.1 because the issue is Android-specific.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73204dfbb7855ff66fcb95355a33ead6cdaeffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->