### PR TITLE
fix: honor BackgroundPollInterval when app is in background

### DIFF
--- a/pkgs/sdk/client/src/Integrations/PollingDataSourceBuilder.cs
+++ b/pkgs/sdk/client/src/Integrations/PollingDataSourceBuilder.cs
@@ -112,7 +112,7 @@ namespace LaunchDarkly.Sdk.Client.Integrations
                 clientContext.DataSourceUpdateSink,
                 clientContext.CurrentContext,
                 requestor,
-                _pollInterval,
+                !clientContext.InBackground ? _pollInterval : _backgroundPollInterval,
                 TimeSpan.Zero,
                 clientContext.TaskExecutor,
                 logger

--- a/pkgs/sdk/client/src/Integrations/StreamingDataSourceBuilder.cs
+++ b/pkgs/sdk/client/src/Integrations/StreamingDataSourceBuilder.cs
@@ -104,6 +104,7 @@ namespace LaunchDarkly.Sdk.Client.Integrations
             {
                 // When in the background, always use polling instead of streaming
                 return new PollingDataSourceBuilder()
+                    .PollInterval(_backgroundPollInterval) // pass here as well, doesn't hurt
                     .BackgroundPollInterval(_backgroundPollInterval)
                     .Build(clientContext);
             }

--- a/pkgs/sdk/client/src/Internal/DataSources/PollingDataSource.cs
+++ b/pkgs/sdk/client/src/Internal/DataSources/PollingDataSource.cs
@@ -63,6 +63,8 @@ namespace LaunchDarkly.Sdk.Client.Internal.DataSources
 
         public bool Initialized => _initialized.Get();
 
+        internal TimeSpan PollingInterval => _pollingInterval;
+
         private async Task UpdateTaskAsync()
         {
             try

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/PollingDataSourceBuilderTest.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/PollingDataSourceBuilderTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using LaunchDarkly.Sdk.Client.Internal.DataSources;
 using LaunchDarkly.TestHelpers;
 using Xunit;
@@ -10,11 +9,6 @@ namespace LaunchDarkly.Sdk.Client.Integrations
     {
         private readonly BuilderBehavior.InternalStateTester<PollingDataSourceBuilder> _tester =
             BuilderBehavior.For(Components.PollingDataSource);
-
-        private static TimeSpan GetPollingInterval(PollingDataSource dataSource) =>
-            (TimeSpan)typeof(PollingDataSource)
-                .GetField("_pollingInterval", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(dataSource);
 
         [Fact]
         public void BackgroundPollInterval()
@@ -46,7 +40,7 @@ namespace LaunchDarkly.Sdk.Client.Integrations
 
             var dataSource = (PollingDataSource)builder.Build(TestUtil.SimpleContext.WithInBackground(false));
 
-            Assert.Equal(TimeSpan.FromMinutes(10), GetPollingInterval(dataSource));
+            Assert.Equal(TimeSpan.FromMinutes(10), dataSource.PollingInterval);
         }
 
         [Fact]
@@ -58,7 +52,7 @@ namespace LaunchDarkly.Sdk.Client.Integrations
 
             var dataSource = (PollingDataSource)builder.Build(TestUtil.SimpleContext.WithInBackground(true));
 
-            Assert.Equal(TimeSpan.FromMinutes(30), GetPollingInterval(dataSource));
+            Assert.Equal(TimeSpan.FromMinutes(30), dataSource.PollingInterval);
         }
     }
 }

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/PollingDataSourceBuilderTest.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/PollingDataSourceBuilderTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using LaunchDarkly.Sdk.Client.Internal.DataSources;
 using LaunchDarkly.TestHelpers;
 using Xunit;
 
@@ -8,6 +10,11 @@ namespace LaunchDarkly.Sdk.Client.Integrations
     {
         private readonly BuilderBehavior.InternalStateTester<PollingDataSourceBuilder> _tester =
             BuilderBehavior.For(Components.PollingDataSource);
+
+        private static TimeSpan GetPollingInterval(PollingDataSource dataSource) =>
+            (TimeSpan)typeof(PollingDataSource)
+                .GetField("_pollingInterval", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(dataSource);
 
         [Fact]
         public void BackgroundPollInterval()
@@ -28,6 +35,30 @@ namespace LaunchDarkly.Sdk.Client.Integrations
             prop.AssertSetIsChangedTo(
                 PollingDataSourceBuilder.DefaultPollInterval.Subtract(TimeSpan.FromMilliseconds(1)),
                 PollingDataSourceBuilder.DefaultPollInterval);
+        }
+
+        [Fact]
+        public void BuildUsesPollIntervalWhenForeground()
+        {
+            var builder = Components.PollingDataSource()
+                .PollInterval(TimeSpan.FromMinutes(10))
+                .BackgroundPollInterval(TimeSpan.FromMinutes(30));
+
+            var dataSource = (PollingDataSource)builder.Build(TestUtil.SimpleContext.WithInBackground(false));
+
+            Assert.Equal(TimeSpan.FromMinutes(10), GetPollingInterval(dataSource));
+        }
+
+        [Fact]
+        public void BuildUsesBackgroundPollIntervalWhenInBackground()
+        {
+            var builder = Components.PollingDataSource()
+                .PollInterval(TimeSpan.FromMinutes(10))
+                .BackgroundPollInterval(TimeSpan.FromMinutes(30));
+
+            var dataSource = (PollingDataSource)builder.Build(TestUtil.SimpleContext.WithInBackground(true));
+
+            Assert.Equal(TimeSpan.FromMinutes(30), GetPollingInterval(dataSource));
         }
     }
 }

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/StreamingDataSourceBuilderTest.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/StreamingDataSourceBuilderTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using LaunchDarkly.Sdk.Client.Internal.DataSources;
 using LaunchDarkly.TestHelpers;
 using Xunit;
 
@@ -24,6 +26,21 @@ namespace LaunchDarkly.Sdk.Client.Integrations
             var prop = _tester.Property(b => b._initialReconnectDelay, (b, v) => b.InitialReconnectDelay(v));
             prop.AssertDefault(StreamingDataSourceBuilder.DefaultInitialReconnectDelay);
             prop.AssertCanSet(TimeSpan.FromMilliseconds(222));
+        }
+
+        [Fact]
+        public void BuildInBackgroundFallsBackToPollingWithBackgroundPollInterval()
+        {
+            var builder = Components.StreamingDataSource()
+                .BackgroundPollInterval(TimeSpan.FromMinutes(30));
+
+            var dataSource = builder.Build(TestUtil.SimpleContext.WithInBackground(true));
+
+            var polling = Assert.IsType<PollingDataSource>(dataSource);
+            var pollingInterval = (TimeSpan)typeof(PollingDataSource)
+                .GetField("_pollingInterval", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(polling);
+            Assert.Equal(TimeSpan.FromMinutes(30), pollingInterval);
         }
     }
 }

--- a/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/StreamingDataSourceBuilderTest.cs
+++ b/pkgs/sdk/client/test/LaunchDarkly.ClientSdk.Tests/Integrations/StreamingDataSourceBuilderTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using LaunchDarkly.Sdk.Client.Internal.DataSources;
 using LaunchDarkly.TestHelpers;
 using Xunit;
@@ -37,10 +36,7 @@ namespace LaunchDarkly.Sdk.Client.Integrations
             var dataSource = builder.Build(TestUtil.SimpleContext.WithInBackground(true));
 
             var polling = Assert.IsType<PollingDataSource>(dataSource);
-            var pollingInterval = (TimeSpan)typeof(PollingDataSource)
-                .GetField("_pollingInterval", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(polling);
-            Assert.Equal(TimeSpan.FromMinutes(30), pollingInterval);
+            Assert.Equal(TimeSpan.FromMinutes(30), polling.PollingInterval);
         }
     }
 }


### PR DESCRIPTION
`PollingDataSourceBuilder.Build()` was always passing `_pollInterval` to the constructed `PollingDataSource`, regardless of `clientContext.InBackground`. Users configuring polling with a distinct `BackgroundPollInterval` had it silently ignored; streaming-configured SDKs that fell back to polling in background used the 5-minute foreground default rather than the 60-minute background default.

The polling builder now selects the correct interval based on `InBackground`. The streaming builder's background fallback also sets both fields to the background value for defense-in-depth.

Fixes [SDK-2920](https://launchdarkly.atlassian.net/browse/SDK-2920).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **background polling** so `BackgroundPollInterval` is actually used when `InBackground` is true, instead of always applying the foreground `PollInterval`.
> 
> `PollingDataSourceBuilder.Build()` now picks `_pollInterval` vs `_backgroundPollInterval` based on `clientContext.InBackground`. When streaming falls back to polling in the background, the streaming builder also passes the background interval into `PollInterval` on the nested polling builder (defense in depth).
> 
> An internal `PollingInterval` getter on `PollingDataSource` supports new tests for foreground vs background builds and streaming’s background fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9e3d46488554d9d1194de1e401563feceef2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[SDK-2920]: https://launchdarkly.atlassian.net/browse/SDK-2920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ