### PR TITLE
fix: Correct nuget license format.

### DIFF
--- a/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
+++ b/pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj
@@ -25,7 +25,7 @@
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.ClientSdk.xml</DocumentationFile>
         <Company>LaunchDarkly</Company>
         <Copyright>Copyright 2020 LaunchDarkly</Copyright>
-        <LicenseExpression>Apache-2.0</LicenseExpression>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/launchdarkly/dotnet-core</PackageProjectUrl>
         <RepositoryUrl>https://github.com/launchdarkly/dotnet-core</RepositoryUrl>
         <RepositoryBranch>master</RepositoryBranch>

--- a/pkgs/shared/dotnet-server-sdk-shared-tests/src/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/pkgs/shared/dotnet-server-sdk-shared-tests/src/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -8,7 +8,7 @@
     <Description>LaunchDarkly .NET Shared Tests</Description>
     <Company>LaunchDarkly</Company>
     <Copyright>Copyright 2020 Catamorphic, Co.</Copyright>
-    <LicenseExpression>Apache-2.0</LicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RootNamespace>LaunchDarkly.Sdk.Server.SharedTests</RootNamespace>
     <Configurations>Debug;Release;DebugLocalReferences</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality (n/a — packaging metadata only)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe the solution you've provided**

Two csproj files set `<LicenseExpression>` instead of NuGet's `<PackageLicenseExpression>`. `LicenseExpression` is not a NuGet pack property, so it is silently ignored and the produced packages carry no license metadata.

```diff
- <LicenseExpression>Apache-2.0</LicenseExpression>
+ <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
```

Files changed:
- `pkgs/sdk/client/src/LaunchDarkly.ClientSdk.csproj`
- `pkgs/shared/dotnet-server-sdk-shared-tests/src/LaunchDarkly.ServerSdk.SharedTests.csproj`

Confirmed impact: the published `LaunchDarkly.ClientSdk` packages have an empty license on nuget.org (checked 5.9.2–5.9.4 via the NuGet registration API), while every other package in this repo (which already uses `PackageLicenseExpression`) reports `Apache-2.0`.

All other package-producing csproj files were audited and are already correct: ServerSdk, ServerSdk.Ai, ServerSdk.Telemetry, ServerSdk.Consul, ServerSdk.Redis, ServerSdk.DynamoDB, CommonSdk, CommonSdk.JsonNet, InternalSdk.

**Describe alternatives you've considered**

`PackageLicenseFile` pointing at the repo `LICENSE` — an SPDX expression is preferred and matches the rest of the repo.

**Additional context**

`LaunchDarkly.ServerSdk.SharedTests` is not currently released via release-please and has no versions on nuget.org, but it declares a `PackageId` and produces a package, so it was fixed for consistency.


Link to Devin session: https://app.devin.ai/sessions/7131a9e566a94759a6e416e5653af4fc
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Replaces the non-NuGet property `<LicenseExpression>` with `<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>` in **`LaunchDarkly.ClientSdk.csproj`** and **`LaunchDarkly.ServerSdk.SharedTests.csproj`**.
> 
> NuGet ignores `LicenseExpression`, so published **`LaunchDarkly.ClientSdk`** packages were missing license metadata on nuget.org; future builds will report **Apache-2.0** like the rest of the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b20d4a57db6643c5a461c67100a7122172a2c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->